### PR TITLE
Stop scanner interval before starting a new one

### DIFF
--- a/lib/browser/modules/drive-scanner.js
+++ b/lib/browser/modules/drive-scanner.js
@@ -133,6 +133,10 @@ driveScanner.service('DriveScannerService', function($q, $interval, $timeout) {
       });
     };
 
+    // Make sure any pending interval is cancelled
+    // to avoid potential memory leaks.
+    self.stop();
+
     // Call fn after in the next process tick
     // to be able to capture the first run
     // in unit tests.


### PR DESCRIPTION
This ensures there are no orphaned intervals running.