### PR TITLE
refactor: rename progress property to percentage

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -106,11 +106,11 @@ app.run((AnalyticsService, OSWindowProgressService, ImageWriterService) => {
 
     AnalyticsService.log([
       `Progress (${state.flashState.type}):`,
-      `${state.flashState.progress}% at ${state.flashState.speed} MB/s`,
+      `${state.flashState.percentage}% at ${state.flashState.speed} MB/s`,
       `(eta ${state.flashState.eta}s)`
     ].join(' '));
 
-    OSWindowProgressService.set(state.flashState.progress);
+    OSWindowProgressService.set(state.flashState.percentage);
   });
 });
 

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -31,7 +31,7 @@ const DEFAULT_STATE = Immutable.fromJS({
   selection: {},
   isFlashing: false,
   flashState: {
-    progress: 0,
+    percentage: 0,
     speed: 0
   }
 });
@@ -115,12 +115,12 @@ const storeReducer = (state, action) => {
         throw new Error(`Invalid state type: ${action.data.type}`);
       }
 
-      if (!action.data.progress) {
-        throw new Error('Missing state progress');
+      if (!action.data.percentage) {
+        throw new Error('Missing state percentage');
       }
 
-      if (!_.isNumber(action.data.progress)) {
-        throw new Error(`Invalid state progress: ${action.data.progress}`);
+      if (!_.isNumber(action.data.percentage)) {
+        throw new Error(`Invalid state percentage: ${action.data.percentage}`);
       }
 
       if (!action.data.eta) {

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -51,7 +51,7 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel) 
    * @public
    */
   this.state = {
-    progress: 0,
+    percentage: 0,
     speed: 0
   };
 
@@ -128,7 +128,7 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel) 
       type: Store.Actions.SET_FLASH_STATE,
       data: {
         type: state.type,
-        progress: state.percentage,
+        percentage: state.percentage,
         eta: state.eta,
 
         // Transform bytes to megabytes preserving only two decimal places

--- a/lib/gui/partials/main.html
+++ b/lib/gui/partials/main.html
@@ -81,19 +81,19 @@
 
       <div class="space-vertical-large">
         <progress-button class="btn-brick"
-          percentage="app.writer.state.progress"
+          percentage="app.writer.state.percentage"
           striped="{{ app.writer.state.type == 'check' }}"
           ng-attr-active="{{ app.writer.isFlashing() }}"
           ng-show="app.success"
           ng-click="app.flash(app.selection.getImagePath(), app.selection.getDrive())"
           ng-disabled="!app.selection.hasImage() || !app.selection.hasDrive()">
-            <span ng-show="app.writer.state.progress == 100 && app.writer.isFlashing()">Finishing...</span>
-            <span ng-show="app.writer.state.progress == 0 && !app.writer.isFlashing()">Flash!</span>
-            <span ng-show="app.writer.state.progress == 0 && app.writer.isFlashing() && !app.writer.state.speed">Starting...</span>
-            <span ng-show="app.writer.state.speed && app.writer.state.progress != 100 && app.writer.state.type != 'check'"
-              ng-bind="app.writer.state.progress + '% '"></span>
-            <span ng-show="app.writer.state.speed && app.writer.state.progress != 100 && app.writer.state.type == 'check'"
-              ng-bind="app.writer.state.progress + '% Validating...'"></span>
+            <span ng-show="app.writer.state.percentage == 100 && app.writer.isFlashing()">Finishing...</span>
+            <span ng-show="app.writer.state.percentage == 0 && !app.writer.isFlashing()">Flash!</span>
+            <span ng-show="app.writer.state.percentage == 0 && app.writer.isFlashing() && !app.writer.state.speed">Starting...</span>
+            <span ng-show="app.writer.state.speed && app.writer.state.percentage != 100 && app.writer.state.type != 'check'"
+              ng-bind="app.writer.state.percentage + '% '"></span>
+            <span ng-show="app.writer.state.speed && app.writer.state.percentage != 100 && app.writer.state.type == 'check'"
+              ng-bind="app.writer.state.percentage + '% Validating...'"></span>
         </progress-button>
 
         <div class="alert-ribbon alert-warning" ng-class="{ 'alert-ribbon--open': !app.success }">
@@ -110,7 +110,7 @@
           <span class="glyphicon glyphicon-repeat"></span> Retry
         </button>
 
-        <p class="step-footer step-footer-split" ng-show="app.writer.state.speed && app.writer.state.progress != 100">
+        <p class="step-footer step-footer-split" ng-show="app.writer.state.speed && app.writer.state.percentage != 100">
 
           <!-- Convert our eta (in seconds) to milliseconds, which is what `moment` understands -->
           <span>ETA: {{ app.writer.state.eta * 1000 | amDateFormat:'m[m]ss[s]' }}</span>

--- a/tests/gui/modules/image-writer.spec.js
+++ b/tests/gui/modules/image-writer.spec.js
@@ -28,7 +28,7 @@ describe('Browser: ImageWriter', function() {
 
       it('should be reset by default', function() {
         m.chai.expect(ImageWriterService.state).to.deep.equal({
-          progress: 0,
+          percentage: 0,
           speed: 0
         });
       });
@@ -39,7 +39,7 @@ describe('Browser: ImageWriter', function() {
 
       it('should be able to reset the state', function() {
         ImageWriterService.state = {
-          progress: 50,
+          percentage: 50,
           speed: 3
         };
 
@@ -47,7 +47,7 @@ describe('Browser: ImageWriter', function() {
         $timeout.flush();
 
         m.chai.expect(ImageWriterService.state).to.deep.equal({
-          progress: 0,
+          percentage: 0,
           speed: 0
         });
       });
@@ -104,7 +104,7 @@ describe('Browser: ImageWriter', function() {
         }).to.throw('Invalid state type: 1234');
       });
 
-      it('should throw if progress is missing', function() {
+      it('should throw if percentage is missing', function() {
         ImageWriterService.setFlashing(true);
         m.chai.expect(function() {
           ImageWriterService.setProgressState({
@@ -112,10 +112,10 @@ describe('Browser: ImageWriter', function() {
             eta: 15,
             speed: 100000000000
           });
-        }).to.throw('Missing state progress');
+        }).to.throw('Missing state percentage');
       });
 
-      it('should throw if progress is not a number', function() {
+      it('should throw if percentage is not a number', function() {
         ImageWriterService.setFlashing(true);
         m.chai.expect(function() {
           ImageWriterService.setProgressState({
@@ -124,7 +124,7 @@ describe('Browser: ImageWriter', function() {
             eta: 15,
             speed: 100000000000
           });
-        }).to.throw('Invalid state progress: 50');
+        }).to.throw('Invalid state percentage: 50');
       });
 
       it('should throw if eta is missing', function() {
@@ -196,7 +196,7 @@ describe('Browser: ImageWriter', function() {
         $timeout.flush();
 
         m.chai.expect(ImageWriterService.state).to.not.deep.equal({
-          progress: 0,
+          percentage: 0,
           speed: 0
         });
 
@@ -205,7 +205,7 @@ describe('Browser: ImageWriter', function() {
         $timeout.flush();
 
         m.chai.expect(ImageWriterService.state).to.deep.equal({
-          progress: 0,
+          percentage: 0,
           speed: 0
         });
       });


### PR DESCRIPTION
So the property is consistent from what we get from `etcher-image-write`
and we don't have to unnecessarily rename ourselves to pass it to the
model.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>