### PR TITLE
Make sure the CLI handles arguments correctly when being packaged

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -18,6 +18,7 @@
 
 const _ = require('lodash');
 const fs = require('fs');
+const path = require('path');
 const yargs = require('yargs');
 const utils = require('./utils');
 const packageJSON = require('../../package.json');
@@ -111,4 +112,34 @@ module.exports = yargs
       default: true
     }
   })
-  .argv;
+
+  // Make sure arguments are parsed correctly when running
+  // in development mode (or NPM) and in a final package.
+  //
+  // We rely on the following heuristics to determine if the
+  // Etcher CLI is being run as a final packaged executable
+  // or by a tool passing the script as an argument:
+  .parse(_.attempt(function(argv) {
+
+    // Excluding the extension makes sure we cover cases
+    // like *.exe and *.cmd in Windows systems.
+    const executable = path.basename(argv[0], path.extname(argv[0]));
+
+    if (executable === 'node' || executable === 'electron') {
+
+      // In this case, the second argument (e.g: index 1)
+      // equals `lib/cli/etcher.js`, so the real arguments
+      // start from the third one.
+      return argv.slice(2);
+
+    }
+
+    // Handle the case where the CLI is executed by pointing
+    // the packaged electron `Etcher` binary to the application
+    // asar archive by using `ELECTRON_RUN_AS_NODE`.
+    if (argv[1] && path.basename(argv[1]) === 'app.asar') {
+      return argv.slice(2);
+    }
+
+    return argv.slice(1);
+  }, process.argv));


### PR DESCRIPTION
The CLI now attempts to detect whether it is being run as an argument to
a JavaScript runner (like node or electron), or as a final packaged
executable by applying some heuristics on the first argument.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>