### PR TITLE
Move Etcher CLI exit code definitions to lib/src

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -21,6 +21,7 @@ const form = require('resin-cli-form');
 const writer = require('../src/writer');
 const utils = require('./utils');
 const options = require('./cli');
+const EXIT_CODES = require('../src/exit-codes');
 
 form.run([
   {
@@ -82,8 +83,10 @@ form.run([
 
   if (success) {
     console.log('Your flash is complete!');
+    process.exit(EXIT_CODES.SUCCESS);
   } else {
     console.error('Validation failed!');
+    process.exit(EXIT_CODES.VALIDATION_ERROR);
   }
 
 }).catch(function(error) {
@@ -94,5 +97,5 @@ form.run([
     utils.printError(error);
   }
 
-  process.exit(1);
+  process.exit(EXIT_CODES.GENERAL_ERROR);
 });

--- a/lib/src/exit-codes.js
+++ b/lib/src/exit-codes.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * @summary Etcher exit codes
+ * @namespace EXIT_CODES
+ * @public
+ */
+module.exports = {
+
+  /**
+   * @property {Number} SUCCESS
+   * @memberof EXIT_CODES
+   *
+   * @description
+   * This exit code is used to represent a successful exit
+   * status, with no problems on the way.
+   */
+  SUCCESS: 0,
+
+  /**
+   * @property {Number} GENERAL_ERROR
+   * @memberof EXIT_CODES
+   *
+   * @description
+   * This exit code is used to represent a general error
+   * situation. If the reasons of the error is not
+   * documented as a specialised error code, this one
+   * should be used.
+   */
+  GENERAL_ERROR: 1,
+
+  /**
+   * @property {Number} VALIDATION_ERROR
+   * @memberof EXIT_CODES
+   *
+   * @description
+   * This exit code is used to represent a validation error.
+   */
+  VALIDATION_ERROR: 2
+
+};


### PR DESCRIPTION
The purpose is that defined exit codes can be reused in the GUI, so they
are kept in sync more easily.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>