### PR TITLE
fix(GUI): escape parens in image paths on Linux/OS X

### DIFF
--- a/lib/src/child-writer/utils.js
+++ b/lib/src/child-writer/utils.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const _ = require('lodash');
+const os = require('os');
 const Bluebird = require('bluebird');
 const tmp = Bluebird.promisifyAll(require('tmp'));
 const packageJSON = require('../../../package.json');
@@ -75,7 +76,18 @@ exports.getBooleanArgumentForm = (argumentName, value) => {
 exports.getCLIWriterArguments = (options) => {
   const argv = [
     options.entryPoint,
-    options.image,
+    _.attempt(() => {
+      if (os.platform() === 'win32') {
+        return options.image;
+      }
+
+      // Parenthesis need to be manually escaped,
+      // otherwise bash will complain about syntax
+      // errors when passing this string as an
+      // argument to the writer proxy script.
+      return options.image.replace(/([\(\)])/g, '\\$1');
+
+    }),
     '--robot',
     '--drive',
     options.device,


### PR DESCRIPTION
Images may contain parenthesis. This is usually the case when you
re-download a file with a web browser, which atuaomtically appends `(N)`
to the path.

Not escaping parenthesis means that when passing the image path as an
argument to the write proxy script, bash will complain about it as a
syntax error on the command.

The fix is not necessary in Windows. I've been able to write images
containing parenthesis in that operating system without issues.

Change-Type: patch
Changelog-Entry: Fix error when writing images containing parenthesis in GNU/Linux and OS X.
Fixes: https://github.com/resin-io/etcher/issues/556
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>