### PR TITLE
Resolve AppImage binary path correctly when running it as root

### DIFF
--- a/scripts/elevate-linux.sh
+++ b/scripts/elevate-linux.sh
@@ -35,7 +35,7 @@ error() {
 
 # Check if we're running as root
 if [ "$EUID" -eq 0 ]; then
-  ./$binary
+  $APPDIR/$binary
 else
 
   # Determine a unique mountpoint based on the current mount point.


### PR DESCRIPTION
Currently, when the AppImage was being ran as `root` we would attempt to
run `./usr/bin/etcher`, assuming we were inside the AppDir already and
the relative path would resolve correctly.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>