### PR TITLE
Show size when there is a selected drive

### DIFF
--- a/lib/partials/main.html
+++ b/lib/partials/main.html
@@ -45,7 +45,7 @@
           </div>
 
         </div>
-        <div ng-show="app.selection.hasDrive()" ng-bind="app.selection.getDrive().name" ng-click="app.reselectDrive()"></div>
+        <div ng-show="app.selection.hasDrive()" ng-bind="app.selection.getDrive().name + ' - ' + app.selection.getDrive().size" ng-click="app.reselectDrive()"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
It lets you be sure that the auto-selected drive is the one you intended
to write to.

Fixes: https://github.com/resin-io/etcher/issues/192