### PR TITLE
Upgrade Electron to v0.36.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
 ELECTRON_BUILDER=./node_modules/.bin/electron-builder
 ELECTRON_IGNORE=$(shell cat package.ignore | tr "\\n" "|" | sed "s/.$$//")
-ELECTRON_VERSION=0.36.0
+ELECTRON_VERSION=0.36.8
 APPLICATION_NAME="Etcher"
 
 etcher-release/Etcher-darwin-x64: .

--- a/README.md
+++ b/README.md
@@ -31,19 +31,6 @@ npm install && bower install
 npm start
 ```
 
-GNU/Linux
----------
-
-There is a [known electron issue](https://github.com/atom/electron/issues/3666) that prevents Etcher from running correctly when cloned in directories that don't have global execution permissions at any point of the path.
-
-Until this issue is fixed, we recommend cloning Etcher in directories like `/opt`, and making sure they have execution permissions with:
-
-```sh
-chmod a+x /opt
-```
-
-You can still run Etcher from inside your home directory by giving your home directory global execution permissions, but notice this might bring security concerns. Do it at your own risk.
-
 Support
 -------
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "electron-mocha": "^0.8.0",
     "electron-builder": "^2.6.0",
     "electron-packager": "^5.1.1",
-    "electron-prebuilt": "^0.36.4",
+    "electron-prebuilt": "^0.36.8",
     "gulp": "^3.9.0",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^1.11.2",


### PR DESCRIPTION
This version contains a fix to prevent dropping capabilities in renderer
threads.

See https://github.com/atom/electron/issues/3666
Fixes https://github.com/resin-io/etcher/issues/52