### PR TITLE
Codesign OS X app inside the DMG package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lib/scss",
     "node_modules/electron-mocha",
     "node_modules/electron-builder",
+    "node_modules/electron-osx-sign",
     "node_modules/angular-mocks",
     "node_modules/browserify",
     "node_modules/gulp*",
@@ -41,25 +42,6 @@
     "node_modules/tmp"
   ],
   "builder": {
-    "osx": {
-      "title": "Etcher",
-      "background": "assets/osx/installer.png",
-      "icon": "assets/icon.icns",
-      "icon-size": 110,
-      "contents": [
-        {
-          "x": 415,
-          "y": 225,
-          "type": "link",
-          "path": "/Applications"
-        },
-        {
-          "x": 140,
-          "y": 225,
-          "type": "file"
-        }
-      ]
-    },
     "win": {
       "title": "Etcher",
       "version": "0.0.1",
@@ -94,7 +76,8 @@
     "angular-mocks": "^1.4.7",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^0.8.0",
-    "electron-packager": "^5.1.1",
+    "electron-osx-sign": "^0.3.0",
+    "electron-packager": "^6.0.0",
     "electron-prebuilt": "^0.36.8",
     "gulp": "^3.9.0",
     "gulp-jscs": "^3.0.2",


### PR DESCRIPTION
This PR fixes a frequent issue users were having where opening
`Etcher.app` would result in:

    "Etcher.app" is damaged and can't be opened. You should move it to
    the trash.

Checking the code-signature of the application returned the following
error message:

    $ spctl -a -v Etcher.app
    Etcher.app: invalid signature (code or signature have been modified)

The solution is based on the following paragraphs from Apple's "OS X
Code Signing in Depth" technical note:

https://developer.apple.com/library/mac/technotes/tn2206/_index.html

> Code signing uses extended attributes to store signatures in non-Mach-O
> executables such as script files. If the extended attributes are lost
> then the program's identity will be broken. Thus, when you ship your
> script, you must use a mechanism that preserves extended attributes.
>
> One way to guarantee preservation of extended attributes is by packing
> up your signed code in a read-write disk image (DMG) file before signing
> and then, after signing, converting to read-only. You probably don't
> need to use a disk image until the final package stage so another less
> heavy-handed method would be to use ZIP or XIP files.

In summary, what we now do is:

- Create a temporal read-write DMG image.
- Perform the code-signing *inside* the DMG image.
- Convert the temporal DMG image into a compressed read-only image.

Sadly, this custom workflow doesn't fit in `electron-packager` nor
`electron-builder`, so we had to re-implement the features those
packages provide us in a nice encapsulated way ourselves.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>