### PR TITLE
Prevent click events on disable buttons

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -5877,7 +5877,8 @@ hero-icon[disabled] hero-caption {
 
 hero-button .btn[disabled] {
   background-color: #313339;
-  color: #787c7f; }
+  color: #787c7f;
+  pointer-events: none; }
   hero-button .btn[disabled]:hover {
     background-color: #36383e; }
 

--- a/lib/scss/main.scss
+++ b/lib/scss/main.scss
@@ -52,6 +52,7 @@ hero-button .btn {
   &[disabled] {
     background-color: $btn-disabled;
     color: $color-disabled;
+    pointer-events: none;
 
     &:hover {
       background-color: lighten($btn-disabled, 2);


### PR DESCRIPTION
For some reasons, despite being disabled, buttons still call the action
defined as `ngClick`. In the case of the burn progress button, this
results in:

```sh
TypeError: Cannot read property 'device' of undefined
```

Fixes: https://github.com/resin-io/etcher/issues/132