### PR TITLE
Compress Linux executables and Windows DLLs with UPX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ etcher-release/Etcher-linux-x86: .
 		--out=$(dir $@)
 	mv $(dir $@)Etcher-linux-ia32 $@
 	mv $@/Etcher $@/etcher
+	upx -9 $@/etcher $@/libnode.so
 
 etcher-release/Etcher-linux-x64: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
@@ -67,6 +68,7 @@ etcher-release/Etcher-linux-x64: .
 		--overwrite \
 		--out=$(dir $@)
 	mv $@/Etcher $@/etcher
+	upx -9 $@/etcher $@/*.so*
 
 etcher-release/Etcher-win32-x86: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
@@ -88,6 +90,7 @@ etcher-release/Etcher-win32-x86: .
 		--out=$(dir $@)
 	mv $(dir $@)Etcher-win32-ia32 $@
 	$(call sign-win32,$@/Etcher.exe)
+	upx -9 $@/*.dll
 
 etcher-release/Etcher-win32-x64: .
 	$(ELECTRON_PACKAGER) . $(APPLICATION_NAME) \
@@ -108,6 +111,7 @@ etcher-release/Etcher-win32-x64: .
 		--overwrite \
 		--out=$(dir $@)
 	$(call sign-win32,$@/Etcher.exe)
+	upx -9 $@/*.dll
 
 etcher-release/installers/Etcher-darwin-x64.dmg: etcher-release/Etcher-darwin-x64 package.json
 	# Create temporal read-write DMG image

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -13,6 +13,7 @@ Prequisites
 - [XCode (for OS X)](https://developer.apple.com/xcode://developer.apple.com/xcode/)
 - [AWS CLI (for uploading packages)](https://aws.amazon.com/cli://aws.amazon.com/cli/)
 - [osslsigncode (for signing the Windows installers)](https://sourceforge.net/projects/osslsigncode/)
+- [UPX](http://upx.sourceforge.net)
 
 If you're going to generate installers for another platform than the one you're currently running, make sure you force-install all NPM dependencies, so optional dependencies marked for a certain operating system get installed regardless of the host operating system
 


### PR DESCRIPTION
Before:

    118M   Etcher-linux-x64
    122M   Etcher-linux-x86
    142M   Etcher-win32-x64
    116M   Etcher-win32-x86

After:

    74M    Etcher-linux-x64
    74M    Etcher-linux-x86
    124M   Etcher-win32-x64
    102M   Etcher-win32-x86

Fixes: https://github.com/resin-io/etcher/issues/281
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>