### PR TITLE
Upgrade drivelist to v2.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "angular-ui-router": "^0.2.18",
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
-    "drivelist": "^2.0.9",
+    "drivelist": "^2.0.13",
     "flexboxgrid": "^6.3.0",
     "is-elevated": "^1.0.0",
     "lodash": "^4.5.1",


### PR DESCRIPTION
This version contains the following changes:

- Detect Macbook SDCard readers in OS X.
- Detect removable drives better in Windows.
- Keep one decimal in Windows drive size.

Fixes: https://github.com/resin-io/etcher/issues/255
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>