### PR TITLE
Reformat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,21 +18,30 @@
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
   "builder": {
-    "osx" : {
+    "osx": {
       "title": "Etcher",
       "background": "assets/osx/installer.png",
       "icon": "assets/icon.icns",
       "icon-size": 110,
       "contents": [
-        { "x": 415, "y": 225, "type": "link", "path": "/Applications" },
-        { "x": 140, "y": 225, "type": "file" }
+        {
+          "x": 415,
+          "y": 225,
+          "type": "link",
+          "path": "/Applications"
+        },
+        {
+          "x": 140,
+          "y": 225,
+          "type": "file"
+        }
       ]
     },
     "win": {
-      "title" : "Etcher",
-      "version" : "0.0.1",
+      "title": "Etcher",
+      "version": "0.0.1",
       "publisher": "Resin.io",
-      "icon" : "assets/icon.ico",
+      "icon": "assets/icon.ico",
       "verbosity": 1
     }
   },
@@ -57,8 +66,8 @@
   },
   "devDependencies": {
     "angular-mocks": "^1.4.7",
-    "electron-mocha": "^0.8.0",
     "electron-builder": "^2.6.0",
+    "electron-mocha": "^0.8.0",
     "electron-packager": "^5.1.1",
     "electron-prebuilt": "^0.36.8",
     "gulp": "^3.9.0",


### PR DESCRIPTION
We made some manual changes to `package.json` that were not formatted
correctly.

This PR lets `npm` itself reorganize and format the manifest.