### PR TITLE
fix(Windows): upgrade etcher-image-stream to v5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "drivelist": "^3.2.0",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^2.2.0",
-    "etcher-image-write": "^5.0.1",
+    "etcher-image-write": "^5.0.2",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",
     "immutable": "^3.8.1",


### PR DESCRIPTION
This version contains a fix to an `EPERM` issue ocurring on Windows.

See: https://github.com/resin-io-modules/etcher-image-write/pull/45
Fixes: https://github.com/resin-io/etcher/issues/531
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>