### PR TITLE
Upgrade resin-image-write to v4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.5.1",
     "ngstorage": "^0.3.10",
     "open": "0.0.5",
-    "resin-image-write": "^4.0.0",
+    "resin-image-write": "^4.0.1",
     "resin-cli-errors": "^1.2.0",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",


### PR DESCRIPTION
This new version contains a fix to align unaligned images and prevent
`EINVAL` errors.

Fixes: https://github.com/resin-io/etcher/issues/348
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>