### PR TITLE
Upgrade drivelist to v3.0.0

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -56,7 +56,8 @@ const app = angular.module('Etcher', [
   require('./utils/if-state/if-state'),
   require('./utils/notifier/notifier'),
   require('./utils/path/path'),
-  require('./utils/manifest-bind/manifest-bind')
+  require('./utils/manifest-bind/manifest-bind'),
+  require('./utils/byte-size/byte-size')
 ]);
 
 app.run(function(AnalyticsService) {

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -8,7 +8,7 @@
     <li class="list-group-item" ng-repeat="drive in modal.scanner.drives"
       ng-click="modal.state.toggleSelectDrive(drive)">
         <div>
-          <h4 class="list-group-item-heading">{{ drive.description }} - {{ drive.size }}</h4>
+          <h4 class="list-group-item-heading">{{ drive.description }} - {{ drive.size | gigabyte | number:1 }} GB</h4>
           <p class="list-group-item-text">{{ drive.name }}</p>
         </div>
         <span class="tick tick--success" ng-disabled="!modal.state.isSelectedDrive(drive)"></span>

--- a/lib/gui/partials/main.html
+++ b/lib/gui/partials/main.html
@@ -49,8 +49,7 @@
 
         </div>
         <div ng-show="app.selection.hasDrive()">
-          <div ng-bind="app.selection.getDrive().name + ' - ' + app.selection.getDrive().size"></div>
-
+          <div>{{ app.selection.getDrive().name }} - {{ app.selection.getDrive().size | gigabyte | number:1 }} GB</div>
           <button class="btn btn-link step-footer"
             ng-click="app.reselectDrive()"
             ng-hide="app.writer.isFlashing()">Change</button>

--- a/lib/gui/utils/byte-size/byte-size.js
+++ b/lib/gui/utils/byte-size/byte-size.js
@@ -17,20 +17,15 @@
 'use strict';
 
 /**
- * @module Etcher.Components.DriveSelector
+ * @module Etcher.Utils.ByteSize
+ *
+ * The purpose of this module is to provide utilities
+ * to work with sizes in bytes.
  */
 
 const angular = require('angular');
-const MODULE_NAME = 'Etcher.Components.DriveSelector';
-const DriveSelector = angular.module(MODULE_NAME, [
-  require('angular-ui-bootstrap'),
-  require('../../modules/drive-scanner'),
-  require('../../models/selection-state'),
-  require('../../utils/byte-size/byte-size')
-]);
-
-DriveSelector.controller('DriveSelectorController', require('./controllers/drive-selector'));
-DriveSelector.service('DriveSelectorStateService', require('./services/drive-selector-state'));
-DriveSelector.service('DriveSelectorService', require('./services/drive-selector'));
+const MODULE_NAME = 'Etcher.Utils.ByteSize';
+const ByteSize = angular.module(MODULE_NAME, []);
+ByteSize.filter('gigabyte', require('./filters/gigabyte'));
 
 module.exports = MODULE_NAME;

--- a/lib/gui/utils/byte-size/filters/gigabyte.js
+++ b/lib/gui/utils/byte-size/filters/gigabyte.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = function() {
+
+  /**
+   * @summary Convert bytes to gigabytes
+   * @function
+   * @public
+   *
+   * @param {Number} bytes - bytes
+   * @returns {Number} gigabytes
+   *
+   * @example
+   * {{ 7801405440 | gigabytes }}
+   */
+  return function(bytes) {
+    return bytes / 1000000000;
+  };
+
+};

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^2.0.13",
+    "drivelist": "^3.0.0",
     "flexboxgrid": "^6.3.0",
     "is-elevated": "^1.0.0",
     "lodash": "^4.5.1",

--- a/tests/gui/utils/byte-size.spec.js
+++ b/tests/gui/utils/byte-size.spec.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const m = require('mochainon');
+const angular = require('angular');
+const os = require('os');
+require('angular-mocks');
+
+describe('Browser: ByteSize', function() {
+
+  beforeEach(angular.mock.module(
+    require('../../../lib/gui/utils/byte-size/byte-size')
+  ));
+
+  describe('GigabyteFilter', function() {
+
+    let gigabyteFilter;
+
+    beforeEach(angular.mock.inject(function(_gigabyteFilter_) {
+      gigabyteFilter = _gigabyteFilter_;
+    }));
+
+    it('should convert bytes to gigabytes', function() {
+      m.chai.expect(gigabyteFilter(7801405440)).to.equal(7.80140544);
+      m.chai.expect(gigabyteFilter(100000000)).to.equal(0.1);
+    });
+
+  });
+});


### PR DESCRIPTION
This new version reports the size as a number of bytes instead of a
human readable string, so we have to take care of converting back to a
readable GB format ourselves.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>