### PR TITLE
Upgrade resin-image-zip to v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.5.1",
     "ngstorage": "^0.3.10",
     "resin-image-write": "^2.0.5",
-    "resin-zip-image": "^1.1.1",
+    "resin-zip-image": "^1.1.2",
     "sudo-prompt": "^2.2.0",
     "trackjs": "^2.1.16",
     "umount": "^1.1.1",


### PR DESCRIPTION
This version contains a fix to prevent the test suite from crashing.