### PR TITLE
Prevent exernal resources from being loaded by the WebView

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -81,6 +81,13 @@ electron.app.on('ready', function() {
       electron.globalShortcut.unregisterAll();
     });
 
+    // Prevent external resources from being loaded (like images)
+    // when dropping them on the WebView.
+    // See https://github.com/electron/electron/issues/5919
+    mainWindow.webContents.on('will-navigate', function(event) {
+      event.preventDefault();
+    });
+
     mainWindow.loadURL(`file://${path.join(__dirname, 'index.html')}`);
   });
 });


### PR DESCRIPTION
If a user drags and drops an image, an HTML file, or other resource the
WebView understands, Electron will navigate away from the application
and load it up in the WebView, making the application unusable unless
the user restarts it.

Fixes: https://github.com/resin-io/etcher/issues/430
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>