### PR TITLE
docs: document how to update the shrinkwrap file

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -19,6 +19,9 @@ https://github.com/resin-io/etcher/compare/<previous>...<current>
 ```
 
 - Re-take `screenshot.png` so it displays the latest version in the bottom right corner.
+
+- Re-install all dependencies and run `npm shrinkwrap` to update `npm-shrinkwrap.json`.
+
 - Commit the changes with the version number as the commit title, including the `v` prefix, to `master`. For example:
 
 ```sh


### PR DESCRIPTION
We will be generating shrinkwrap files in every release for the
following purposes:

- Be able to run an `npm install` containing the exact package versions
used at the time of publishing.

- Auto-generate dependency updates CHANGELOG entries by comparing
shrinkwrap files between versions.

See: https://docs.npmjs.com/cli/shrinkwrap
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>