### PR TITLE
docs(GUI): deactivate desktop shortcut Linux prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ was written correctly and much more.
 
 ***
 
-[**Download**][etcher] | [**Support**][SUPPORT] | [**Contributing**][CONTRIBUTING] | [**Roadmap**][milestones] | [**CLI**][CLI]
+[**Download**][etcher] | [**Support**][SUPPORT] | [**Documentation**][USER-DOCUMENTATION] | [**Contributing**][CONTRIBUTING] | [**Roadmap**][milestones] | [**CLI**][CLI]
 
 ![Etcher](https://raw.githubusercontent.com/resin-io/etcher/master/screenshot.png)
 
@@ -43,6 +43,7 @@ the [license].
 [SUPPORT]: https://github.com/resin-io/etcher/blob/master/SUPPORT.md
 [CONTRIBUTING]: https://github.com/resin-io/etcher/blob/master/docs/CONTRIBUTING.md
 [CLI]: https://github.com/resin-io/etcher/blob/master/docs/CLI.md
+[USER-DOCUMENTATION]: https://github.com/resin-io/etcher/blob/master/docs/USER-DOCUMENTATION.md
 [milestones]: https://github.com/resin-io/etcher/milestones
 [newissue]: https://github.com/resin-io/etcher/issues/new
 [license]: https://github.com/resin-io/etcher/blob/master/LICENSE

--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -1,0 +1,19 @@
+Etcher User Documentation
+=========================
+
+This document contains application documented oriented to Etcher users.
+
+Deactivate desktop shortcut prompt on GNU/Linux
+-----------------------------------------------
+
+This is a feature provided by [AppImages](appimage), where the applications
+prompts the user to automatically register a desktop shortcut to easily access
+the application.
+
+To deactivate this feature, `touch` any of the files listed below:
+
+- `$HOME/.local/share/appimagekit/no_desktopintegration`
+- `/usr/share/appimagekit/no_desktopintegration`
+- `/etc/appimagekit/no_desktopintegration`
+
+[appimage]: http://appimage.org


### PR DESCRIPTION
Document how to globally disable AppImage's desktop integration feature,
which promtps the user to create a desktop shortcut for the appliation
at startup.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>