### PR TITLE
Document `can-ignore` module.require annotation

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -24,7 +24,10 @@ const os = require('os');
 const isWindows = os.platform() === 'win32';
 
 if (isWindows) {
+
+  // The `can-ignore` annotation is EncloseJS (http://enclosejs.com) specific.
   var removedrive = Bluebird.promisifyAll(require('removedrive', 'can-ignore'));
+
 }
 
 /**


### PR DESCRIPTION
This annotation was introduced in: 1872d1f

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>