### PR TITLE
Show an informative label if a drive is not large enough

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6448,6 +6448,27 @@ button.btn:focus, button.progress-button:focus {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.component-drive-selector-body .list-group-item-header {
+  margin-bottom: 8px; }
+
+.component-drive-selector-body .list-group-item[disabled] .list-group-item-heading {
+  color: #aaaaaa; }
+
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 .page-settings .checkbox input[type="checkbox"]:not(:checked) + * {
   color: #ddd; }
 

--- a/lib/gui/components/drive-selector/styles/_drive-selector.scss
+++ b/lib/gui/components/drive-selector/styles/_drive-selector.scss
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.component-drive-selector-body .list-group-item-header {
+  margin-bottom: 8px;
+}
+
+.component-drive-selector-body .list-group-item[disabled] .list-group-item-heading {
+  color: darken($gray-light, 20%);
+}

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -3,12 +3,18 @@
   <button class="close" ng-click="modal.closeModal()">&times;</button>
 </div>
 
-<div class="modal-body">
+<div class="component-drive-selector-body modal-body">
   <ul class="list-group">
     <li class="list-group-item" ng-repeat="drive in modal.drives.getDrives()"
       ng-disabled="!modal.state.isDriveLargeEnough(drive)"
       ng-click="modal.state.isDriveLargeEnough(drive) && modal.state.toggleSetDrive(drive)">
         <div>
+          <header class="list-group-item-header">
+            <span class="label label-danger"
+              ng-hide="modal.state.isDriveLargeEnough(drive)">
+                <i class="glyphicon glyphicon-resize-small"></i>
+                TOO SMALL FOR IMAGE</span>
+          </header>
           <h4 class="list-group-item-heading">{{ drive.description }} - {{ drive.size | gigabyte | number:1 }} GB</h4>
           <p class="list-group-item-text">{{ drive.name }}</p>
         </div>

--- a/lib/gui/scss/main.scss
+++ b/lib/gui/scss/main.scss
@@ -47,6 +47,7 @@ $alert-padding: 13px;
 @import "../components/update-notifier/styles/update-notifier";
 @import "../components/progress-button/styles/progress-button";
 @import "../components/svg-icon/styles/svg-icon";
+@import "../components/drive-selector/styles/drive-selector";
 @import "../pages/settings/styles/settings";
 @import "../pages/finish/styles/finish";
 


### PR DESCRIPTION
This is a huge improvement over our current approach, which was simply
to cross out the drive without further explanation.

![screenshot 2016-06-11 13 43 51](https://cloud.githubusercontent.com/assets/2192773/15986653/e5c2bb90-2fda-11e6-8e58-688d4e69cb30.png)

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>