### PR TITLE
Fix window contents pushed below when a modal is open

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6268,6 +6268,9 @@ button.btn:focus, button.progress-button:focus {
 .modal-body .list-group-item:first-child {
   border-top: none; }
 
+.modal-open {
+  padding-right: 0 !important; }
+
 /*
  * Copyright 2016 Resin.io
  *

--- a/lib/scss/components/_modal.scss
+++ b/lib/scss/components/_modal.scss
@@ -75,3 +75,13 @@
 .modal-body .list-group-item:first-child {
   border-top: none;
 }
+
+// UI Bootstrap adds the `.modal-open` class to the <body>
+// element and sets its right padding to the width of the
+// window, causing the window content to overflow and get
+// pushed to the bottom.
+// The `!important` flag is needed since UI Bootstrap inlines
+// the styles programatically to the element.
+.modal-open {
+  padding-right: 0 !important;
+}


### PR DESCRIPTION
UI Bootstrap adds the `.modal-open` class to the `<body>`
element and sets its right padding to the width of the
window, causing the window content to overflow and get
pushed to the bottom.
The `!important` flag is needed since UI Bootstrap inlines
the styles programatically to the element.

Fixes: https://github.com/resin-io/etcher/issues/257
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>