### PR TITLE
Check for python in build scripts

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -32,6 +32,11 @@ if ! command -v bower 2>/dev/null; then
   exit 1
 fi
 
+if ! command -v python 2>/dev/null; then
+  echo "Dependency missing: python" 1>&2
+  exit 1
+fi
+
 ELECTRON_OSX_SIGN=./node_modules/.bin/electron-osx-sign
 ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
 SIGN_IDENTITY_OSX="Developer ID Application: Rulemotion Ltd (66H43P8FRG)"

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -37,6 +37,11 @@ if ! command -v upx 2>/dev/null; then
   exit 1
 fi
 
+if ! command -v python 2>/dev/null; then
+  echo "Dependency missing: python" 1>&2
+  exit 1
+fi
+
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <arch>" 1>&2
   exit 1

--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -86,6 +86,13 @@ if %ERRORLEVEL% neq 0 (
   exit /b 1
 )
 
+:: Check that asar is installed.
+where python >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Dependency missing: python 1>&2
+  exit /b 1
+)
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Global variables
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
This dependency is not used directly by our build scripts, but its used
by `node-gyp` when building native modules, and its much nicer to show a
warning early on than having to halt the build script in the middle for
missing this dependency (specially on Windows systems).

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>