### PR TITLE
fix(GUI): escape image path spaces correctly on Windows

### DIFF
--- a/lib/src/child-writer/writer-proxy.js
+++ b/lib/src/child-writer/writer-proxy.js
@@ -82,17 +82,18 @@ return isElevated().then((elevated) => {
       const elevator = Bluebird.promisifyAll(require('elevator'));
 
       return elevator.executeAsync([
-        [
+        'set',
+        'ELECTRON_RUN_AS_NODE=1',
+        '&&',
+        'set',
+        `${CONSTANTS.TEMPORARY_LOG_FILE_ENVIRONMENT_VARIABLE}=${logFile}`,
+        '&&',
 
-          'set ELECTRON_RUN_AS_NODE=1 &&',
-          `set ${CONSTANTS.TEMPORARY_LOG_FILE_ENVIRONMENT_VARIABLE}=${logFile} &&`,
+        // This is a trick to make the binary afterwards catch
+        // the environment variables set just previously.
+        'call'
 
-          // This is a trick to make the binary afterwards catch
-          // the environment variables set just previously.
-          'call'
-
-        ].concat(process.argv).join(' ')
-      ], {
+      ].concat(process.argv), {
         hidden: true,
         terminating: true,
         doNotPushdCurrentDirectory: true,


### PR DESCRIPTION
The `elevator` module passes its arguments directly to
`child_process.execFile()`, which handles escaping spaces and other
weird issues by default.

Instead of passing a separate argument for every word of the writer
proxy script command, we passed the whole thing at once, which means we
didn't get the escaping features by default.

Change-Type: patch
Changelog-Entry: Fix flashing not starting when an image name contains a space.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>