### PR TITLE
Downgrade sudo-prompt to v1.1.8

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -39,9 +39,8 @@ exports.require = function(app, callback) {
         // Keep parent process hidden
         app.dock.hide();
 
-        sudoPrompt.exec(process.argv.join(' '), {
-          name: 'Etcher'
-        }, function(error) {
+        sudoPrompt.setName('Etcher');
+        sudoPrompt.exec(process.argv.join(' '), function(error) {
           if (error) {
             electron.dialog.showErrorBox('Elevation Error', error.message);
             process.exit(1);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "is-elevated": "^1.0.0",
     "lodash": "^3.10.1",
     "resin-image-write": "^2.0.5",
-    "sudo-prompt": "^2.0.2",
+    "sudo-prompt": "^1.1.8",
     "trackjs": "^2.1.16",
     "umount": "^1.1.1"
   },


### PR DESCRIPTION
Later versions make use of shell commands over the internal contents of
the module causing errors when the application is packaged as an
`asar`.

This issue is being fixed here: https://github.com/jorangreef/sudo-prompt/issues/10