### PR TITLE
Use correct exit codes when running Etcher CLI with --robot

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -78,14 +78,18 @@ form.run([
 }).then(function(success) {
 
   if (options.robot) {
-    return console.log(`done ${success}`);
+    console.log(`done ${success}`);
+  } else {
+    if (success) {
+      console.log('Your flash is complete!');
+    } else {
+      console.error('Validation failed!');
+    }
   }
 
   if (success) {
-    console.log('Your flash is complete!');
     process.exit(EXIT_CODES.SUCCESS);
   } else {
-    console.error('Validation failed!');
     process.exit(EXIT_CODES.VALIDATION_ERROR);
   }
 


### PR DESCRIPTION
Currently, the exit codes documented in the help section was not
honoured if the CLI was ran with the `--robot` option. In this case, the
CLI would exit with code 0 even if the validation failed.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>