### PR TITLE
Fix uncaught exception if no file was selected from a dialog

### DIFF
--- a/lib/src/dialog.js
+++ b/lib/src/dialog.js
@@ -54,9 +54,11 @@ exports.selectImage = function() {
           ]
         }
       ]
-    }, resolve);
+    }, function(files) {
+      return resolve(files || []);
+    });
   }).get(0).then(function(file) {
-    if (zipImage.isZip(file) && !zipImage.isValidZipImage(file)) {
+    if (file && zipImage.isZip(file) && !zipImage.isValidZipImage(file)) {
       electron.dialog.showErrorBox(
         'Invalid zip image',
         `${packageJSON.displayName} can only open Zip archives that contain exactly one image file inside.`

--- a/tests/src/dialog.spec.js
+++ b/tests/src/dialog.spec.js
@@ -8,6 +8,24 @@ describe('Dialog:', function() {
 
   describe('.selectImage()', function() {
 
+    describe('given the user does not select anything', function() {
+
+      beforeEach(function() {
+        this.showOpenDialogStub = m.sinon.stub(electron.dialog, 'showOpenDialog');
+        this.showOpenDialogStub.yields(undefined);
+      });
+
+      afterEach(function() {
+        this.showOpenDialogStub.restore();
+      });
+
+      it('should eventually be undefined', function() {
+        const promise = dialog.selectImage();
+        m.chai.expect(promise).to.eventually.be.undefined;
+      });
+
+    });
+
     describe('given the users performs a selection', function() {
 
       beforeEach(function() {


### PR DESCRIPTION
The following error is thrown if the open file dialog is cancelled
without any selection:

```
  Unhandled rejection TypeError: Cannot read property '0' of undefined
    at Number.indexedGetter (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/call_get.js:106:15)
    at Number.tryCatcher (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/promise.js:503:31)
    at Promise._settlePromise (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/promise.js:560:18)
    at Promise._settlePromise0 (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/promise.js:605:10)
    at Promise._settlePromises (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/promise.js:684:18)
    at Async._drainQueue (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/async.js:126:16)
    at Async._drainQueues (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/async.js:136:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/parallels/Projects/etcher/node_modules/bluebird/js/release/async.js:16:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>