### PR TITLE
Reset writer state on flash error

### DIFF
--- a/lib/browser/app.js
+++ b/lib/browser/app.js
@@ -249,7 +249,10 @@ app.controller('AppController', function(
         AnalyticsService.logEvent('Flash error');
       }
     })
-    .catch(dialog.showError)
+    .catch(function(error) {
+      self.writer.resetState();
+      dialog.showError(error);
+    })
     .finally(OSWindowProgressService.clear);
   };
 });


### PR DESCRIPTION
Not doing so leads the writer state to have a `progress` of `100%`,
while `isFlashing()` is `false`, which is an inconsistent state.

Fixes: https://github.com/resin-io/etcher/issues/327
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>