### PR TITLE
Prevent pressing "space" to re-click the "Flash" button

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6390,6 +6390,11 @@ button.btn:focus, button.progress-button:focus {
 .progress-button--primary.progress-button--striped {
   background-image: -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.25, #3b679b), color-stop(0.25, #5c93d6), color-stop(0.5, #5c93d6), color-stop(0.5, #3b679b), color-stop(0.75, #3b679b), color-stop(0.75, #5c93d6), to(#5c93d6)); }
 
+.progress-button--primary[active="true"]:active {
+  box-shadow: none;
+  background-color: #5cb85c;
+  border-color: #4286d7; }
+
 .progress-button[percentage="100"][active="false"] .progress-button__bar {
   background-color: #5cb85c; }
 

--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -252,6 +252,10 @@ app.controller('AppController', function(
 
   this.flash = function(image, drive) {
 
+    if (self.writer.isFlashing()) {
+      return;
+    }
+
     // Stop scanning drives when flashing
     // otherwise Windows throws EPERM
     self.scanner.stop();

--- a/lib/gui/components/progress-button/styles/_progress-button.scss
+++ b/lib/gui/components/progress-button/styles/_progress-button.scss
@@ -73,6 +73,12 @@ $progress-button-stripes-animation-duration: 1s;
   }
 }
 
+.progress-button--primary[active="true"]:active {
+  box-shadow: none;
+  background-color: $brand-success;
+  border-color: $btn-primary-border;
+}
+
 .progress-button[percentage="100"][active="false"] .progress-button__bar {
   background-color: $brand-success;
 }


### PR DESCRIPTION
Currently we disable pointer events on the "Flash" button once a flash
is in progress to prevent the user from clicking it, but we didn't
consider that if the user kept focus on the button, he can press the
"space" bar for the same effect.

Fixes: https://github.com/resin-io/etcher/issues/431
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>