### PR TITLE
Add entry point file to decide between GUI/CLI

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -23,7 +23,7 @@
 var angular = require('angular');
 const _ = require('lodash');
 const electron = require('electron');
-const dialog = electron.remote.require('./dialog');
+const dialog = electron.remote.require('./gui/dialog');
 
 const app = angular.module('Etcher', [
   require('angular-ui-router'),

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -26,7 +26,7 @@ const electron = require('electron');
 if (window.mocha) {
   var writer = electron.remote.require(require('path').join(__dirname, '..', '..', 'src', 'writer'));
 } else {
-  var writer = electron.remote.require('../src/writer');
+  var writer = electron.remote.require('./src/writer');
 }
 
 const MODULE_NAME = 'Etcher.image-writer';

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// See http://electron.atom.io/docs/v0.37.7/api/environment-variables/#electronrunasnode
+if (process.env.ELECTRON_RUN_AS_NODE) {
+  require('./cli/etcher');
+} else {
+  require('./gui/etcher');
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "etcher",
   "displayName": "Etcher",
   "version": "1.0.0-beta.4",
-  "main": "lib/gui/etcher.js",
+  "main": "lib/start.js",
   "description": "An image flasher with support for Windows, OS X and GNU/Linux.",
   "homepage": "https://github.com/resin-io/etcher",
   "repository": {
@@ -13,7 +13,7 @@
     "test:main": "electron-mocha --recursive tests/src -R progress",
     "test:gui": "electron-mocha --recursive --renderer tests/gui -R progress",
     "test": "npm run-script test:main && npm run-script test:gui",
-    "start": "electron lib/gui/etcher.js"
+    "start": "electron lib/start.js"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This file runs the Etcher CLI if the binary was ran with
`ELECTRON_RUN_AS_NODE`, or the GUI otherwise.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>