### PR TITLE
Fix GNU/Linux not opening an external resource when elevated

### DIFF
--- a/lib/gui/os/open-external/directives/open-external.js
+++ b/lib/gui/os/open-external/directives/open-external.js
@@ -18,7 +18,6 @@
 
 const electron = require('electron');
 const os = require('os');
-const nodeOpen = require('open');
 
 /**
  * @summary OsOpenExternal directive
@@ -45,25 +44,6 @@ module.exports = function() {
       element.css('cursor', 'pointer');
 
       element.on('click', function() {
-
-        // Electron's `shell.openExternal()` fails on GNU/Linux
-        // when Electron is ran with `sudo`.
-        // The issue was reported, and this is a workaround until
-        // its fixed on the Electron side.
-        // `node-open` is smart enough to check the `$SUDO_USER`
-        // environment variable and to prepend `sudo -u <user>`
-        // if needed.
-        // We keep `shell.openExternal()` for OSes other than
-        // Linux since we intend to fully rely on it when the
-        // issue is fixed, and since its closer integration with
-        // the operating system might lead to more accurate results
-        // than a third party NPM module.
-        //
-        // See https://github.com/electron/electron/issues/5039
-        if (os.platform() === 'linux') {
-          return nodeOpen(attributes.osOpenExternal);
-        }
-
         electron.shell.openExternal(attributes.osOpenExternal);
       });
     }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "is-elevated": "^1.0.0",
     "lodash": "^4.5.1",
     "ngstorage": "^0.3.10",
-    "open": "0.0.5",
     "resin-cli-errors": "^1.2.0",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",


### PR DESCRIPTION
We currently had a workaround in place to make use of `node-open`
instead of Electron's built-in `shell` module since the latter didn't
work on older Electron versions on GNU/Linux for some reason.

After some experimentation, `node-open` doesn't seem to be working for
elevated applications anymore. I honestly didn't chase the issue further
since Electron `shell` has been fixed, and works fine when elevated,
therefore this PR basically undoes the previous workaround.

Fixes: https://github.com/resin-io/etcher/issues/443
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>