### PR TITLE
Upgrade etcher-image-write to v5.0.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
+  - npm install -g npm
   - npm install --build-from-source
   - npm install -g bower
   - bower install

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "drivelist": "^3.1.2",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^2.0.0",
-    "etcher-image-write": "^5.0.0",
+    "etcher-image-write": "^5.0.1",
     "flexboxgrid": "^6.3.0",
     "is-elevated": "^1.0.0",
     "lodash": "^4.5.1",


### PR DESCRIPTION
The new version contains an important fix to prevent `EPERM` errors on
Windows with certain drives.

Fixes: https://github.com/resin-io/etcher/issues/334
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>