### PR TITLE
fix(GUI): incorrect ETA on certain timezones

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -30,6 +30,7 @@ const app = angular.module('Etcher', [
   require('angular-moment'),
   require('angular-middle-ellipses'),
   require('angular-if-state'),
+  require('angular-seconds-to-date'),
 
   // Etcher modules
   require('./modules/drive-scanner'),

--- a/lib/gui/partials/main.html
+++ b/lib/gui/partials/main.html
@@ -111,10 +111,7 @@
         </button>
 
         <p class="step-footer step-footer-split" ng-show="app.writer.state.speed && app.writer.state.percentage != 100">
-
-          <!-- Convert our eta (in seconds) to milliseconds, which is what `moment` understands -->
-          <span>ETA: {{ app.writer.state.eta * 1000 | amDateFormat:'m[m]ss[s]' }}</span>
-
+          <span>ETA: {{ app.writer.state.eta | secondsToDate | amDateFormat:'m[m]ss[s]' }}</span>
           <span ng-bind="app.writer.state.speed.toFixed(2) + ' MB/s'"></span>
         </p>
       </div>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -59,6 +59,11 @@
       "from": "angular-moment@>=1.0.0-beta.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.0.0-beta.6.tgz"
     },
+    "angular-seconds-to-date": {
+      "version": "1.0.0",
+      "from": "angular-seconds-to-date@latest",
+      "resolved": "https://registry.npmjs.org/angular-seconds-to-date/-/angular-seconds-to-date-1.0.0.tgz"
+    },
     "angular-ui-bootstrap": {
       "version": "1.3.3",
       "from": "angular-ui-bootstrap@>=1.3.2 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "angular-if-state": "^1.0.0",
     "angular-middle-ellipses": "^1.0.0",
     "angular-moment": "^1.0.0-beta.6",
+    "angular-seconds-to-date": "^1.0.0",
     "angular-ui-bootstrap": "^1.3.2",
     "angular-ui-router": "^0.2.18",
     "bluebird": "^3.0.5",


### PR DESCRIPTION
In certain timezones, like India's, the ETA would display very weird
numbers. The problem was that we passed a number of milliseconds to
MomentJS, which created a Date object based on it taking timezones into
consideration.

As a solution, we convert the seconds to a Date object containing the
lowest possible date values, and set its seconds to the ETA, since this
effectively represents just the number of seconds we're interested in.

Changelog-Entry: Fix incorrect ETA numbers in certain timezones.
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>