### PR TITLE
Consider carriage returns when asserting SVG contents equality

### DIFF
--- a/tests/gui/components/svg-icon.spec.js
+++ b/tests/gui/components/svg-icon.spec.js
@@ -35,7 +35,7 @@ describe('Browser: SVGIcon', function() {
       const icon = '../../../../../lib/gui/assets/etcher.svg';
       let iconContents = fs.readFileSync(path.join(__dirname, '../../../lib/gui/assets/etcher.svg'), {
         encoding: 'utf8'
-      }).split('\n');
+      }).split(/\r?\n/);
 
       // Injecting XML as HTML causes the XML header to be commented out.
       // Modify here to ease assertions later on.


### PR DESCRIPTION
This was causing builds to fail in Windows.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>