### PR TITLE
Fix Cannot read property 'length' of undefined

### DIFF
--- a/lib/browser/modules/drive-scanner.js
+++ b/lib/browser/modules/drive-scanner.js
@@ -100,7 +100,7 @@ driveScanner.service('DriveScannerService', function($q, $interval, $timeout) {
    * });
    */
   this.scan = function() {
-    return $q.when(drives.listRemovable()).catch(dialog.showError);
+    return $q.when(drives.listRemovable());
   };
 
   /**
@@ -130,7 +130,7 @@ driveScanner.service('DriveScannerService', function($q, $interval, $timeout) {
       return self.scan().then(function(drives) {
         emitter.emit('scan', drives);
         self.setDrives(drives);
-      });
+      }).catch(dialog.showError);
     };
 
     // Make sure any pending interval is cancelled


### PR DESCRIPTION
This error was reported by TrackJS various times:

```
TypeError: Cannot read property 'length' of undefined
  at EventEmitter.<anonymous> (file:///Users/jviotti/Projects/resin/etcher/lib/browser/app.js:104:15)
  at emitOne (events.js:77:13)
  at EventEmitter.emit (events.js:169:7)
  at /Users/jviotti/Projects/resin/etcher/lib/browser/modules/drive-scanner.js:131:17
  at processQueue (/Users/jviotti/Projects/resin/etcher/node_modules/angular/angular.js:15616:28)
  at /Users/jviotti/Projects/resin/etcher/node_modules/angular/angular.js:15632:27
  at Scope.$eval (/Users/jviotti/Projects/resin/etcher/node_modules/angular/angular.js:16884:28)
  at Scope.$digest (/Users/jviotti/Projects/resin/etcher/node_modules/angular/angular.js:16700:31)
  at /Users/jviotti/Projects/resin/etcher/node_modules/angular/angular.js:16923:26
  at completeOutstandingRequest (/Users/jviotti/Projects/resin/etcher/node_modules/angular/angular.js:5825:10),
```

The error refers to the following line in `app.js`:

```js
if (drives.length === 1 && self.selection.hasImage()) {
```

Which indicates that the array of detected drives returned to the main
controller is `undefined` for some reason.

The problem resides in the `.scan()` method of `DriveScannerService`:

```js
this.scan = function() {
  return $q.when(drives.listRemovable()).catch(dialog.showError);
};
```

When an error is thrown when scanning the drives, the `.catch()` block
is called. This means that the error is not propagated to the outer code
and the promise resolves with `undefined`.

The solution is to move `.catch()` to the place `.scan()` is called,
instead of making use of it in the low-level parts of the process.