### PR TITLE
Prevent an invalid drive from being auto-selected

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -165,6 +165,10 @@ app.controller('AppController', function(
     if (drives.length === 1 && self.selection.hasImage()) {
       const drive = _.first(drives);
 
+      if (!self.selection.isDriveValid(drive)) {
+        return;
+      }
+
       // Do not autoselect the same drive over and over again
       // and fill the logs unnecessary.
       // `angular.equals` is used instead of `_.isEqual` to


### PR DESCRIPTION
Currently we have logic in the drive selector dialog to prevent invalid
drives (too small, locked, etc) from being selected, however we are not
protecting auto-selection from these invalid devices.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>