### PR TITLE
Set mocha reporter to `min`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:resin-io/etcher.git"
   },
   "scripts": {
-    "test": "electron-mocha --recursive --renderer tests/gui -R progress",
+    "test": "electron-mocha --recursive --renderer tests/gui -R min",
     "start": "electron lib/start.js"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",


### PR DESCRIPTION
Fancier reporters are not shown correctly on CI servers.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>