### PR TITLE
Make clear that Etcher supports OS X >= 10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Installers
 
 Refer to the [downloads page](http://etcher.io) for the latest pre-made installers for all supported operating systems.
 
+> Etcher only supports OS X >= 10.9
+
 Developing
 ----------
 


### PR DESCRIPTION
Electron no longer supports 10.8.

See http://electron.atom.io/docs/v0.37.5/tutorial/supported-platforms/#os-x

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>