### PR TITLE
Apply checksum label padding as a custom modifier

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -5974,8 +5974,11 @@ html {
  * limitations under the License.
  */
 .label {
+  font-size: 9px;
+  font-weight: normal; }
+
+.label-big {
   font-size: 11px;
-  font-weight: normal;
   padding: 8px 25px; }
 
 .label-default {

--- a/lib/gui/pages/finish/templates/success.tpl.html
+++ b/lib/gui/pages/finish/templates/success.tpl.html
@@ -28,7 +28,7 @@
         </div>
       </div>
 
-      <span class="label label-default">CRC32 CHECKSUM : <b class="monospace">{{ ::finish.params.checksum }}</b></span>
+      <span class="label label-big label-default">CRC32 CHECKSUM : <b class="monospace">{{ ::finish.params.checksum }}</b></span>
     </div>
   </div>
 </div>

--- a/lib/gui/scss/components/_label.scss
+++ b/lib/gui/scss/components/_label.scss
@@ -15,8 +15,12 @@
  */
 
 .label {
-  font-size: 11px;
+  font-size: 9px;
   font-weight: normal;
+}
+
+.label-big {
+  font-size: 11px;
   padding: 8px 25px;
 }
 


### PR DESCRIPTION
We want to re-use the `label` component without big paddings in other
areas of the application, therefore we move the custom padding to a
separate label modifier.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>