### PR TITLE
Remove implicit "Enable" from settings items

### DIFF
--- a/lib/gui/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/pages/settings/templates/settings.tpl.html
@@ -4,21 +4,21 @@
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="settings.storage.errorReporting">
-      <span>Enable error reporting</span>
+      <span>Report errors</span>
     </label>
   </div>
 
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="settings.storage.unmountOnSuccess">
-      <span>Enable auto-unmounting on success</span>
+      <span>Auto-unmount on success</span>
     </label>
   </div>
 
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model="settings.storage.validateWriteOnSuccess">
-      <span>Enable write validation on success</span>
+      <span>Validate write on success</span>
     </label>
   </div>
 </div>


### PR DESCRIPTION
The fact that there is a checkbox at the left of the items already makes
clear the ticking them enables the setting.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>