### PR TITLE
Bump version to v1.0.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "etcher",
   "displayName": "Etcher",
-  "version": "0.0.1",
+  "version": "1.0.0-beta.0",
   "main": "lib/etcher.js",
   "description": "An image burner with support for Windows, OS X and GNU/Linux.",
   "homepage": "https://github.com/resin-io/etcher",


### PR DESCRIPTION
This is the correct way of adding a pre-release identifier according to
https://github.com/npm/node-semver.