### PR TITLE
fix(progressButton): spiky diagonal lines

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6376,7 +6376,7 @@ button.btn:focus, button.progress-button:focus {
   background: #6ca1e0; }
 
 .progress-button--primary.progress-button--striped {
-  background-image: -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.25, #3b679b), color-stop(0.25, #5c93d6), color-stop(0.5, #5c93d6), color-stop(0.5, #3b679b), color-stop(0.75, #3b679b), color-stop(0.75, #5c93d6), to(#5c93d6)); }
+  background-image: -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.25, #3b679b), color-stop(0.26, #5c93d6), color-stop(0.5, #5c93d6), color-stop(0.51, #3b679b), color-stop(0.75, #3b679b), color-stop(0.76, #5c93d6), to(#5c93d6)); }
 
 .progress-button--primary[active="true"]:active {
   box-shadow: none;

--- a/lib/gui/components/progress-button/styles/_progress-button.scss
+++ b/lib/gui/components/progress-button/styles/_progress-button.scss
@@ -62,14 +62,20 @@ $progress-button-stripes-animation-duration: 1s;
   $progress-button-stripes-color: desaturate(darken($brand-primary, 18%), 20%);
 
   &.progress-button--striped {
+
+    // Notice that we add `0.01` to certain gradient stop positions.
+    // That workarounds a Chrome rendering issue where diagonal
+    // lines look spiky.
+    // See https://github.com/resin-io/etcher/issues/472
     background-image: -webkit-gradient(linear, 0 0, 100% 100%,
       color-stop(0.25, $progress-button-stripes-color),
-      color-stop(0.25, $progress-button-stripes-background-color),
+      color-stop(0.25 + 0.01, $progress-button-stripes-background-color),
       color-stop(0.50, $progress-button-stripes-background-color),
-      color-stop(0.50, $progress-button-stripes-color),
+      color-stop(0.50 + 0.01, $progress-button-stripes-color),
       color-stop(0.75, $progress-button-stripes-color),
-      color-stop(0.75, $progress-button-stripes-background-color),
+      color-stop(0.75 + 0.01, $progress-button-stripes-background-color),
       to($progress-button-stripes-background-color));
+
   }
 }
 


### PR DESCRIPTION
The progress button exhibits spiky diagonals when used it with the
"striped" modifier. This can be seen better when drastically reducing the animation
speed.

Turns out its a Webkit rendering bug. I've stumbled into dozens of
"workarounds" on the internet (mainly Stack Overflow), however none of
them fixed the issue.

After some crazy amount of experimentation, the issue is gone if we add
1% to certain stop positions. Weird stuff.

![screenshot 2016-06-27 13 22 37](https://cloud.githubusercontent.com/assets/2192773/16389462/16911de6-3c6c-11e6-963b-262e33a0c740.png)

Fixes: https://github.com/resin-io/etcher/issues/472
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>