### PR TITLE
Escape leading periods on packageignore list

### DIFF
--- a/scripts/packageignore.js
+++ b/scripts/packageignore.js
@@ -25,8 +25,10 @@ console.log(_.flatten([
   }),
 
   // Top level hidden files
-  _.filter(topLevelFiles, function(file) {
+  _.map(_.filter(topLevelFiles, function(file) {
     return _.startsWith(file, '.');
+  }), function(file) {
+    return '\\' + file;
   }),
 
   // Top level markdown files


### PR DESCRIPTION
Otherwise, the `.` is interpreted as a period in a regular expression,
  which matches every literal character, causing some packages deep in
  the `node_modules/` hierarchy to be ignored for no reason.

For example, if we ignore `.git`, then a package like `foo-git` will be
excluded from the final package.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>