### PR TITLE
Remove body display hidden white flash workaround

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -179,16 +179,6 @@ app.controller('AppController', function(
     }
   });
 
-  // We manually add `style="display: none;"` to <body>
-  // and unset it here instead of using ngCloak since
-  // the latter takes effect as soon as the Angular
-  // library was loaded, but doesn't always mean that
-  // the application is ready, causing the application
-  // to be shown in an unitialized state for some milliseconds.
-  // Here in the controller, we are sure things are
-  // completely up and running.
-  document.querySelector('body').style.display = 'initial';
-
   this.selectImage = function(image) {
     if (!SupportedFormatsModel.isSupportedImage(image.path)) {
       AnalyticsService.logEvent('Invalid image', image);

--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -17,7 +17,7 @@
 
     <script src="./app.js"></script>
   </head>
-  <body ng-app="Etcher" style="display: none">
+  <body ng-app="Etcher">
     <header class="section-header">
       <button class="btn btn-link" os-open-external="https://github.com/resin-io/etcher/blob/master/SUPPORT.md">
         <span class="glyphicon glyphicon-question-sign"></span> Need Help?


### PR DESCRIPTION
In older versions of Electron, the application would display a quick
flash of white before running caused by the WebView loading up.

This workaround doesn't seem necessary anymore.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>