### PR TITLE
Use SUDO_USER environment variable for default file selection path.

### DIFF
--- a/lib/src/dialog.js
+++ b/lib/src/dialog.js
@@ -22,6 +22,37 @@ const zipImage = require('resin-zip-image');
 const packageJSON = require('../../package.json');
 
 /**
+ * @summary Get default directory for file selection dialog.
+ * @function
+ * @private
+ *
+ * @description
+ * This function is meant to be used with electron dialog.showOpenDialog method.
+ *
+ * If etcher is run with sudo, it will return the sudo user's home directory,
+ * as long as the SUDO_USER environment variable is set.
+ *
+ * In every other case the function will return undefined so that electron
+ * decides what the default path should be.
+ *
+ * Works on linux and darwin platforms only.
+ */
+const getDefaultSelectionPath = function() {
+	if (process.platform !== 'linux' && process.platform !== 'darwin') {
+		return;
+	}
+	if (process.env.UID || !process.env.SUDO_USER) {
+		return;
+	}
+	if (process.platform == 'linux') {
+		return '/home/' + process.env.SUDO_USER;
+	}
+	else { // darwin
+		return '/Users/' + process.env.SUDO_USER;
+	}
+};
+
+/**
  * @summary Open an image selection dialog
  * @function
  * @public
@@ -44,6 +75,7 @@ exports.selectImage = function() {
   return new Bluebird(function(resolve) {
     electron.dialog.showOpenDialog({
       properties: [ 'openFile' ],
+      defaultPath: getDefaultSelectionPath(),
       filters: [
         {
           name: 'IMG/ISO/ZIP',

--- a/lib/src/dialog.js
+++ b/lib/src/dialog.js
@@ -19,6 +19,7 @@
 const electron = require('electron');
 const Bluebird = require('bluebird');
 const zipImage = require('resin-zip-image');
+const homedir = require('user-homedir');
 const packageJSON = require('../../package.json');
 
 /**
@@ -37,20 +38,12 @@ const packageJSON = require('../../package.json');
  *
  * Works on linux and darwin platforms only.
  */
-const getDefaultSelectionPath = function() {
+exports.getDefaultSelectionPath = Bluebird.method(function() {
 	if (process.platform !== 'linux' && process.platform !== 'darwin') {
 		return;
 	}
-	if (process.env.UID || !process.env.SUDO_USER) {
-		return;
-	}
-	if (process.platform == 'linux') {
-		return '/home/' + process.env.SUDO_USER;
-	}
-	else { // darwin
-		return '/Users/' + process.env.SUDO_USER;
-	}
-};
+	return homedir();
+});
 
 /**
  * @summary Open an image selection dialog
@@ -72,23 +65,26 @@ const getDefaultSelectionPath = function() {
  * });
  */
 exports.selectImage = function() {
-  return new Bluebird(function(resolve) {
-    electron.dialog.showOpenDialog({
-      properties: [ 'openFile' ],
-      defaultPath: getDefaultSelectionPath(),
-      filters: [
-        {
-          name: 'IMG/ISO/ZIP',
-          extensions: [
-            'zip',
-            'img',
-            'iso'
-          ]
-        }
-      ]
-    }, function(files) {
-      return resolve(files || []);
-    });
+  exports.getDefaultSelectionPath()
+  .then(function(defaultPath) {
+    return new Bluebird(function(resolve) {
+      electron.dialog.showOpenDialog({
+        properties: [ 'openFile' ],
+	defaultPath: defaultPath,
+        filters: [
+          {
+            name: 'IMG/ISO/ZIP',
+            extensions: [
+              'zip',
+              'img',
+              'iso'
+            ]
+          }
+        ]
+      }, function(files) {
+        return resolve(files || []);
+      });
+    })
   }).get(0).then(function(file) {
     if (file && zipImage.isZip(file) && !zipImage.isValidZipImage(file)) {
       electron.dialog.showErrorBox(

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "sudo-prompt": "^2.2.0",
     "trackjs": "^2.1.16",
     "umount": "^1.1.1",
+    "user-homedir": "0.0.1",
     "username": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Etcher is usually run with sudo as it needs to permission to write
to removable drives. This results to electron opening root user's
file directories by default.

If etcher is run with UID 0 and SUDO_USER is set, with this solution
etcher will open /home/SUDO_USER on linux and /Users/SUDO_USER on
darwin.

This should not have any effect otherwise.