### PR TITLE
minifix(GUI): handle image dialog and drive selector errors

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -210,7 +210,7 @@ app.controller('AppController', function(
       }
 
       this.selectImage(image);
-    });
+    }).catch(this.handleError);
   };
 
   this.selectDrive = (drive) => {
@@ -222,7 +222,9 @@ app.controller('AppController', function(
   };
 
   this.openDriveSelector = () => {
-    DriveSelectorService.open().then(this.selectDrive);
+    DriveSelectorService.open()
+      .then(this.selectDrive)
+      .catch(this.handleError);
   };
 
   this.reselectImage = () => {


### PR DESCRIPTION
Currently, if either `OSDialogService.selectImage()` or
`DriveSelectorService.open()` are rejected, we completely swallow the
errors, making very hard to debug certain problems.

This PR takes care of showing the usual error dialog for those cases.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>