### PR TITLE
Move update notifier modal style to the component

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6221,12 +6221,6 @@ button.btn:focus, button.progress-button:focus {
 .modal-open {
   padding-right: 0 !important; }
 
-.modal-fat-and-short {
-  width: 400px;
-  margin-top: -10px; }
-  .modal-fat-and-short .modal-content {
-    height: 245px; }
-
 .modal-footer {
   flex-grow: 0;
   border: 0; }
@@ -6306,6 +6300,12 @@ button.btn:focus, button.progress-button:focus {
 .update-notifier-modal-body {
   padding: 30px 35px;
   overflow: hidden; }
+
+.modal-update-notifier {
+  width: 400px;
+  margin-top: -10px; }
+  .modal-update-notifier .modal-content {
+    height: 245px; }
 
 .update-notifier-modal-body__content {
   padding-bottom: 15px;

--- a/lib/gui/components/update-notifier/services/update-notifier.js
+++ b/lib/gui/components/update-notifier/services/update-notifier.js
@@ -83,7 +83,7 @@ module.exports = function($uibModal, UPDATE_NOTIFIER_SLEEP_TIME, ManifestBindSer
       animation: true,
       templateUrl: './components/update-notifier/templates/update-notifier-modal.tpl.html',
       controller: 'UpdateNotifierController as modal',
-      size: 'fat-and-short'
+      size: 'update-notifier'
     }).result;
   };
 

--- a/lib/gui/components/update-notifier/styles/_update-notifier.scss
+++ b/lib/gui/components/update-notifier/styles/_update-notifier.scss
@@ -19,6 +19,18 @@
   overflow: hidden;
 }
 
+.modal-update-notifier {
+  width: 400px;
+
+  // Move it a bit to the top for
+  // aesthetic reasons
+  margin-top: -10px;
+
+  .modal-content {
+    height: 245px;
+  }
+}
+
 .update-notifier-modal-body__content {
   @extend .text-center;
 

--- a/lib/gui/scss/components/_modal.scss
+++ b/lib/gui/scss/components/_modal.scss
@@ -93,18 +93,6 @@
   padding-right: 0 !important;
 }
 
-.modal-fat-and-short {
-  width: 400px;
-
-  // Move it a bit to the top for
-  // aesthetic reasons
-  margin-top: -10px;
-
-  .modal-content {
-    height: 245px;
-  }
-}
-
 .modal-footer {
   flex-grow: 0;
   border: 0;


### PR DESCRIPTION
Currently, the modal style style used in this component was declared in
`components/_modal.scss`, however since this srule is very specific to
the update notifier component, its better declared in
`update-notifier/styles`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>