### PR TITLE
Show drive name in drive selector modal

### DIFF
--- a/lib/browser/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/browser/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -9,7 +9,7 @@
       ng-click="modal.state.toggleSelectDrive(drive)">
         <div>
           <h4 class="list-group-item-heading">{{ drive.description }} - {{ drive.size }}</h4>
-          <p class="list-group-item-text">{{ drive.device }}</p>
+          <p class="list-group-item-text">{{ drive.name }}</p>
         </div>
         <span class="tick tick--success" ng-disabled="!modal.state.isSelectedDrive(drive)"></span>
     </li>


### PR DESCRIPTION
The `name` property equals the drive letter in Windows, and the mount
point in UNIX based operating systems.

Fixes: https://github.com/resin-io/etcher/issues/258
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>