### PR TITLE
chore: add a GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,54 @@
+- **What Etcher version are you running?**
+
+*(You can check this at runtime in the bottom right corner of the application. If you're running Etcher locally, please let us know in which commit or branch you're in.)*
+
+
+- **What operating system and architecture are you running Etcher in?**
+
+*(For example: Windows 10 x64, OS X 10.11.4 x64, Ubuntu 14.04 x86.)*
+
+
+- **What is the behaviour you're experiencing? How can we reproduce it?**
+
+
+- **Do you have any input on how this can be fixed/improved?**
+
+
+- **Was this happening on a previous version?**
+
+
+- **Do you see any meaningful error information on DevTools?**
+
+*(You can open DevTools by pressing `Ctrl+Alt+I`, or `Cmd+Alt+I` if you're running OS X.)*
+
+
+
+***
+
+**If you're having an error when flashing an image to a drive: **
+
+*(Feel free to delete this whole section if it doesn't apply.)*
+
+- **Can you reproduce the issue with a different image or drive?**
+
+
+- **Can you share a link to the exact image you're trying to flash, so we can test it ourselves?**
+
+
+- **At which point of the flashing does the error happens? (right at the beginning, randomly, etc)**
+
+
+- **What was the format of the drive _before_ attempting to flash to it?**
+
+
+***
+
+**If Etcher is failing to detect your drive: **
+
+*(Feel free to delete this whole section if it doesn't apply.)*
+
+- **Can you post the output of the script that applies to your operating system from the following list?:**
+
+  - [OS X](https://raw.githubusercontent.com/resin-io-modules/drivelist/master/scripts/darwin.sh)
+  - [GNU/Linux](https://raw.githubusercontent.com/resin-io-modules/drivelist/master/scripts/linux.sh)
+  - [Windows](https://raw.githubusercontent.com/resin-io-modules/drivelist/master/scripts/win32.bat)


### PR DESCRIPTION
An issue template would help us ensure we get all the information we
need at the time of submission, so we don't have to go back and forth
with the user to answer the same questions every time, wasting the
user's time.

See: https://github.com/blog/2111-issue-and-pull-request-templates
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>