### PR TITLE
Implement OS notifications on burn completion

### DIFF
--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -33,6 +33,7 @@ require('./browser/modules/image-writer');
 require('./browser/modules/path');
 require('./browser/modules/notifier');
 require('./browser/modules/analytics');
+require('./browser/modules/notification');
 require('./browser/components/progress-button/progress-button');
 require('./browser/components/drive-selector/drive-selector');
 require('./browser/pages/finish/finish');
@@ -51,6 +52,7 @@ const app = angular.module('Etcher', [
   'Etcher.image-writer',
   'Etcher.notifier',
   'Etcher.analytics',
+  'Etcher.notification',
 
   // Models
   'Etcher.Models.SelectionState',
@@ -92,7 +94,8 @@ app.controller('AppController', function(
   ImageWriterService,
   AnalyticsService,
   DriveSelectorService,
-  WindowProgressService
+  WindowProgressService,
+  NotificationService
 ) {
   let self = this;
   this.selection = SelectionStateModel;
@@ -239,9 +242,11 @@ app.controller('AppController', function(
       self.success = success;
 
       if (self.success) {
+        NotificationService.send('Success!', 'You burn is complete');
         AnalyticsService.logEvent('Done');
         $state.go('success');
       } else {
+        NotificationService.send('Oops!', 'Looks like your burn has failed');
         AnalyticsService.logEvent('Burn error');
       }
     })

--- a/lib/browser/modules/notification.js
+++ b/lib/browser/modules/notification.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * @module Etcher.notification
+ */
+
+const angular = require('angular');
+const electron = require('electron');
+const app = electron.remote.app;
+const notification = angular.module('Etcher.notification', []);
+
+notification.service('NotificationService', function() {
+
+  /**
+   * @summary Send a notification
+   * @function
+   * @public
+   *
+   * @description
+   * This function makes use of Electron's notification desktop
+   * integration feature. See:
+   * http://electron.atom.io/docs/v0.37.5/tutorial/desktop-environment-integration/
+   *
+   * @param {String} title - notification title
+   * @param {String} body - notification body
+   * @returns {Object} HTML5 notification object
+   *
+   * @example
+   * const notification = NotificationService.send('Hello', 'Foo Bar Bar');
+   * notification.onclick = function() {
+   *   console.log('The notification has been clicked');
+   * };
+   */
+  this.send = function(title, body) {
+
+    // `app.dock` is only defined in OS X
+    if (app.dock) {
+      app.dock.bounce();
+    }
+
+    return new Notification(title, {
+      body: body
+    });
+  };
+
+});


### PR DESCRIPTION
Its helpful to have an auditive/visual cue when a burn operation
completed.

Instead of adding a setting entry to enable/disable notifications, you
can use the standard way to control notifications from your operating
system. For example, in OS X, you might go to "System Preferences" ->
"Notifications" and disable notifications for "Etcher".

Fixes: https://github.com/resin-io/etcher/issues/280
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>