### PR TITLE
refactor: flatten "flash" data structure property

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -29,12 +29,10 @@ const redux = require('redux');
 const DEFAULT_STATE = Immutable.fromJS({
   availableDrives: [],
   selection: {},
-  flash: {
-    flashing: false,
-    state: {
-      progress: 0,
-      speed: 0
-    }
+  isFlashing: false,
+  flashState: {
+    progress: 0,
+    speed: 0
   }
 });
 
@@ -47,7 +45,8 @@ const ACTIONS = _.fromPairs(_.map([
   'SET_AVAILABLE_DRIVES',
   'SET_FLASH_STATE',
   'RESET_FLASH_STATE',
-  'SET_FLASHING',
+  'SET_FLASHING_FLAG',
+  'UNSET_FLASHING_FLAG',
   'SELECT_DRIVE',
   'SELECT_IMAGE',
   'REMOVE_DRIVE',
@@ -104,28 +103,25 @@ const storeReducer = function(state, action) {
     }
 
     case ACTIONS.SET_FLASH_STATE: {
-      if (!state.getIn([ 'flash', 'flashing' ])) {
+      if (!state.get('isFlashing')) {
         throw new Error('Can\'t set the flashing state when not flashing');
       }
 
-      return state.setIn([ 'flash', 'state' ], Immutable.fromJS(action.data));
+      return state.set('flashState', Immutable.fromJS(action.data));
     }
 
     case ACTIONS.RESET_FLASH_STATE: {
-      return state.setIn([ 'flash', 'state' ], DEFAULT_STATE.getIn([ 'flash', 'state' ]));
+      return state.set('flashState', DEFAULT_STATE.get('flashState'));
     }
 
-    case ACTIONS.SET_FLASHING: {
-      const value = Boolean(action.data);
-      const newState = state.setIn([ 'flash', 'flashing' ], value);
+    case ACTIONS.SET_FLASHING_FLAG: {
+      return state.set('isFlashing', true);
+    }
 
-      if (!value) {
-        return storeReducer(newState, {
-          type: ACTIONS.RESET_FLASH_STATE
-        });
-      }
-
-      return newState;
+    case ACTIONS.UNSET_FLASHING_FLAG: {
+      return storeReducer(state.set('isFlashing', false), {
+        type: ACTIONS.RESET_FLASH_STATE
+      });
     }
 
     case ACTIONS.SELECT_DRIVE: {

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -61,7 +61,7 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel, 
 
     // Safely bring the state to the world of Angular
     $timeout(function() {
-      self.state = Store.getState().toJS().flash.state;
+      self.state = Store.getState().toJS().flashState;
     });
 
   });
@@ -79,7 +79,7 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel, 
    * }
    */
   this.isFlashing = function() {
-    return Store.getState().toJS().flash.flashing;
+    return Store.getState().toJS().isFlashing;
   };
 
   /**
@@ -96,10 +96,15 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel, 
    * ImageWriterService.setFlashing(true);
    */
   this.setFlashing = function(status) {
-    Store.dispatch({
-      type: Store.Actions.SET_FLASHING,
-      data: status
-    });
+    if (Boolean(status)) {
+      Store.dispatch({
+        type: Store.Actions.SET_FLASHING_FLAG
+      });
+    } else {
+      Store.dispatch({
+        type: Store.Actions.UNSET_FLASHING_FLAG
+      });
+    }
   };
 
   /**


### PR DESCRIPTION
Currently, the "flash" property of the application state containing both
the actual flashing state, and the flashing flag.

To simplify things, the following changes have been introduced:

- Move `flash.flashing` to `isFlashing`.
- Move `flash.state` to `flashState`.
- Rename `SET_FLASHING` to `SET_FLASHING_FLAG`.
- Extract `UNSET_FLASHING_FLAG` from `SET_FLASHING_FLAG`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>