### PR TITLE
Prevent global shorcuts from interferring with other applications

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -63,8 +63,22 @@ electron.app.on('ready', function() {
       mainWindow = null;
     });
 
-    electron.globalShortcut.register('CmdOrCtrl+Alt+I', function() {
-      mainWindow.webContents.openDevTools();
+    // For some reason, Electron shortcuts are registered
+    // globally, which means that the app listers for shorcuts
+    // even if its not currently focused, potentially interferring
+    // with shorcuts registered by other applications.
+    // As a workaround, we register all shortcuts when the windows
+    // gains focus, and unregister them when the windows loses focus.
+    // See http://electron.atom.io/docs/api/global-shortcut/
+
+    mainWindow.on('focus', function() {
+      electron.globalShortcut.register('CmdOrCtrl+Alt+I', function() {
+        mainWindow.webContents.openDevTools();
+      });
+    });
+
+    mainWindow.on('blur', function() {
+      electron.globalShortcut.unregisterAll();
     });
 
     mainWindow.loadURL(`file://${path.join(__dirname, 'index.html')}`);


### PR DESCRIPTION
Fixes: https://github.com/resin-io/etcher/issues/389
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>