### PR TITLE
style: fix lint warning in exit-codes.js

### DIFF
--- a/lib/src/exit-codes.js
+++ b/lib/src/exit-codes.js
@@ -63,5 +63,4 @@ module.exports = {
    */
   CANCELLED: 3
 
-
 };


### PR DESCRIPTION
The lint complained that there were two consequent empty lines.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>