### PR TITLE
Make sure CLI args are parsed correctly when spawning in OS X

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -130,7 +130,7 @@ module.exports = yargs
 
     // Excluding the extension makes sure we cover cases
     // like *.exe and *.cmd in Windows systems.
-    const executable = path.basename(argv[0], path.extname(argv[0]));
+    const executable = path.basename(argv[0], path.extname(argv[0])).toLowerCase();
 
     if (executable === 'node' || executable === 'electron') {
 


### PR DESCRIPTION
The binary used when spawning the CLI in OS X during development is
`electron-prebuilt/disk/Electron.app/Contents/MacOS/Electron`.

To make sure we catch both `Electron` and `electron`, make the
executable name lowercase before comparing it.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>