### PR TITLE
Don't require angular-ui-bootstrap in main module

### DIFF
--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -25,7 +25,6 @@ const _ = require('lodash');
 const electron = require('electron');
 const dialog = electron.remote.require('./src/dialog');
 
-require('angular-ui-bootstrap');
 require('angular-ui-router');
 require('./browser/models/selection-state');
 require('./browser/modules/drive-scanner');
@@ -45,7 +44,6 @@ require('./browser/utils/path/path');
 
 const app = angular.module('Etcher', [
   'ui.router',
-  'ui.bootstrap',
 
   // Etcher modules
   'Etcher.drive-scanner',


### PR DESCRIPTION
This dependency is only required by `Etcher.Components.DriveSelector`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>