### PR TITLE
Fix Error: Cannot find module `../global-shortcut` in Windows

### DIFF
--- a/lib/etcher.js
+++ b/lib/etcher.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const electron = require('electron');
+const globalShortcut = require('global-shortcut');
 const path = require('path');
 const elevate = require('./elevate');
 const packageJSON = require('../package.json');
@@ -63,7 +64,7 @@ electron.app.on('ready', function() {
       mainWindow = null;
     });
 
-    electron.globalShortcut.register('CmdOrCtrl+Alt+I', function() {
+    globalShortcut.register('CmdOrCtrl+Alt+I', function() {
       mainWindow.webContents.openDevTools();
     });
 


### PR DESCRIPTION
Since the Electron upgrade, Windows users are hitting a weird error
about `global-shortcut` not existing.

A solution is to `require('global-shortcut')` instead of accessing it as
a property of `electron`.
![capture](https://cloud.githubusercontent.com/assets/2192773/14747934/166e7c7a-0885-11e6-8fec-c22223d9cbfd.PNG)

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>