### PR TITLE
Show error dialogs on elevation errors

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -43,7 +43,7 @@ exports.require = function(app, callback) {
           name: 'Resin Etcher'
         }, function(error) {
           if (error) {
-            console.error(error.message);
+            electron.dialog.showErrorBox('Elevation Error', error.message);
             process.exit(1);
           }
 
@@ -55,7 +55,7 @@ exports.require = function(app, callback) {
 
         elevator.execute(process.argv, {}, function(error) {
           if (error) {
-            console.error(error.message);
+            electron.dialog.showErrorBox('Elevation Error', error.message);
             process.exit(1);
           }
 


### PR DESCRIPTION
Printing to `stderr` makes no sense since the process is detached from
the shell when packaged.