### PR TITLE
Upgrade angular-ui-bootstrap to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "angular": "^1.4.6",
-    "angular-ui-bootstrap": "^0.14.2",
+    "angular-ui-bootstrap": "^1.2.1",
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "drivelist": "^2.0.7",


### PR DESCRIPTION
There are no breaking changes in the only widget we're using from this
library, `uib-dropdown.`