### PR TITLE
fix(GUI): uncaught exception in update notifier

### DIFF
--- a/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
+++ b/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
@@ -13,7 +13,9 @@
 
   <div class="checkbox text-right">
     <label>
-      <input type="checkbox" ng-model="modal.settings.get('sleepUpdateCheck')">
+      <input type="checkbox"
+        ng-model="modal.sleepUpdateCheck"
+        ng-change="modal.settings.set('sleepUpdateCheck', modal.sleepUpdateCheck)">
       <span>Remind me again in 7 days</span>
     </label>
   </div>


### PR DESCRIPTION
Since the addition of Redux and ImmutableJS data structures, we store
the application settings in the Redux store.

This means that checkboxes on templates can no longer bind to the
setting properties directly.

This was fixed in the setting page, but we missed one of them in the
update notifier model.

```html
ng-model="modal.settings.get('sleepUpdateCheck')"
```

Won't lead any meaningful return, and in fact, throws an uncaught
exception.

Changelog-Entry: Fix uncaught exception when showing the update notifier modal.
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>