### PR TITLE
Upgrade resin-image-write to v3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.5.1",
     "ngstorage": "^0.3.10",
     "open": "0.0.5",
-    "resin-image-write": "^3.0.2",
+    "resin-image-write": "^3.0.3",
     "resin-zip-image": "^1.1.2",
     "sudo-prompt": "^2.2.0",
     "trackjs": "^2.1.16",


### PR DESCRIPTION
This new version contains a fix for the `stream.push() after EOF` error
hit when writing unaligned images.

Fixes: https://github.com/resin-io/etcher/issues/307
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>