### PR TITLE
chore: configure commitizen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Etcher
 Etcher is a powerful OS image flasher built with web technologies to ensure flashing an SDCard or USB drive is pleasant and safe experience. It protects you from accidentally writing to your hard-drives, ensures every byte of data was written correctly and much more.
 
 [![dependencies](https://david-dm.org/resin-io/etcher.svg)](https://david-dm.org/resin-io/etcher.svg)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![Build Status](https://travis-ci.org/resin-io/etcher.svg?branch=master)](https://travis-ci.org/resin-io/etcher)
 [![Build status](https://ci.appveyor.com/api/projects/status/e745k1gt39nik0t7/branch/master?svg=true)](https://ci.appveyor.com/project/resin-io/etcher/branch/master)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/resin-io/chat)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -107,6 +107,8 @@ We encourage our contributors to test the application on as many operating syste
 
 ## Sending a pull request
 
+We make use of [commitizen](https://commitizen.github.io/cz-cli/#making-your-repo-commitizen-friendly) to ensure certain commit conventions, since they will be used to auto-generate the CHANGELOG. The project already includes all necessary configuration, so you only have to install the commitizen cli tool (`npm install -g commitizen`) and commit by executing `git cz`, which will drive you through an interactive wizard to make sure your commit is perfectly crafted according to our guidelines.
+
 When sending a pull request, consider the following guidelines:
 
 - Write a concise commit message explaining your changes.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "angular-mocks": "^1.4.7",
+    "cz-conventional-changelog": "^1.1.6",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^1.2.2",
     "electron-osx-sign": "^0.3.0",
@@ -91,5 +92,10 @@
     "jshint": "^2.9.1",
     "jshint-stylish": "^2.0.1",
     "mochainon": "^1.0.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
Etcher will start following Angular's commit guidelines, enforced by a
neat tool called `commitizer`, with the main purpose of being able to
auto-generate the CHANGELOG file.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>