### PR TITLE
Fix child writer process not working on packaged app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
 
 install:
   - npm install
+  - npm install -g bower
+  - bower install
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ install:
   - npm -g install npm@2
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
+  - npm install -g bower
+  - bower install
 
 build: off
 

--- a/lib/gui/modules/analytics.js
+++ b/lib/gui/modules/analytics.js
@@ -60,10 +60,12 @@ analytics.config(function($mixpanelProvider) {
 // http://docs.trackjs.com/tracker/framework-integrations
 
 analytics.run(function($window) {
-  $window.trackJs.configure({
-    userId: username.sync(),
-    version: packageJSON.version
-  });
+  if ($window.trackJs) {
+    $window.trackJs.configure({
+      userId: username.sync(),
+      version: packageJSON.version
+    });
+  }
 });
 
 analytics.config(function($provide) {

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -22,6 +22,8 @@
 
 const angular = require('angular');
 const _ = require('lodash');
+const path = require('path');
+const isRunningInAsar = require('electron-is-running-in-asar');
 const electron = require('electron');
 const childProcess = require('child_process');
 const EXIT_CODES = require('../../src/exit-codes');
@@ -117,6 +119,10 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel, 
    */
   this.performWrite = function(image, drive, onProgress) {
     const argv = _.clone(electron.remote.process.argv);
+
+    if (isRunningInAsar()) {
+      argv.push(path.join(process.resourcesPath, 'app.asar'));
+    }
 
     argv.push(image);
     argv.push('--drive', drive.device);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
     "drivelist": "^3.0.0",
+    "electron-is-running-in-asar": "v1.0.0",
     "etcher-image-stream": "^1.2.0",
     "etcher-image-write": "^4.0.2",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
Setting `ELECTRON_RUN_AS_NODE=1` causes the node process to ignore the
default application location ('resources/app.asar') when no argument has
been passed.

This works fine when spawning the child process on develoment mode since
we're pointing to `lib/start.js` manually anyway, but fails when being
packaged since the electron binary tries to run the actual image as a
JavaScript program, failing with weird scary error messages.

As a workaround, we make use of an utility package called
`electron-is-running-in-asar`, which as the name implies, attempts to
detect whether the application is being ran from inside an asar package
or not. If the first case holds, we push the path to the `app.asar`
ourselves.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>