### PR TITLE
fix: check for updates only once at startup

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -66,8 +66,27 @@ const app = angular.module('Etcher', [
   require('./utils/byte-size/byte-size')
 ]);
 
-app.run(function(AnalyticsService) {
+app.run(function(AnalyticsService, UpdateNotifierService, SelectionStateModel) {
   AnalyticsService.logEvent('Application start');
+
+  if (UpdateNotifierService.shouldCheckForUpdates()) {
+    AnalyticsService.logEvent('Checking for updates');
+
+    UpdateNotifierService.isLatestVersion().then(function(isLatestVersion) {
+
+      // In case the internet connection is not good and checking the
+      // latest published version takes too long, only show notify
+      // the user about the new version if he didn't start the flash
+      // process (e.g: selected an image), otherwise such interruption
+      // might be annoying.
+      if (!isLatestVersion && !SelectionStateModel.hasImage()) {
+
+        AnalyticsService.logEvent('Notifying update');
+        UpdateNotifierService.notify();
+      }
+    });
+  }
+
 });
 
 app.config(function($stateProvider, $urlRouterProvider) {
@@ -115,24 +134,6 @@ app.controller('AppController', function(
     // and its reported by TrackJS.
     throw error;
   };
-
-  if (UpdateNotifierService.shouldCheckForUpdates()) {
-    AnalyticsService.logEvent('Checking for updates');
-
-    UpdateNotifierService.isLatestVersion().then(function(isLatestVersion) {
-
-      // In case the internet connection is not good and checking the
-      // latest published version takes too long, only show notify
-      // the user about the new version if he didn't start the flash
-      // process (e.g: selected an image), otherwise such interruption
-      // might be annoying.
-      if (!isLatestVersion && !SelectionStateModel.hasImage()) {
-
-        AnalyticsService.logEvent('Notifying update');
-        UpdateNotifierService.notify();
-      }
-    });
-  }
 
   // This catches the case where the user enters
   // the settings screen when a flash finished


### PR DESCRIPTION
Currently, the update check runs every single time the main application
controller is instantiated, meaning that the update check would run
again when you visit the settings screen and go back to the main page,
or return to the main page after finishing a flash.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>