### PR TITLE
Fix lint warnings

### DIFF
--- a/tests/gui/utils/byte-size.spec.js
+++ b/tests/gui/utils/byte-size.spec.js
@@ -2,7 +2,6 @@
 
 const m = require('mochainon');
 const angular = require('angular');
-const os = require('os');
 require('angular-mocks');
 
 describe('Browser: ByteSize', function() {


### PR DESCRIPTION
- `os` in unused in `byte-size.spec.js`

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>