### PR TITLE
fix: prevent user from zooming in the whole application

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -74,6 +74,16 @@ electron.app.on('ready', () => {
     electron.globalShortcut.unregisterAll();
   });
 
+  // Prevent the user from being allowed to zoom-in the application.
+  //
+  // This function should be called on the renderer process. We use
+  // `executeJavaScript()` rather than moving this to a file in the
+  // renderer process for convenience, since we have all other
+  // electron desktop experience fixes in this file.
+  //
+  // See https://github.com/electron/electron/issues/3609
+  mainWindow.webContents.executeJavaScript('require(\'electron\').webFrame.setZoomLevelLimits(1, 1);');
+
   // Prevent external resources from being loaded (like images)
   // when dropping them on the WebView.
   // See https://github.com/electron/electron/issues/5919


### PR DESCRIPTION
Turns out the user can zoom-in the whole application, which we didn't
notice before.

![screenshot 2016-06-27 13 42 09](https://cloud.githubusercontent.com/assets/2192773/16389898/1dc34b3c-3c6e-11e6-9736-41fae6e4b591.png)

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>