### PR TITLE
minifix(GUI): use close() to dismiss drive selector modal

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -214,6 +214,10 @@ app.controller('AppController', function(
   };
 
   this.selectDrive = (drive) => {
+    if (!drive) {
+      return;
+    }
+
     this.selection.setDrive(drive);
 
     AnalyticsService.logEvent('Select drive', {

--- a/lib/gui/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/components/drive-selector/controllers/drive-selector.js
@@ -56,7 +56,7 @@ module.exports = function($uibModalInstance, DrivesModel, SelectionStateModel) {
     // is resolved with a non-existent drive.
     if (!selectedDrive || !_.includes(this.drives.getDrives(), selectedDrive)) {
 
-      $uibModalInstance.dismiss();
+      $uibModalInstance.close();
     } else {
       $uibModalInstance.close(selectedDrive);
     }


### PR DESCRIPTION
Using `dismiss()` causes the promise to be rejected, with no reason in
this case. Given we made sure we were handling errors from dialogs in a
previous commit, this issue manifested itself.

The `close()` function, without arguments, makes more sense in this
case.

See: https://github.com/resin-io/etcher/pull/548
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>