### PR TITLE
Override files if needed in the build scripts

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -107,6 +107,7 @@ function installer_dmg {
 	hdiutil detach $volume_directory || true
 
 	# Create temporal read-write DMG image
+	rm -f $temporal_dmg
 	hdiutil create \
 		-srcfolder $source_directory \
 		-volname "$APPLICATION_NAME" \
@@ -183,6 +184,7 @@ function installer_dmg {
 	# Convert temporal DMG image into a production-ready
 	# compressed and read-only DMG image.
 	mkdir -p $output_directory
+	rm -f $output_directory/Etcher-darwin-x64.dmg
 	hdiutil convert $temporal_dmg \
 		-format UDZO \
 		-imagekey zlib-level=9 \

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -146,6 +146,7 @@ function installer {
 
   mkdir -p $output_directory
   app_dir_create $source_directory $architecture $appdir_temporary_location
+  rm -f $output_file
   ./scripts/AppImageAssistant-$architecture $appdir_temporary_location $output_file
   rm -rf $appdir_temporary_location
 }


### PR DESCRIPTION
This allows the users to continuously run the build script without
having to remove `etcher-release` or certain files inside that directory
to prevent silly "file exists" errors.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>