### PR TITLE
Upgrade node-umount to v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "resin-zip-image": "^1.1.2",
     "sudo-prompt": "^3.1.0",
     "trackjs": "^2.1.16",
-    "umount": "^1.1.1",
+    "umount": "^1.1.3",
     "username": "^2.1.0",
     "yargs": "^4.6.0"
   },


### PR DESCRIPTION
This new version contains a fix where the `diskutil` command was not
found on certain OS X setups.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>