### PR TITLE
Try to get more information about error messages

### DIFF
--- a/lib/gui/os/dialog/services/dialog.js
+++ b/lib/gui/os/dialog/services/dialog.js
@@ -88,7 +88,13 @@ module.exports = function($q, SupportedFormatsModel) {
    */
   this.showError = function(error) {
     error = error || {};
-    electron.remote.dialog.showErrorBox(error.message || 'An error ocurred!', error.stack || '');
+
+    // Try to get as most information as possible about the error
+    // rather than falling back to generic messages right away.
+    const title = error.message || error.code || 'An error ocurred';
+    const message = error.stack || JSON.stringify(error) || '';
+
+    electron.remote.dialog.showErrorBox(title, message);
 
     // Also throw it so it gets displayed in DevTools
     // and its reported by TrackJS.


### PR DESCRIPTION
If the error object is not well-formed, try to get as most information
about it as we can instead of just realying on generic error messages.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>