### PR TITLE
fix(GUI): uncaught error when cancelling an elevation request

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -265,7 +265,13 @@ app.controller('AppController', function(
   };
 
   this.wasLastFlashSuccessful = () => {
-    return _.get(this.writer.getFlashResults(), 'passedValidation', true);
+    const flashResults = this.writer.getFlashResults();
+
+    if (_.get(flashResults, 'cancelled', false)) {
+      return true;
+    }
+
+    return _.get(flashResults, 'passedValidation', true);
   };
 
   this.flash = (image, drive) => {

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -242,9 +242,10 @@ imageWriter.service('ImageWriterService', function($q, $timeout, SettingsModel) 
     return this.performWrite(image, drive, this.setProgressState).then((results) => {
 
       // TODO: Make sure `etcher-image-write` always
-      // sends a `cancelled` property.
+      // sends a `cancelled` and `passedValidation` property.
       _.defaults(results, {
-        cancelled: false
+        cancelled: false,
+        passedValidation: false
       });
 
       this.unsetFlashingFlag(results);


### PR DESCRIPTION
Currently, if we cancel elevation, we'd get a big scary validation error
about `passedValidation` not being passed to the flash results object.

This fix also requires some adjustments to `wasLastFlashSuccessful()` in
order to adapt to the cancellation scenario.

Since a cancelled elevation request means the writing never took place,
`wasLastFlashSuccessful()` returns `true` if so, without even looking at
`passedValidation`.

Change-Type: patch
Changelog-Entry: Fix error when cancelling an elevation request.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>