### PR TITLE
refactor: apply REMOVE_DRIVE recursively in SET_AVAILABLE_DRIVES

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -38,7 +38,7 @@ const DEFAULT_STATE = Immutable.fromJS({
   }
 });
 
-module.exports = redux.createStore(function(state, action) {
+const store = function(state, action) {
   state = state || DEFAULT_STATE;
 
   switch (action.type) {
@@ -58,7 +58,9 @@ module.exports = redux.createStore(function(state, action) {
       if (selectedDevice && !_.find(action.data, {
         device: selectedDevice
       })) {
-        return newState.deleteIn([ 'selection', 'drive' ]);
+        return store(newState, {
+          type: 'REMOVE_DRIVE'
+        });
       }
 
       return newState;
@@ -150,4 +152,6 @@ module.exports = redux.createStore(function(state, action) {
     }
 
   }
-});
+};
+
+module.exports = redux.createStore(store);


### PR DESCRIPTION
We were duplicating the remove drive logic in the `SET_AVAILABLE_DRIVES`
case when the currently selected drive didn't exist anymore.

A better way to handle this without coding repetition is to recursively
apply the reduced with the new state.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>