### PR TITLE
Prevent selection of invalid images

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var angular = require('angular');
+const path = require('path');
 const _ = require('lodash');
 
 const app = angular.module('Etcher', [
@@ -188,6 +189,13 @@ app.controller('AppController', function(
   document.querySelector('body').style.display = 'initial';
 
   this.selectImage = function(image) {
+    const extension = path.extname(image.path).slice(1);
+
+    if (!_.includes(SupportedFormatsModel.getAllExtensions(), extension)) {
+      AnalyticsService.logEvent('Invalid image', image);
+      return;
+    }
+
     self.selection.setImage(image);
     AnalyticsService.logEvent('Select image', image);
   };


### PR DESCRIPTION
The user might attempt to select an invalid image by dropping on the
first step, which would cause Etcher to blindly select it, possibly
causing errors later on the process.

This PR makes use of the list of supported extensions provided by
`SupportedFormatsModel` and prevents the selection if necessary, logging
an event that might help us determine which unsupported image types
users try to burn most often.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>