### PR TITLE
Enforce expected NodeJS version in build scripts

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -10,6 +10,8 @@ Common Pre-requisites
 
 Make sure you're running the exact same NodeJS version as the one included with the current Electron build being used by Etcher to avoid any strange native dependencies issues.
 
+The expected NodeJS version is determined by the `engines.node` property in [`package.json`](https://github.com/resin-io/etcher/blob/master/package.json).
+
 - [Bower](http://bower.io)
 - [UPX](http://upx.sourceforge.net)
 - [Python](https://www.python.org)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "lib/start.js",
   "description": "An image flasher with support for Windows, OS X and GNU/Linux.",
   "homepage": "https://github.com/resin-io/etcher",
+  "engines" : {
+    "node" : "5.10.0"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:resin-io/etcher.git"

--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -39,6 +39,12 @@ ELECTRON_VERSION=`node -e "console.log(require('./package.json').devDependencies
 APPLICATION_NAME=`node -e "console.log(require('./package.json').displayName)"`
 APPLICATION_COPYRIGHT=`node -e "console.log(require('./package.json').copyright)"`
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
+ELECTRON_NODE_VERSION=`node -e "console.log(require('./package.json').engines.node)"`
+
+if [[ "v$ELECTRON_NODE_VERSION" != "`node -v`" ]]; then
+  echo "Incompatible NodeJS version. Expected: $ELECTRON_NODE_VERSION" 1>&2
+  exit 1
+fi
 
 function install {
   rm -rf node_modules bower_components

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -53,6 +53,12 @@ ELECTRON_VERSION=`node -e "console.log(require('./package.json').devDependencies
 APPLICATION_NAME=`node -e "console.log(require('./package.json').displayName)"`
 APPLICATION_COPYRIGHT=`node -e "console.log(require('./package.json').copyright)"`
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
+ELECTRON_NODE_VERSION=`node -e "console.log(require('./package.json').engines.node)"`
+
+if [[ "v$ELECTRON_NODE_VERSION" != "`node -v`" ]]; then
+  echo "Incompatible NodeJS version. Expected: $ELECTRON_NODE_VERSION" 1>&2
+  exit 1
+fi
 
 function install {
 

--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -124,6 +124,19 @@ for /f %%i in (' "node -e ""console.log(require('./package.json').version)""" ')
   set etcher_version=%%i
 )
 
+for /f %%i in (' "node -e ""console.log(require('./package.json').engines.node)""" ') do (
+  set electron_node_version=%%i
+)
+
+for /f %%i in (' "node -v" ') do (
+  set node_version=%%i
+)
+
+if not "v%electron_node_version%"=="%node_version%" (
+  echo Incompatible NodeJS version. Expected: %electron_node_version% 1>&2
+  exit /b 1
+)
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Configure NPM to build native addons for Electron correctly
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Not building Etcher with the exact NodeJS version bundled with Electron
can cause all sorts of weird issues. This was previously documented, but
its now enforced so Etcher packagers don't forget by accident.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>