### PR TITLE
Throw error after displaying it with dialog

### DIFF
--- a/lib/src/dialog.js
+++ b/lib/src/dialog.js
@@ -81,4 +81,5 @@ exports.selectImage = function() {
  */
 exports.showError = function(error) {
   electron.dialog.showErrorBox(error.message, error.stack || '');
+  throw error;
 };


### PR DESCRIPTION
Currently, we "swallow" errors by only showing them with the "dialog"
module, causing them to not be logged to TrackJS.