### PR TITLE
upgrade: `sudo-prompt` to v5.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4888,9 +4888,9 @@
       }
     },
     "sudo-prompt": {
-      "version": "5.0.3",
-      "from": "sudo-prompt@>=5.0.3 <6.0.0",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-5.0.3.tgz"
+      "version": "5.1.0",
+      "from": "sudo-prompt@>=5.1.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-5.1.0.tgz"
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "resin-cli-visuals": "^1.2.8",
     "rx": "^4.1.0",
     "semver": "^5.1.0",
-    "sudo-prompt": "^5.0.3",
+    "sudo-prompt": "^5.1.0",
     "tail": "^1.1.0",
     "tmp": "0.0.28",
     "trackjs": "^2.1.16",


### PR DESCRIPTION
This new version contains a huge improvement on how the `kdesudo` dialog
looks.

See: https://github.com/jorangreef/sudo-prompt/commit/17f45ebef31afd9fb6260f7c2950fea4aab5ae4d
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>