### PR TITLE
Fix sporadic race condition in update notifier test suite

### DIFF
--- a/tests/gui/components/update-notifier.spec.js
+++ b/tests/gui/components/update-notifier.spec.js
@@ -73,7 +73,7 @@ describe('Browser: UpdateNotifier', function() {
         describe('given the `lastUpdateNotify` was updated long ago', function() {
 
           beforeEach(function() {
-            SettingsModel.data.lastUpdateNotify = Date.now() + UPDATE_NOTIFIER_SLEEP_TIME + 1;
+            SettingsModel.data.lastUpdateNotify = Date.now() + UPDATE_NOTIFIER_SLEEP_TIME + 1000;
           });
 
           it('should return true', function() {


### PR DESCRIPTION
We rely on a millisecond to determine the state of the update notifier
logic, which can fail at least once per 50 builds or so.

We increase the time difference to account for this little room for
error.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>