### PR TITLE
Enable useContentSize BrowserWindow option

### DIFF
--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -38,6 +38,7 @@ electron.app.on('ready', function() {
     mainWindow = new electron.BrowserWindow({
       width: 800,
       height: 380,
+      useContentSize: true,
       show: false,
       resizable: false,
       fullscreen: false,


### PR DESCRIPTION
From the documentation:

> `useContentSize` Boolean - The `width` and `height` would be used as web
> page’s size, which means the actual window’s size will include window
> frame’s size and be slightly larger. Default is `false`.

The original issue is that when you specify a width/height, the actual
size that you get is slighly smaller, since the OS title bar is included
in the size you provide.

By using the `useContentSize` option, we ensure the `WebView` gets the
intended size, no matter the title bar.

This PR invalidates: https://github.com/resin-io/etcher/pull/244

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>