### PR TITLE
refactor: improve analytics and image-writer module names

### DIFF
--- a/lib/gui/modules/analytics.js
+++ b/lib/gui/modules/analytics.js
@@ -17,7 +17,7 @@
 'use strict';
 
 /**
- * @module Etcher.analytics
+ * @module Etcher.Modules.Analytics
  */
 
 const _ = require('lodash');
@@ -32,7 +32,7 @@ window.MIXPANEL_CUSTOM_LIB_URL = '../../bower_components/mixpanel/mixpanel.js';
 
 require('../../../bower_components/mixpanel/mixpanel-jslib-snippet.js');
 require('../../../bower_components/angular-mixpanel/src/angular-mixpanel');
-const MODULE_NAME = 'Etcher.analytics';
+const MODULE_NAME = 'Etcher.Modules.Analytics';
 const analytics = angular.module(MODULE_NAME, [
   'analytics.mixpanel',
   require('../models/settings')

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -17,14 +17,14 @@
 'use strict';
 
 /**
- * @module Etcher.image-writer
+ * @module Etcher.Modules.ImageWriter
  */
 
 const angular = require('angular');
 const Store = require('../models/store');
 const childWriter = require('../../src/child-writer');
 
-const MODULE_NAME = 'Etcher.image-writer';
+const MODULE_NAME = 'Etcher.Modules.ImageWriter';
 const imageWriter = angular.module(MODULE_NAME, [
   require('../models/settings'),
   require('../utils/notifier/notifier')


### PR DESCRIPTION
- From `Etcher.analytics` to `Etcher.Modules.Analytics`.
- From `Etcher.image-writer` to `Etcher.Modules.ImageWriter`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>