### PR TITLE
Configure TrackJS with userId

### DIFF
--- a/lib/browser/modules/analytics.js
+++ b/lib/browser/modules/analytics.js
@@ -55,6 +55,13 @@ analytics.config(function($mixpanelProvider) {
 
 // TrackJS integration
 // http://docs.trackjs.com/tracker/framework-integrations
+
+analytics.run(function($window) {
+  $window.trackJs.configure({
+    userId: username.sync()
+  });
+});
+
 analytics.config(function($provide) {
   $provide.decorator('$exceptionHandler', function($delegate, $window, $injector) {
     return function(exception, cause) {


### PR DESCRIPTION
Otherwise, all we get in TrackJS are "anonymous" users, without a way to
link them to Mixpanel users.