### PR TITLE
Fix application not being elevated in Windows

### DIFF
--- a/lib/src/elevate.js
+++ b/lib/src/elevate.js
@@ -55,7 +55,9 @@ exports.require = function(app, applicationName, callback) {
     }).then(function() {
 
       // Don't keep the original parent process alive
-      process.exit(0);
+      setTimeout(function() {
+        process.exit(0);
+      });
 
     });
 


### PR DESCRIPTION
After elevation routine refactoring, it looks like we have to exit the
parent process after a short while, otherwise it kills the app before
the elevated child process is executed.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>