### PR TITLE
upgrade(GUI): electron to v1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "electron-mocha": "^1.2.2",
     "electron-osx-sign": "^0.3.0",
     "electron-packager": "^7.0.1",
-    "electron-prebuilt": "1.1.1",
+    "electron-prebuilt": "1.2.6",
     "eslint": "^2.13.1",
     "gulp": "^3.9.0",
     "gulp-sass": "^2.0.4",


### PR DESCRIPTION
This version contains a GNU/Linux fix there the image extension was
changed by the dialog.

Change-Type: patch
Changelog-Entry: Fix `ENOENT` error when selecting certain images with multiple extensions on GNU/Linux.
See: https://github.com/electron/electron/issues/6305
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>