### PR TITLE
fix: deselect drive if its not available anymore

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -162,11 +162,6 @@ app.controller('AppController', function(
   DriveScannerService.on('drives', function(drives) {
     self.drives.setDrives(drives);
 
-    // Cover the case where you select a drive, but then eject it.
-    if (self.selection.hasDrive() && !_.find(drives, self.selection.isCurrentDrive)) {
-      self.selection.removeDrive();
-    }
-
     if (_.isEmpty(drives)) {
       DriveSelectorService.close();
     }

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -52,7 +52,16 @@ module.exports = redux.createStore(function(state, action) {
         throw new Error(`Invalid drives: ${action.data}`);
       }
 
-      return state.set('availableDrives', Immutable.fromJS(action.data));
+      const newState = state.set('availableDrives', Immutable.fromJS(action.data));
+      const selectedDevice = state.getIn([ 'selection', 'drive', 'device' ]);
+
+      if (selectedDevice && !_.find(action.data, {
+        device: selectedDevice
+      })) {
+        return newState.deleteIn([ 'selection', 'drive' ]);
+      }
+
+      return newState;
     }
 
     case 'SET_FLASH_STATE': {

--- a/tests/gui/models/drives.spec.js
+++ b/tests/gui/models/drives.spec.js
@@ -7,15 +7,18 @@ require('angular-mocks');
 describe('Browser: DrivesModel', function() {
 
   beforeEach(angular.mock.module(
-    require('../../../lib/gui/models/drives')
+    require('../../../lib/gui/models/drives'),
+    require('../../../lib/gui/models/selection-state')
   ));
 
   describe('DrivesModel', function() {
 
     let DrivesModel;
+    let SelectionStateModel;
 
-    beforeEach(angular.mock.inject(function(_DrivesModel_) {
+    beforeEach(angular.mock.inject(function(_DrivesModel_, _SelectionStateModel_) {
       DrivesModel = _DrivesModel_;
+      SelectionStateModel = _SelectionStateModel_;
     }));
 
     it('should have no drives by default', function() {
@@ -85,21 +88,57 @@ describe('Browser: DrivesModel', function() {
         this.drives = [
           {
             device: '/dev/sdb',
-            description: 'Foo',
-            size: '14G',
+            name: 'SD Card',
+            size: 9999999,
             mountpoint: '/mnt/foo',
-            system: false
+            system: false,
+            protected: false
           },
           {
             device: '/dev/sdc',
-            description: 'Bar',
-            size: '14G',
+            name: 'USB Drive',
+            size: 9999999,
             mountpoint: '/mnt/bar',
-            system: false
+            system: false,
+            protected: false
           }
         ];
 
         DrivesModel.setDrives(this.drives);
+      });
+
+      describe('given one of the drives was selected', function() {
+
+        beforeEach(function() {
+          SelectionStateModel.setDrive({
+            device: '/dev/sdc',
+            name: 'USB Drive',
+            size: 9999999,
+            mountpoint: '/mnt/bar',
+            system: false,
+            protected: false
+          });
+        });
+
+        afterEach(function() {
+          SelectionStateModel.removeDrive();
+        });
+
+        it('should be delected if its not contain in the available drives anymore', function() {
+          m.chai.expect(SelectionStateModel.hasDrive()).to.be.true;
+          DrivesModel.setDrives([
+            {
+              device: '/dev/sdb',
+              name: 'SD Card',
+              size: 9999999,
+              mountpoint: '/mnt/foo',
+              system: false,
+              protected: false
+            }
+          ]);
+          m.chai.expect(SelectionStateModel.hasDrive()).to.be.false;
+        });
+
       });
 
       describe('.hasAvailableDrives()', function() {


### PR DESCRIPTION
If the user has a selected drive, but a new scan shows that such drive
is no longer available, then the selected drive should be de-selected.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>