### PR TITLE
Fix window height inconsistencies in Windows

### DIFF
--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -18,6 +18,7 @@
 
 const electron = require('electron');
 const path = require('path');
+const os = require('os');
 const elevate = require('./elevate');
 let mainWindow = null;
 
@@ -35,9 +36,22 @@ electron.app.on('ready', function() {
       return process.exit(1);
     }
 
+    // Electron height doesn't account for the window title bar
+    // in Windows, meaning that we have to do it ourselves.
+    // After some experimentation, we can get the correct WebView
+    // height with the following formula:
+    //
+    //   HEIGHT + 39px
+    //
+    // See https://github.com/electron/electron/issues/5025
+    const WINDOWS_WINDOW_TITLE_BAR_HEIGHT = 39;
+    const DEFAULT_WINDOW_HEIGHT = 380;
+    const WINDOWS_WINDOW_HEIGHT = DEFAULT_WINDOW_HEIGHT + WINDOWS_WINDOW_TITLE_BAR_HEIGHT;
+    const WINDOW_HEIGHT = os.platform() === 'win32' ? WINDOWS_WINDOW_HEIGHT : DEFAULT_WINDOW_HEIGHT;
+
     mainWindow = new electron.BrowserWindow({
       width: 800,
-      height: 380,
+      height: WINDOW_HEIGHT,
       show: false,
       resizable: false,
       fullscreen: false,


### PR DESCRIPTION
Electron height doesn't account for the window title bar
in Windows, meaning that we have to do it ourselves.
After some experimentation, we can get the correct `WebView`
height with the following formula:

  HEIGHT + 39px

This issue was raised in https://github.com/electron/electron/issues/5025
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>