### PR TITLE
Prevent dialog.showErrorBox() throwing if wrong parameters

### DIFF
--- a/lib/src/dialog.js
+++ b/lib/src/dialog.js
@@ -82,6 +82,7 @@ exports.selectImage = function() {
  * dialog.showError(new Error('Foo Bar'));
  */
 exports.showError = function(error) {
-  electron.dialog.showErrorBox(error.message, error.stack || '');
+  error = error || {};
+  electron.dialog.showErrorBox(error.message || 'An error ocurred!', error.stack || '');
   throw error;
 };


### PR DESCRIPTION
If the function lacks a message or a title, the following error is
thrown:

    Error: Could not call remote function ``.
    Check that the function signature is correct.
    Underlying error: Error processing argument at index 0,
    conversion failure from undefined

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>