### PR TITLE
Make all angular modules export the name of the module

### DIFF
--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -27,53 +27,38 @@ const dialog = electron.remote.require('./src/dialog');
 
 require('angular-ui-bootstrap');
 require('angular-ui-router');
-require('./browser/models/selection-state');
-require('./browser/modules/drive-scanner');
-require('./browser/modules/image-writer');
-require('./browser/modules/analytics');
-require('./browser/components/progress-button/progress-button');
-require('./browser/components/drive-selector/drive-selector');
-require('./browser/pages/finish/finish');
-require('./browser/pages/settings/settings');
-require('./browser/os/notification/notification');
-require('./browser/os/window-progress/window-progress');
-require('./browser/os/open-external/open-external');
-require('./browser/os/dropzone/dropzone');
-require('./browser/utils/if-state/if-state');
-require('./browser/utils/notifier/notifier');
-require('./browser/utils/path/path');
 
 const app = angular.module('Etcher', [
   'ui.router',
   'ui.bootstrap',
 
   // Etcher modules
-  'Etcher.drive-scanner',
-  'Etcher.image-writer',
-  'Etcher.analytics',
+  require('./browser/modules/drive-scanner'),
+  require('./browser/modules/image-writer'),
+  require('./browser/modules/analytics'),
 
   // Models
-  'Etcher.Models.SelectionState',
-  'Etcher.Models.Settings',
+  require('./browser/models/selection-state'),
+  require('./browser/models/settings'),
 
   // Components
-  'Etcher.Components.ProgressButton',
-  'Etcher.Components.DriveSelector',
+  require('./browser/components/progress-button/progress-button'),
+  require('./browser/components/drive-selector/drive-selector'),
 
   // Pages
-  'Etcher.Pages.Finish',
-  'Etcher.Pages.Settings',
+  require('./browser/pages/finish/finish'),
+  require('./browser/pages/settings/settings'),
 
   // OS
-  'Etcher.OS.WindowProgress',
-  'Etcher.OS.OpenExternal',
-  'Etcher.OS.Dropzone',
-  'Etcher.OS.Notification',
+  require('./browser/os/notification/notification'),
+  require('./browser/os/window-progress/window-progress'),
+  require('./browser/os/open-external/open-external'),
+  require('./browser/os/dropzone/dropzone'),
 
   // Utils
-  'Etcher.Utils.IfState',
-  'Etcher.Utils.Notifier',
-  'Etcher.Utils.Path'
+  require('./browser/utils/if-state/if-state'),
+  require('./browser/utils/notifier/notifier'),
+  require('./browser/utils/path/path')
 ]);
 
 app.run(function(AnalyticsService) {

--- a/lib/browser/components/drive-selector/drive-selector.js
+++ b/lib/browser/components/drive-selector/drive-selector.js
@@ -22,15 +22,16 @@
 
 const angular = require('angular');
 require('angular-ui-bootstrap');
-require('../../../browser/modules/drive-scanner');
-require('../../../browser/models/selection-state');
 
-const DriveSelector = angular.module('Etcher.Components.DriveSelector', [
+const MODULE_NAME = 'Etcher.Components.DriveSelector';
+const DriveSelector = angular.module(MODULE_NAME, [
   'ui.bootstrap',
-  'Etcher.drive-scanner',
-  'Etcher.Models.SelectionState'
+  require('../../../browser/modules/drive-scanner'),
+  require('../../../browser/models/selection-state')
 ]);
 
 DriveSelector.controller('DriveSelectorController', require('./controllers/drive-selector'));
 DriveSelector.service('DriveSelectorStateService', require('./services/drive-selector-state'));
 DriveSelector.service('DriveSelectorService', require('./services/drive-selector'));
+
+module.exports = MODULE_NAME;

--- a/lib/browser/components/progress-button/progress-button.js
+++ b/lib/browser/components/progress-button/progress-button.js
@@ -21,5 +21,7 @@
  */
 
 const angular = require('angular');
-const ProgressButton = angular.module('Etcher.Components.ProgressButton', []);
+const MODULE_NAME = 'Etcher.Components.ProgressButton';
+const ProgressButton = angular.module(MODULE_NAME, []);
 ProgressButton.directive('progressButton', require('./directives/progress-button'));
+module.exports = MODULE_NAME;

--- a/lib/browser/models/selection-state.js
+++ b/lib/browser/models/selection-state.js
@@ -22,7 +22,8 @@
 
 const _ = require('lodash');
 const angular = require('angular');
-const SelectionStateModel = angular.module('Etcher.Models.SelectionState', []);
+const MODULE_NAME = 'Etcher.Models.SelectionState';
+const SelectionStateModel = angular.module(MODULE_NAME, []);
 
 SelectionStateModel.service('SelectionStateModel', function() {
   let self = this;
@@ -195,3 +196,5 @@ SelectionStateModel.service('SelectionStateModel', function() {
   };
 
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/models/settings.js
+++ b/lib/browser/models/settings.js
@@ -22,7 +22,8 @@
 
 const angular = require('angular');
 require('ngstorage');
-const SettingsModel = angular.module('Etcher.Models.Settings', [
+const MODULE_NAME = 'Etcher.Models.Settings';
+const SettingsModel = angular.module(MODULE_NAME, [
   'ngStorage'
 ]);
 
@@ -40,3 +41,5 @@ SettingsModel.service('SettingsModel', function($localStorage) {
   });
 
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/modules/analytics.js
+++ b/lib/browser/modules/analytics.js
@@ -32,10 +32,10 @@ window.MIXPANEL_CUSTOM_LIB_URL = '../bower_components/mixpanel/mixpanel.js';
 
 require('../../../bower_components/mixpanel/mixpanel-jslib-snippet.js');
 require('../../../bower_components/angular-mixpanel/src/angular-mixpanel');
-require('../models/settings');
-const analytics = angular.module('Etcher.analytics', [
+const MODULE_NAME = 'Etcher.analytics';
+const analytics = angular.module(MODULE_NAME, [
   'analytics.mixpanel',
-  'Etcher.Models.Settings'
+  require('../models/settings')
 ]);
 
 analytics.config(function($mixpanelProvider) {
@@ -155,3 +155,5 @@ analytics.service('AnalyticsService', function($log, $mixpanel, SettingsModel) {
   };
 
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/modules/drive-scanner.js
+++ b/lib/browser/modules/drive-scanner.js
@@ -25,7 +25,8 @@ const _ = require('lodash');
 const EventEmitter = require('events').EventEmitter;
 const drivelist = require('drivelist');
 
-const driveScanner = angular.module('Etcher.drive-scanner', [
+const MODULE_NAME = 'Etcher.drive-scanner';
+const driveScanner = angular.module(MODULE_NAME, [
   require('angular-q-promisify')
 ]);
 
@@ -159,3 +160,5 @@ driveScanner.service('DriveScannerService', function($q, $interval, $timeout) {
   };
 
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/modules/image-writer.js
+++ b/lib/browser/modules/image-writer.js
@@ -29,11 +29,10 @@ if (window.mocha) {
   var writer = electron.remote.require('./src/writer');
 }
 
-require('../models/settings');
-require('../utils/notifier/notifier');
-const imageWriter = angular.module('Etcher.image-writer', [
-  'Etcher.Models.Settings',
-  'Etcher.Utils.Notifier'
+const MODULE_NAME = 'Etcher.image-writer';
+const imageWriter = angular.module(MODULE_NAME, [
+  require('../models/settings'),
+  require('../utils/notifier/notifier')
 ]);
 
 imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel, NotifierService) {
@@ -170,3 +169,5 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel, 
   };
 
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/os/dropzone/dropzone.js
+++ b/lib/browser/os/dropzone/dropzone.js
@@ -21,5 +21,7 @@
  */
 
 const angular = require('angular');
-const OSDropzone = angular.module('Etcher.OS.Dropzone', []);
+const MODULE_NAME = 'Etcher.OS.Dropzone';
+const OSDropzone = angular.module(MODULE_NAME, []);
 OSDropzone.directive('osDropzone', require('./directives/dropzone'));
+module.exports = MODULE_NAME;

--- a/lib/browser/os/notification/notification.js
+++ b/lib/browser/os/notification/notification.js
@@ -24,5 +24,7 @@
  */
 
 const angular = require('angular');
-const OSNotification = angular.module('Etcher.OS.Notification', []);
+const MODULE_NAME = 'Etcher.OS.Notification';
+const OSNotification = angular.module(MODULE_NAME, []);
 OSNotification.service('OSNotificationService', require('./services/notification'));
+module.exports = MODULE_NAME;

--- a/lib/browser/os/open-external/open-external.js
+++ b/lib/browser/os/open-external/open-external.js
@@ -21,5 +21,7 @@
  */
 
 const angular = require('angular');
-const OSOpenExternal = angular.module('Etcher.OS.OpenExternal', []);
+const MODULE_NAME = 'Etcher.OS.OpenExternal';
+const OSOpenExternal = angular.module(MODULE_NAME, []);
 OSOpenExternal.directive('osOpenExternal', require('./directives/open-external'));
+module.exports = MODULE_NAME;

--- a/lib/browser/os/window-progress/window-progress.js
+++ b/lib/browser/os/window-progress/window-progress.js
@@ -25,5 +25,7 @@
  */
 
 const angular = require('angular');
-const OSWindowProgress = angular.module('Etcher.OS.WindowProgress', []);
+const MODULE_NAME = 'Etcher.OS.WindowProgress';
+const OSWindowProgress = angular.module(MODULE_NAME, []);
 OSWindowProgress.service('OSWindowProgressService', require('./services/window-progress'));
+module.exports = MODULE_NAME;

--- a/lib/browser/pages/finish/finish.js
+++ b/lib/browser/pages/finish/finish.js
@@ -28,17 +28,14 @@
 
 const angular = require('angular');
 require('angular-ui-router');
-require('../../modules/image-writer');
-require('../../modules/analytics');
-require('../../models/selection-state');
-require('../../models/settings');
 
-const FinishPage = angular.module('Etcher.Pages.Finish', [
+const MODULE_NAME = 'Etcher.Pages.Finish';
+const FinishPage = angular.module(MODULE_NAME, [
   'ui.router',
-  'Etcher.image-writer',
-  'Etcher.analytics',
-  'Etcher.Models.SelectionState',
-  'Etcher.Models.Settings'
+  require('../../modules/image-writer'),
+  require('../../modules/analytics'),
+  require('../../models/selection-state'),
+  require('../../models/settings')
 ]);
 
 FinishPage.controller('FinishController', require('./controllers/finish'));
@@ -51,3 +48,5 @@ FinishPage.config(function($stateProvider) {
       templateUrl: './browser/pages/finish/templates/success.tpl.html'
     });
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/pages/settings/settings.js
+++ b/lib/browser/pages/settings/settings.js
@@ -22,11 +22,11 @@
 
 const angular = require('angular');
 require('angular-ui-router');
-require('../../models/settings');
 
-const SettingsPage = angular.module('Etcher.Pages.Settings', [
+const MODULE_NAME = 'Etcher.Pages.Settings';
+const SettingsPage = angular.module(MODULE_NAME, [
   'ui.router',
-  'Etcher.Models.Settings'
+  require('../../models/settings')
 ]);
 
 SettingsPage.controller('SettingsController', require('./controllers/settings'));
@@ -39,3 +39,5 @@ SettingsPage.config(function($stateProvider) {
       templateUrl: './browser/pages/settings/templates/settings.tpl.html'
     });
 });
+
+module.exports = MODULE_NAME;

--- a/lib/browser/utils/if-state/if-state.js
+++ b/lib/browser/utils/if-state/if-state.js
@@ -27,9 +27,12 @@
 const angular = require('angular');
 require('angular-ui-router');
 
-const IfState = angular.module('Etcher.Utils.IfState', [
+const MODULE_NAME = 'Etcher.Utils.IfState';
+const IfState = angular.module(MODULE_NAME, [
   'ui.router'
 ]);
 
 IfState.directive('showIfState', require('./directives/show-if-state'));
 IfState.directive('hideIfState', require('./directives/hide-if-state'));
+
+module.exports = MODULE_NAME;

--- a/lib/browser/utils/notifier/notifier.js
+++ b/lib/browser/utils/notifier/notifier.js
@@ -24,5 +24,7 @@
  */
 
 const angular = require('angular');
-const Notifier = angular.module('Etcher.Utils.Notifier', []);
+const MODULE_NAME = 'Etcher.Utils.Notifier';
+const Notifier = angular.module(MODULE_NAME, []);
 Notifier.service('NotifierService', require('./services/notifier'));
+module.exports = MODULE_NAME;

--- a/lib/browser/utils/path/path.js
+++ b/lib/browser/utils/path/path.js
@@ -24,5 +24,7 @@
  */
 
 const angular = require('angular');
-const Path = angular.module('Etcher.Utils.Path', []);
+const MODULE_NAME = 'Etcher.Utils.Path';
+const Path = angular.module(MODULE_NAME, []);
 Path.filter('basename', require('./filters/basename'));
+module.exports = MODULE_NAME;

--- a/tests/browser/components/drive-selector.spec.js
+++ b/tests/browser/components/drive-selector.spec.js
@@ -3,11 +3,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/components/drive-selector/drive-selector');
 
 describe('Browser: DriveSelector', function() {
 
-  beforeEach(angular.mock.module('Etcher.Components.DriveSelector'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/components/drive-selector/drive-selector')
+  ));
 
   describe('DriveSelectorStateService', function() {
 

--- a/tests/browser/models/selection-state.spec.js
+++ b/tests/browser/models/selection-state.spec.js
@@ -3,11 +3,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/models/selection-state');
 
 describe('Browser: SelectionState', function() {
 
-  beforeEach(angular.mock.module('Etcher.Models.SelectionState'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/models/selection-state')
+  ));
 
   describe('SelectionStateModel', function() {
 

--- a/tests/browser/modules/drive-scanner.spec.js
+++ b/tests/browser/modules/drive-scanner.spec.js
@@ -4,11 +4,12 @@ const m = require('mochainon');
 const angular = require('angular');
 const drivelist = require('drivelist');
 require('angular-mocks');
-require('../../../lib/browser/modules/drive-scanner');
 
 describe('Browser: DriveScanner', function() {
 
-  beforeEach(angular.mock.module('Etcher.drive-scanner'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/modules/drive-scanner')
+  ));
 
   describe('DriveScannerService', function() {
 

--- a/tests/browser/modules/image-writer.spec.js
+++ b/tests/browser/modules/image-writer.spec.js
@@ -3,11 +3,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/modules/image-writer');
 
 describe('Browser: ImageWriter', function() {
 
-  beforeEach(angular.mock.module('Etcher.image-writer'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/modules/image-writer')
+  ));
 
   describe('ImageWriterService', function() {
 

--- a/tests/browser/os/dropzone.spec.js
+++ b/tests/browser/os/dropzone.spec.js
@@ -19,11 +19,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/os/dropzone/dropzone');
 
 describe('Browser: OSDropzone', function() {
 
-  beforeEach(angular.mock.module('Etcher.OS.Dropzone'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/os/dropzone/dropzone')
+  ));
 
   describe('osDropzone', function() {
 

--- a/tests/browser/os/open-external.spec.js
+++ b/tests/browser/os/open-external.spec.js
@@ -22,11 +22,12 @@ const angular = require('angular');
 const electron = require('electron');
 const shell = electron.remote.require('shell');
 require('angular-mocks');
-require('../../../lib/browser/os/open-external/open-external');
 
 describe('Browser: OSOpenExternal', function() {
 
-  beforeEach(angular.mock.module('Etcher.OS.OpenExternal'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/os/open-external/open-external')
+  ));
 
   describe('osOpenExternal', function() {
 

--- a/tests/browser/os/window-progress.spec.js
+++ b/tests/browser/os/window-progress.spec.js
@@ -19,11 +19,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/os/window-progress/window-progress');
 
 describe('Browser: OSWindowProgress', function() {
 
-  beforeEach(angular.mock.module('Etcher.OS.WindowProgress'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/os/window-progress/window-progress')
+  ));
 
   describe('OSWindowProgressService', function() {
 

--- a/tests/browser/utils/if-state.spec.js
+++ b/tests/browser/utils/if-state.spec.js
@@ -19,11 +19,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/utils/if-state/if-state');
 
 describe('Browser: IfState', function() {
 
-  beforeEach(angular.mock.module('Etcher.Utils.IfState'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/utils/if-state/if-state')
+  ));
 
   let $compile;
   let $rootScope;

--- a/tests/browser/utils/notifier.spec.js
+++ b/tests/browser/utils/notifier.spec.js
@@ -3,11 +3,12 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
-require('../../../lib/browser/utils/notifier/notifier');
 
 describe('Browser: Notifier', function() {
 
-  beforeEach(angular.mock.module('Etcher.Utils.Notifier'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/utils/notifier/notifier')
+  ));
 
   describe('NotifierService', function() {
 

--- a/tests/browser/utils/path.spec.js
+++ b/tests/browser/utils/path.spec.js
@@ -4,11 +4,12 @@ const m = require('mochainon');
 const angular = require('angular');
 const os = require('os');
 require('angular-mocks');
-require('../../../lib/browser/utils/path/path');
 
 describe('Browser: Path', function() {
 
-  beforeEach(angular.mock.module('Etcher.Utils.Path'));
+  beforeEach(angular.mock.module(
+    require('../../../lib/browser/utils/path/path')
+  ));
 
   describe('BasenameFilter', function() {
 


### PR DESCRIPTION
This makes them very nicely require-able, for example:

    angular.module('MyModule', [
      require('my-dependency');
    ]);

From https://medium.com/@kentcdodds/how-to-distribute-your-angularjs-module-e04d4dd58ddc#.yqg2zo8im
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>