### PR TITLE
Rename release/ to etcher-release/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ node_modules
 bower_components
 
 # Compiled Electron releases
-release/
+etcher-release/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ELECTRON_IGNORE=$(shell cat package.ignore | tr "\\n" "|" | sed "s/.$$//")
 ELECTRON_VERSION=0.36.0
 APPLICATION_NAME="Etcher"
 
-release/Etcher-darwin-x64: .
+etcher-release/Etcher-darwin-x64: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
 		--platform=darwin \
 		--arch=x64 \
@@ -15,7 +15,7 @@ release/Etcher-darwin-x64: .
 		--overwrite \
 		--out=$(dir $@)
 
-release/Etcher-linux-ia32: .
+etcher-release/Etcher-linux-ia32: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
 		--platform=linux \
 		--arch=ia32 \
@@ -25,7 +25,7 @@ release/Etcher-linux-ia32: .
 		--overwrite \
 		--out=$(dir $@)
 
-release/Etcher-linux-x64: .
+etcher-release/Etcher-linux-x64: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
 		--platform=linux \
 		--arch=x64 \
@@ -35,7 +35,7 @@ release/Etcher-linux-x64: .
 		--overwrite \
 		--out=$(dir $@)
 
-release/Etcher-win32-ia32: .
+etcher-release/Etcher-win32-ia32: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
 		--platform=win32 \
 		--arch=ia32 \
@@ -46,7 +46,7 @@ release/Etcher-win32-ia32: .
 		--overwrite \
 		--out=$(dir $@)
 
-release/Etcher-win32-x64: .
+etcher-release/Etcher-win32-x64: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
 		--platform=win32 \
 		--arch=x64 \
@@ -57,48 +57,48 @@ release/Etcher-win32-x64: .
 		--overwrite \
 		--out=$(dir $@)
 
-release/installers/Etcher.dmg: release/Etcher-darwin-x64 package.json
+etcher-release/installers/Etcher.dmg: etcher-release/Etcher-darwin-x64 package.json
 	$(ELECTRON_BUILDER) "$</$(APPLICATION_NAME).app" \
 		--platform=osx \
 		--out=$(dir $@)
 
-release/installers/Etcher-linux-x64.tar.gz: release/Etcher-linux-x64
+etcher-release/installers/Etcher-linux-x64.tar.gz: etcher-release/Etcher-linux-x64
 	mkdir -p $(dir $@)
 	tar -zcf $@ $<
 
-release/installers/Etcher-linux-ia32.tar.gz: release/Etcher-linux-ia32
+etcher-release/installers/Etcher-linux-ia32.tar.gz: etcher-release/Etcher-linux-ia32
 	mkdir -p $(dir $@)
 	tar -zcf $@ $<
 
-release/installers/Etcher-x64.exe: release/Etcher-win32-x64 package.json
+etcher-release/installers/Etcher-x64.exe: etcher-release/Etcher-win32-x64 package.json
 	$(ELECTRON_BUILDER) $< \
 		--platform=win \
 		--out=$(dir $@)win-x64
 	mv $(dir $@)win-x64/Etcher\ Setup.exe $@
 	rmdir $(dir $@)win-x64
 
-release/installers/Etcher.exe: release/Etcher-win32-ia32 package.json
+etcher-release/installers/Etcher.exe: etcher-release/Etcher-win32-ia32 package.json
 	$(ELECTRON_BUILDER) $< \
 		--platform=win \
 		--out=$(dir $@)win-ia32
 	mv $(dir $@)win-ia32/Etcher\ Setup.exe $@
 	rmdir $(dir $@)win-ia32
 
-package-osx: release/Etcher-darwin-x64
-package-linux: release/Etcher-linux-ia32 release/Etcher-linux-x64
-package-win32: release/Etcher-win32-ia32 release/Etcher-win32-x64
+package-osx: etcher-release/Etcher-darwin-x64
+package-linux: etcher-release/Etcher-linux-ia32 etcher-release/Etcher-linux-x64
+package-win32: etcher-release/Etcher-win32-ia32 etcher-release/Etcher-win32-x64
 package-all: package-osx package-linux package-win32
 
-installer-osx: release/installers/Etcher.dmg
-installer-linux: release/installers/Etcher-linux-x64.tar.gz release/installers/Etcher-linux-ia32.tar.gz
-installer-win32: release/installers/Etcher-x64.exe release/installers/Etcher.exe
+installer-osx: etcher-release/installers/Etcher.dmg
+installer-linux: etcher-release/installers/Etcher-linux-x64.tar.gz etcher-release/installers/Etcher-linux-ia32.tar.gz
+installer-win32: etcher-release/installers/Etcher-x64.exe etcher-release/installers/Etcher.exe
 installer-all: installer-osx installer-linux installer-win32
 
-release:
+etcher-release:
 	rm -rf node_modules
 	npm install --force
 	npm test
 	make installer-all
 
 clean:
-	rm -rf release/
+	rm -rf etcher-release/

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -17,6 +17,6 @@ Run the following command to make installers for all supported operating systems
 make release
 ```
 
-The resulting installers will be saved to `release/installers`.
+The resulting installers will be saved to `etcher-release/installers`.
 
 You can run `make clean` to start in a fresh state.

--- a/package.ignore
+++ b/package.ignore
@@ -7,7 +7,7 @@ bower.json
 gulpfile.js
 screenshot.png
 tests
-release
+etcher-release
 lib/scss
 node_modules/electron-mocha
 node_modules/electron-builder


### PR DESCRIPTION
The `bluebird` module contains a directory called "release", which gets
omitted by `electron-packager`.

After some experimentation, there doesn't seems to be a way to make
`electron-packager` ignore a pattern only on the current directory,
therefore we change the name of our output directory to something that
can't possibly collide with something else.