### PR TITLE
Implement GNU/Linux elevation dialog

### DIFF
--- a/lib/elevate.js
+++ b/lib/elevate.js
@@ -35,10 +35,12 @@ exports.require = function(app, callback) {
 
     if (!elevated) {
 
-      if (platform === 'darwin') {
+      if (platform === 'darwin' || platform === 'linux') {
 
         // Keep parent process hidden
-        app.dock.hide();
+        if (app.dock) {
+          app.dock.hide();
+        }
 
         sudoPrompt.exec(process.argv.join(' '), {
           name: packageJSON.displayName


### PR DESCRIPTION
Make use of `sudo-prompt` Linux (beta) support, which attempts to use
`gksudo`, `kdesudo` or `pkexec`.

Fixes: https://github.com/resin-io/etcher/issues/277
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>