### PR TITLE
Open DevTools in "undocked" mode by default

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -73,7 +73,9 @@ electron.app.on('ready', function() {
 
     mainWindow.on('focus', function() {
       electron.globalShortcut.register('CmdOrCtrl+Alt+I', function() {
-        mainWindow.webContents.openDevTools();
+        mainWindow.webContents.openDevTools({
+          mode: 'undocked'
+        });
       });
     });
 


### PR DESCRIPTION
Otherwise, DevTools gets opened inside the Etcher window, causing the
GUI to get completely messed up.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>