### PR TITLE
feat: add support for dsk images

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1591,9 +1591,9 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etcher-image-stream": {
-      "version": "2.1.0",
-      "from": "etcher-image-stream@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-2.1.0.tgz"
+      "version": "2.2.0",
+      "from": "etcher-image-stream@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-2.2.0.tgz"
     },
     "etcher-image-write": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chalk": "^1.1.3",
     "drivelist": "^3.2.0",
     "electron-is-running-in-asar": "^1.0.0",
-    "etcher-image-stream": "^2.1.0",
+    "etcher-image-stream": "^2.2.0",
     "etcher-image-write": "^5.0.1",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",

--- a/tests/gui/models/supported-formats.spec.js
+++ b/tests/gui/models/supported-formats.spec.js
@@ -32,7 +32,7 @@ describe('Browser: SupportedFormats', function() {
 
       it('should return the supported non compressed extensions', function() {
         const extensions = SupportedFormatsModel.getNonCompressedExtensions();
-        m.chai.expect(extensions).to.deep.equal([ 'img', 'iso' ]);
+        m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'dsk' ]);
       });
 
     });


### PR DESCRIPTION
This type of images are distributed by the Ostro Project.

Closes: https://github.com/resin-io/etcher/issues/491
See: https://github.com/resin-io-modules/etcher-image-stream/pull/10
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>