### PR TITLE
Don't ignore lib/browser in the final package

### DIFF
--- a/package.ignore
+++ b/package.ignore
@@ -9,7 +9,6 @@ installers.json
 screenshot.png
 tests
 lib/scss
-lib/browser
 node_modules/electron-mocha
 node_modules/electron-builder
 node_modules/angular-mocks


### PR DESCRIPTION
Previously, the browser code lives in `build/browser` given it was built
with Browserify. Recently, Browserify was removed:

https://github.com/resin-io/etcher/commit/96bf7f3624322045c996090b91b235d4feb85949

and therefore we load the browser code from `lib/browser`.