### PR TITLE
Hide drive selector modal if no available drives

### DIFF
--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -134,6 +134,10 @@ app.controller('AppController', function(
       self.selection.removeDrive();
     }
 
+    if (_.isEmpty(drives)) {
+      DriveSelectorService.close();
+    }
+
     // Notice we only autoselect the drive if there is an image,
     // which means that the first step was completed successfully,
     // otherwise the drive is selected while the drive step is disabled

--- a/lib/browser/components/drive-selector/services/drive-selector.js
+++ b/lib/browser/components/drive-selector/services/drive-selector.js
@@ -16,7 +16,9 @@
 
 'use strict';
 
-module.exports = function($uibModal) {
+module.exports = function($uibModal, $q) {
+
+  let modal = null;
 
   /**
    * @summary Open the drive selector widget
@@ -32,12 +34,37 @@ module.exports = function($uibModal) {
    * });
    */
   this.open = function() {
-    return $uibModal.open({
+    modal = $uibModal.open({
       animation: true,
       templateUrl: './browser/components/drive-selector/templates/drive-selector-modal.tpl.html',
       controller: 'DriveSelectorController as modal',
       size: 'sm'
-    }).result;
+    });
+
+    return modal.result;
+  };
+
+  /**
+   * @summary Close the drive selector widget
+   * @function
+   * @public
+   *
+   * @fulfil {Undefined}
+   * @returns {Promise}
+   *
+   * @example
+   * DriveSelectorService.close();
+   */
+  this.close = function() {
+
+    if (modal) {
+      return modal.dismiss();
+    }
+
+    // Resolve `undefined` if the modal
+    // was already closed for consistency
+    return $q.resolve();
+
   };
 
 };


### PR DESCRIPTION
If you have the drive selector modal opened, but you eject all the
available drives, the modal will be closed automatically.

Fixes: https://github.com/resin-io/etcher/issues/295
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>