### PR TITLE
Prefix robot progress state output with "progress"

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -63,6 +63,7 @@ form.run([
 
     if (options.robot) {
       console.log([
+        'progress',
         state.type,
         Math.floor(state.percentage) + '%',
         state.eta + 's',


### PR DESCRIPTION
This makes it a bit easier to determine if a `stdout` line is a progress
state or not, rather than checking for both `write` or `check`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>