### PR TITLE
Return to avoid any further code execution after an elevation error

### DIFF
--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -32,7 +32,7 @@ electron.app.on('ready', function() {
 
     if (error) {
       electron.dialog.showErrorBox('Elevation Error', error.message);
-      process.exit(1);
+      return process.exit(1);
     }
 
     mainWindow = new electron.BrowserWindow({


### PR DESCRIPTION
Turns out that even by using `process.exit(1)`, the electron main
process doesn't exit instantly, but continues executing code.

This causes electron to throw on `electron.globalShortcut` because this
functionality is not available given that we didn't create a renderer
view.

Fixes: https://github.com/resin-io/etcher/issues/215