### PR TITLE
Implement Etcher CLI "robot" option

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -63,6 +63,14 @@ module.exports = yargs
     return true;
   })
 
+  .check(function(argv) {
+    if (argv.robot && !argv.drive) {
+      throw new Error('Missing drive');
+    }
+
+    return true;
+  })
+
   .options({
     help: {
       describe: 'show help',
@@ -78,6 +86,11 @@ module.exports = yargs
       describe: 'drive',
       string: true,
       alias: 'd'
+    },
+    robot: {
+      describe: 'parse-able output without interactivity',
+      boolean: true,
+      alias: 'r'
     },
     yes: {
       describe: 'confirm non-interactively',

--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -41,7 +41,7 @@ form.run([
     // If `options.yes` is `false`, pass `undefined`,
     // otherwise the question will not be asked because
     // `false` is a defined value.
-    yes: options.yes || undefined
+    yes: options.robot || options.yes || undefined
 
   }
 }).then(function(answers) {
@@ -49,7 +49,7 @@ form.run([
     throw new Error('Aborted');
   }
 
-  var progressBar = new visuals.Progress('Burning');
+  const progressBar = new visuals.Progress('Burning');
 
   return writer.writeImage(options._[0], {
     device: answers.drive
@@ -57,11 +57,34 @@ form.run([
     unmountOnSuccess: false,
     validateWriteOnSuccess: false
   }, function(state) {
-    return progressBar.update(state);
+
+    if (options.robot) {
+      console.log([
+        state.type,
+        Math.floor(state.percentage) + '%',
+        state.eta + 's',
+        Math.floor(state.speed)
+      ].join(' '));
+    } else {
+      progressBar.update(state);
+    }
+
   });
 }).then(function() {
-  console.log('Your flash is complete!');
+
+  if (options.robot) {
+    console.log('done');
+  } else {
+    console.log('Your flash is complete!');
+  }
+
 }).catch(function(error) {
-  utils.printError(error);
+
+  if (options.robot) {
+    console.error(error.message);
+  } else {
+    utils.printError(error);
+  }
+
   process.exit(1);
 });


### PR DESCRIPTION
This option makes the Etcher CLI outputs state information in a way that
can be easily parsed by a parent process spawning it.

The format of the state output is:

```
<type> <percentage>% <eta>s <speed>
```

This can be easily parsed as follows:

```js
const output = line.split(' ');

const state = {
  type: output[0],
  percentage: parseInt(output[1], 10),
  eta: parseInt(output[2], 10),
  speed: parseInt(output[3], 10)
};
```

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>