### PR TITLE
Add support for command line arguments (including passing in an image file)

### DIFF
--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -92,7 +92,9 @@ electron.app.on('ready', function() {
       }, 100);
 
       if (args._.length === 1) {
-        mainWindow.webContents.executeJavaScript('angular.element(document.getElementById("appcontainer")).scope().app.selectImage("' + args._[0] + '");');
+        mainWindow.webContents.executeJavaScript(
+          'angular.element(document.getElementById("appcontainer")).scope().app.selectImage("' + args._[0] + '");'
+        );
       }
     });
 

--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -43,7 +43,7 @@ electron.app.on('ready', function() {
 
   if (args._.length > 1) {
     console.log('Only one image can be specified.');
-    console.log('(See ' + process.argv[0] + ' -h for more information.)');
+    console.log('(Run "' + process.argv[0] + '" -h for more information.)');
     return process.exit(0);
   }
 

--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -19,11 +19,46 @@
 const electron = require('electron');
 const path = require('path');
 const elevate = require('./elevate');
+const fs = require('fs');
+const args = require('minimist')(process.argv.slice(2));
 let mainWindow = null;
 
 electron.app.on('window-all-closed', electron.app.quit);
 
 electron.app.on('ready', function() {
+
+  if (args.h || args.help) {
+    console.log('Etcher - A better way to flash OS images to SD cards');
+    console.log('http://etcher.io\n');
+    console.log('Usage:');
+    console.log('   ' + process.argv[0] + ' [options] [image]\n');
+    console.log('Options:');
+    console.log('   -h | --help     This information');
+    console.log('\n');
+    console.log('Supported image formats:');
+    console.log('   .img .iso .zip');
+    console.log('\n');
+    return process.exit(0);
+  }
+
+  if (args._.length > 1) {
+    console.log('Only one image can be specified.');
+    console.log('(See ' + process.argv[0] + ' -h for more information.)');
+    return process.exit(0);
+  }
+
+  if (args._.length === 1) {
+
+    // Check for image file existence and pass into the writer
+    var stat;
+    try {
+      stat = fs.statSync(args._[0]);
+    }
+    catch (e) {
+      console.log('Cannot find image ' + args._[0]);
+      process.exit(0);
+    }
+  }
 
   // No menu bar
   electron.Menu.setApplicationMenu(null);
@@ -56,6 +91,9 @@ electron.app.on('ready', function() {
         mainWindow.show();
       }, 100);
 
+      if (args._.length === 1) {
+        mainWindow.webContents.executeJavaScript('angular.element(document.getElementById("appcontainer")).scope().app.selectImage("' + args._[0] + '");');
+      }
     });
 
     mainWindow.on('closed', function() {

--- a/lib/partials/main.html
+++ b/lib/partials/main.html
@@ -1,4 +1,4 @@
-<div class="row around-xs">
+<div class="row around-xs" id="appcontainer">
   <div class="col-xs">
     <div class="box text-center" os-dropzone="app.selectImage($file)">
       <svg-icon class="center-block" path="../../../../../assets/images/image.svg"></svg-icon>

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "sudo-prompt": "^2.2.0",
     "trackjs": "^2.1.16",
     "umount": "^1.1.1",
-    "username": "^2.1.0"
+    "username": "^2.1.0",
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "angular-mocks": "^1.4.7",


### PR DESCRIPTION
This allows parsing of arguments on the command line as well as passing in an image filename when invoking Etcher.  This streamlines the process when launching Etcher from the command line with an image in the current directory.

(I'm sure there's a better way to pass the filename in but I'm not sure what it is :/ )

I tested this on Ubuntu 15.04.  It closes issue #332.