### PR TITLE
Document that ELECTRON_RUN_AS_NODE doesn't load app.asar by default

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -17,8 +17,14 @@
 'use strict';
 
 // See http://electron.atom.io/docs/v0.37.7/api/environment-variables/#electronrunasnode
+//
+// Notice that if running electron with `ELECTRON_RUN_AS_NODE`, the binary
+// *won't* attempt to load the `app.asar` application by default, therefore
+// if passing `ELECTRON_RUN_AS_NODE`, you have to pass the path to the asar
+// or the entry point file (this file) manually as an argument.
 if (process.env.ELECTRON_RUN_AS_NODE) {
   require('./cli/etcher');
+
 } else {
   require('./gui/etcher');
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>