### PR TITLE
fix(GUI): don't throw if state speed is 0

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -149,7 +149,7 @@ const storeReducer = (state, action) => {
         throw new Error(`Invalid state eta: ${action.data.eta}`);
       }
 
-      if (!action.data.speed) {
+      if (_.isUndefined(action.data.speed) || _.isNull(action.data.speed)) {
         throw new Error('Missing state speed');
       }
 

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -153,8 +153,14 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel) 
         percentage: state.percentage,
         eta: state.eta,
 
-        // Transform bytes to megabytes preserving only two decimal places
-        speed: Math.floor(state.speed / 1e+6 * 100) / 100 || 0
+        speed: _.attempt(() => {
+          if (_.isNumber(state.speed) && !_.isNaN(state.speed)) {
+
+            // Transform bytes to megabytes preserving only two decimal places
+            return Math.floor(state.speed / 1e+6 * 100) / 100;
+
+          }
+        })
       }
     });
   };

--- a/tests/gui/modules/image-writer.spec.js
+++ b/tests/gui/modules/image-writer.spec.js
@@ -201,6 +201,18 @@ describe('Browser: ImageWriter', function() {
         }).to.throw('Missing state speed');
       });
 
+      it('should not throw if speed is 0', function() {
+        ImageWriterService.setFlashingFlag();
+        m.chai.expect(function() {
+          ImageWriterService.setProgressState({
+            type: 'write',
+            percentage: 50,
+            eta: 15,
+            speed: 0
+          });
+        }).to.not.throw('Missing state speed');
+      });
+
     });
 
     describe('.getFlashResults()', function() {


### PR DESCRIPTION
There is a small flaw in the current state validation rules where a
speed that equals zero will be considered as if the speed was missing
giving that `!0 == true`.

Changelog-Entry: Fix state validation error when speed equals zero.
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>