### PR TITLE
fix: don't throw missing eta if eta is zero

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -123,7 +123,7 @@ const storeReducer = (state, action) => {
         throw new Error(`Invalid state progress: ${action.data.progress}`);
       }
 
-      if (!action.data.eta) {
+      if (!action.data.eta && action.data.eta !== 0) {
         throw new Error('Missing state eta');
       }
 

--- a/tests/gui/modules/image-writer.spec.js
+++ b/tests/gui/modules/image-writer.spec.js
@@ -138,6 +138,18 @@ describe('Browser: ImageWriter', function() {
         }).to.throw('Missing state eta');
       });
 
+      it('should not throw if eta is equal to zero', function() {
+        ImageWriterService.setFlashing(true);
+        m.chai.expect(function() {
+          ImageWriterService.setProgressState({
+            type: 'write',
+            percentage: 50,
+            eta: 0,
+            speed: 100000000000
+          });
+        }).to.not.throw('Missing state eta');
+      });
+
       it('should throw if eta is not a number', function() {
         ImageWriterService.setFlashing(true);
         m.chai.expect(function() {


### PR DESCRIPTION
The commit 0f8136f, which enforced validation for the state object,
introduced a subtle bug where `Missing state eta` would be thrown if
`eta === 0`, since `!0` evaluates to `true`.

This would cause the flashing to stop right at the end (when eta is
zero).

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>