### PR TITLE
fix: ensure dialog.showErrorBox() arguments are strings

### DIFF
--- a/lib/gui/os/dialog/services/dialog.js
+++ b/lib/gui/os/dialog/services/dialog.js
@@ -107,7 +107,18 @@ module.exports = function($q, SupportedFormatsModel) {
     });
 
     const message = description || error.stack || JSON.stringify(error) || '';
-    electron.remote.dialog.showErrorBox(title, message);
+
+    // Ensure the parameters are strings to prevent the following
+    // types of obscure errors:
+    //
+    //   Error: Could not call remote function ''.
+    //   Check that the function signature is correct.
+    //   Underlying error:
+    //     Error processing argument at index 0, conversion failure
+    //
+    // This can be thrown if for some reason, either `title` or `message`
+    // are not strings.
+    electron.remote.dialog.showErrorBox(title.toString(), message.toString());
   };
 
 };


### PR DESCRIPTION
If for some reason either the error title or message are not strings,
the user gets a very obscure error that looks something like this:

```
Error: Could not call remote function ''.
Check that the function signature is correct.
Underlying error:
  Error processing argument at index 0, conversion failure
```

What's even worse is that the above error is thrown when we attempt to
display an `Error` object, therefore completely hiding the real error.

In this commit, we make sure both parameters to `showErrorBox()` are
strings, as a safety measure to prevent this from happening again.

See: https://github.com/resin-io/etcher/issues/127
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>