### PR TITLE
Install dev dependencies before calling electron-builder on Windows

### DIFF
--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -213,6 +213,7 @@ upx -9 %package_output%\*.dll
 set installer_tmp_output=%output_build_directory%\win32-%arch%-tmp-installer
 set installer_output=%output_directory%\Etcher-win32-%arch%.exe
 
+call npm install --only=dev
 call %electron_builder% %package_output%^
  --platform=win^
  --out=%installer_tmp_output%


### PR DESCRIPTION
Since the addition of a patch to only install production dependencies on
build scripts, the Windows build would fail when reaching to
`electron-builder`, since this dependency might not be installed at that
point.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>