### PR TITLE
fix: throw if attempting to select a locked drive

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -96,6 +96,10 @@ module.exports = redux.createStore(function(state, action) {
         throw new Error(`Invalid drive protected state: ${action.data.protected}`);
       }
 
+      if (action.data.protected) {
+        throw new Error('The drive is write-protected');
+      }
+
       // TODO: Reuse from SelectionStateModel.isDriveLargeEnough()
       if (state.getIn([ 'selection', 'image', 'size' ], 0) > action.data.size) {
         throw new Error('The drive is not large enough');

--- a/tests/gui/models/selection-state.spec.js
+++ b/tests/gui/models/selection-state.spec.js
@@ -199,6 +199,17 @@ describe('Browser: SelectionState', function() {
           });
         });
 
+        it('should throw if drive is write protected', function() {
+          m.chai.expect(function() {
+            SelectionStateModel.setDrive({
+              device: '/dev/disk1',
+              name: 'USB Drive',
+              size: 999999999,
+              protected: true
+            });
+          }).to.throw('The drive is write-protected');
+        });
+
         it('should throw if no device', function() {
           m.chai.expect(function() {
             SelectionStateModel.setDrive({


### PR DESCRIPTION
We shouldn't allow a write-protected drive from being selected, since
users will get confusing `EPERM` errors later on.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>