### PR TITLE
Fix image containing dots in the filename considered unsupported

### DIFF
--- a/lib/gui/models/supported-formats.js
+++ b/lib/gui/models/supported-formats.js
@@ -114,10 +114,10 @@ SupportedFormats.service('SupportedFormatsModel', function() {
     // to check every possible extension of an image path,
     // like `.tar.gz`.
 
-    const firstDotIndex = image.indexOf('.');
+    const firstDotIndex = _.get(/(\.)[\w\.]+$/.exec(image), 'index');
 
     // An image without an extension is not considered a valid image
-    if (firstDotIndex === -1) {
+    if (!firstDotIndex) {
       return false;
     }
 

--- a/tests/gui/models/supported-formats.spec.js
+++ b/tests/gui/models/supported-formats.spec.js
@@ -68,6 +68,13 @@ describe('Browser: SupportedFormats', function() {
         m.chai.expect(isSupported).to.be.true;
       });
 
+      it('should return true if the extension is supported and the file name includes dots', function() {
+        const supportedExtensions = SupportedFormatsModel.getAllExtensions();
+        const imagePath = '/path/to/foo.1.2.3-bar.' + _.first(supportedExtensions);
+        const isSupported = SupportedFormatsModel.isSupportedImage(imagePath);
+        m.chai.expect(isSupported).to.be.true;
+      });
+
       it('should return true if the extension is a supported one plus a supported compressed extensions', function() {
         const nonCompressedExtension = _.first(SupportedFormatsModel.getNonCompressedExtensions());
         const compressedExtension = _.first(SupportedFormatsModel.getCompressedExtensions());


### PR DESCRIPTION
Currently, we detect the extensions of an image path by finding the
first dot, and splitting everything afterwards, however this will fail
with image paths containing dots, like `foo.1.2.3-bar.iso.gz`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>