### PR TITLE
Make sure elevated mount-point evaluates to a single line in GNU/Linux

### DIFF
--- a/scripts/elevate-linux.sh
+++ b/scripts/elevate-linux.sh
@@ -39,7 +39,7 @@ if [ "$EUID" -eq 0 ]; then
 else
 
   # Determine a unique mountpoint based on the current mount point.
-  mountpoint=$(mount | grep $(basename $APPIMAGE) | awk '{ print $3 }')-elevated
+  mountpoint=$(mount | grep $(basename $APPIMAGE) | grep fuse | head -n 1 | awk '{ print $3 }')-elevated
 
   # We remount the AppImage to be able to workaround FUSE a
   # security measure of not allowing root to run binaries


### PR DESCRIPTION
Consider the case where a previously elevated mount was not unmounted
correctly. `mount | grep $(basename $APPIMAGE)` would evaluate to a
multi-line string, and therefore `awk` will perform its work on *each*
line separately, usually returning something like:

```
/tmp/.mountXXXX
/tmp/.mountYYYY-elevated
```

We then pass `$mountpoint` to `mkdir -p`, which evaluates to:

```
mkdir -p /tmp/.mountXXXX
/tmp/.mountYYYY-elevated
```

Therefore `/tmp/.mountXXXX` gets created, and
`/tmp/.mountYYYY-elevated` is ran as an executable, causing all sort of
cryptic errors to come out. This can be even worse, since the third
column of a `mount` line is not always a path, so the errors make even
less sense.

Fixes: https://github.com/resin-io/etcher/issues/482
Fixes: https://github.com/resin-io/etcher/issues/459

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>