### PR TITLE
Make use of package.json display name to reference the app

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -21,6 +21,7 @@ const isElevated = require('is-elevated');
 const sudoPrompt = require('sudo-prompt');
 const os = require('os');
 const platform = os.platform();
+const packageJSON = require('../package.json');
 
 exports.require = function(app, callback) {
   isElevated(function(error, elevated) {
@@ -40,7 +41,7 @@ exports.require = function(app, callback) {
         app.dock.hide();
 
         sudoPrompt.exec(process.argv.join(' '), {
-          name: 'Etcher'
+          name: packageJSON.displayName
         }, function(error) {
           if (error) {
             return callback(error);

--- a/lib/src/dialog.js
+++ b/lib/src/dialog.js
@@ -19,6 +19,7 @@
 const electron = require('electron');
 const Bluebird = require('bluebird');
 const zipImage = require('resin-zip-image');
+const packageJSON = require('../../package.json');
 
 /**
  * @summary Open an image selection dialog
@@ -58,7 +59,7 @@ exports.selectImage = function() {
     if (zipImage.isZip(file) && !zipImage.isValidZipImage(file)) {
       electron.dialog.showErrorBox(
         'Invalid zip image',
-        'Etcher can only open Zip archives that contain exactly one image file inside.'
+        `${packageJSON.displayName} can only open Zip archives that contain exactly one image file inside.`
       );
 
       return;


### PR DESCRIPTION
Our `package.json` contains a custom `displayName` property which equals
"Etcher" at the time of this writing.

This PR makes use of this property directly instead of hardcoding
"Etcher" in some places.