### PR TITLE
fix: don't allow to set the flashing state if not flashing

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -86,6 +86,10 @@ const store = function(state, action) {
     }
 
     case 'SET_FLASH_STATE': {
+      if (!state.getIn([ 'flash', 'flashing' ])) {
+        throw new Error('Can\'t set the flashing state when not flashing');
+      }
+
       return state.setIn([ 'flash', 'state' ], Immutable.fromJS(action.data));
     }
 

--- a/tests/gui/modules/image-writer.spec.js
+++ b/tests/gui/modules/image-writer.spec.js
@@ -67,6 +67,22 @@ describe('Browser: ImageWriter', function() {
 
     });
 
+    describe('.setProgressState()', function() {
+
+      it('should not allow setting the state if flashing is false', function() {
+        ImageWriterService.setFlashing(false);
+        m.chai.expect(function() {
+          ImageWriterService.setProgressState({
+            type: 'write',
+            percentage: 50,
+            eta: 15,
+            speed: 100000000000
+          });
+        }).to.throw('Can\'t set the flashing state when not flashing');
+      });
+
+    });
+
     describe('.setFlashing()', function() {
 
       it('should be able to set flashing to true', function() {


### PR DESCRIPTION
Currently, we allow updating the flashing state independently on the
value of the `flashing` property.

In order to maintain the application state coherent, we deny updating
the flashing state if we're not currently flashing, which lets us safely
assume that the state will be in a reset state if we're not flashing.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>