### PR TITLE
chore: add commands to build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,22 @@ os:
   - linux
   - osx
 
+# C++11 support
+# See https://github.com/PacificBiosciences/pbdagcon/pull/7
+
+compiler:
+  - gcc
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - upx-ucl
+      - gcc-4.8
+      - g++-4.8
+      - clang
+
 before_install:
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
@@ -18,9 +34,16 @@ before_install:
   - npm config set spin=false
 
 install:
-  - npm install
+  - if [ "$CXX" = "g++" ]; then
+      export CXX="g++-4.8" CC="gcc-4.8";
+    fi
   - npm install -g bower
-  - bower install
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      ./scripts/build/linux.sh install x64;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      ./scripts/build/darwin.sh install;
+    fi
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@
 init:
   - git config --global core.autocrlf input
 
+image: Visual Studio 2013
+
 cache:
   - C:\Users\appveyor\.node-gyp
   - '%AppData%\npm-cache'
@@ -12,19 +14,17 @@ cache:
 environment:
   global:
     ELECTRON_NO_ATTACH_CONSOLE: true
-    npm_config_disturl: https://atom.io/download/atom-shell
-    npm_config_runtime: electron
-    npm_config_target: 1.1.1
-    npm_config_arch: x64
   matrix:
     - nodejs_version: 6.1.0
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm install -g npm
-  - npm install --build-from-source
-  - npm install -g bower
-  - bower install
+  - npm install -g npm bower rimraf asar
+  - choco install nsis -version 2.51
+  - choco install upx
+  - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
+  - set PATH=C:\Program Files (x86)\NSIS;%PATH%
+  - .\scripts\build\windows.bat install x64
 
 build: off
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,33 +33,30 @@ git clone https://github.com/resin-io/etcher
 cd etcher
 ```
 
-- Configure NPM.
-
-In UNIX based operating systems:
-
-```sh
-export npm_config_disturl=https://atom.io/download/atom-shell
-export npm_config_target=<ELECTRON_VERSION>
-export npm_config_runtime=electron
-```
-
-In Windows:
-
-```sh
-set npm_config_disturl=https://atom.io/download/atom-shell
-set npm_config_target=<ELECTRON_VERSION>
-set npm_config_runtime=electron
-```
-
-You can find the appropriate electron version in the
-`devDependencies['electron-prebuilt']` field in `package.json`.
-
 - Install dependencies.
 
-```sh
-npm install --build-from-source
-bower install
-```
+Please make use of the following scripts to install dependencies rather than
+simply running `npm install` given that we need to do extra configuration to
+make sure native dependencies are correctly compiled for Electron, otherwise
+the application might not run successfully.
+
+  - OS X
+
+  ```sh
+  ./scripts/build/darwin.sh install
+  ```
+
+  - GNU/Linux
+
+  ```sh
+  ./scripts/build/linux.sh install <x64|x86>
+  ```
+
+  - Windows
+
+  ```sh
+  .\scripts\build\windows.bat install <x64|x86>
+  ```
 
 - Run the GUI application.
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -62,7 +62,6 @@ found in the [Electron releases page][electron-releases].
 
 - Update the `NODE_VERSION` environment variable in `.travis.yml`.
 
-- Update the `nodejs_version` and `npm_config_target` environment variables in
-`appveyor.yml`.
+- Update the `nodejs_version` environment variable in `appveyor.yml`.
 
 [electron-releases]: https://github.com/electron/electron/releases

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -60,7 +60,7 @@ Run the following command from the *Developer Command Prompt for VS2013*, to
 ensure all Visual Studio command utilities are available in the `%PATH%`:
 
 ```sh
-> .\scripts\build\windows.bat <arch>
+> .\scripts\build\windows.bat all <x64|x86>
 ```
 
 ### OS X
@@ -72,7 +72,7 @@ Pre-requisites:
 Run the following command:
 
 ```sh
-$ ./scripts/build/darwin.sh
+$ ./scripts/build/darwin.sh all
 ```
 
 ### GNU/Linux
@@ -80,7 +80,7 @@ $ ./scripts/build/darwin.sh
 Run the following command:
 
 ```sh
-$ ./scripts/build/linux.sh <arch>
+$ ./scripts/build/linux.sh all <x64|x86>
 ```
 
 Publishing

--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -37,6 +37,17 @@ if ! command -v python 2>/dev/null; then
   exit 1
 fi
 
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <command>" 1>&2
+  exit 1
+fi
+
+COMMAND=$1
+if [ "$COMMAND" != "install" ] && [ "$COMMAND" != "package" ] && [ "$COMMAND" != "all" ]; then
+  echo "Unknown command: $COMMAND" 1>&2
+  exit 1
+fi
+
 ELECTRON_OSX_SIGN=./node_modules/.bin/electron-osx-sign
 ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
 SIGN_IDENTITY_OSX="Developer ID Application: Rulemotion Ltd (66H43P8FRG)"
@@ -200,7 +211,12 @@ function installer_dmg {
 
 }
 
-install
-package etcher-release
-installer_dmg etcher-release/Etcher-darwin-x64 etcher-release/installers
-installer_zip etcher-release/Etcher-darwin-x64 etcher-release/installers
+if [ "$COMMAND" == "install" ] || [ "$COMMAND" == "all" ]; then
+  install
+fi
+
+if [ "$COMMAND" == "package" ] || [ "$COMMAND" == "all" ]; then
+  package etcher-release
+  installer_dmg etcher-release/Etcher-darwin-x64 etcher-release/installers
+  installer_zip etcher-release/Etcher-darwin-x64 etcher-release/installers
+fi

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -42,12 +42,18 @@ if ! command -v python 2>/dev/null; then
   exit 1
 fi
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <arch>" 1>&2
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <command> <arch>" 1>&2
   exit 1
 fi
 
-ARCH=$1
+COMMAND=$1
+if [ "$COMMAND" != "install" ] && [ "$COMMAND" != "package" ] && [ "$COMMAND" != "all" ]; then
+  echo "Unknown command: $COMMAND" 1>&2
+  exit 1
+fi
+
+ARCH=$2
 if [ "$ARCH" != "x64" ] && [ "$ARCH" != "x86" ]; then
   echo "Unknown architecture: $ARCH" 1>&2
   exit 1
@@ -156,14 +162,25 @@ function installer {
   rm -rf $appdir_temporary_location
 }
 
-if [ "$ARCH" == "x86" ]; then
-  install ia32
-  package_x86 etcher-release
+if [ "$COMMAND" == "install" ] || [ "$COMMAND" == "all" ]; then
+  if [ "$ARCH" == "x86" ]; then
+    install ia32
+  fi
+
+  if [ "$ARCH" == "x64" ]; then
+    install x64
+  fi
 fi
 
-if [ "$ARCH" == "x64" ]; then
-  install x64
-  package_x64 etcher-release
+if [ "$COMMAND" == "package" ] || [ "$COMMAND" == "all" ]; then
+  if [ "$ARCH" == "x86" ]; then
+    package_x86 etcher-release
+  fi
+
+  if [ "$ARCH" == "x64" ]; then
+    package_x64 etcher-release
+  fi
+
+  installer etcher-release/Etcher-linux-$ARCH $ARCH etcher-release/installers
 fi
 
-installer etcher-release/Etcher-linux-$ARCH $ARCH etcher-release/installers

--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -16,7 +16,8 @@
 :: limitations under the License.
 ::::
 
-set arch=%1
+set command=%1
+set arch=%2
 set output_build_directory=etcher-release
 set output_directory=%output_build_directory%\installers
 set certificate_file=certificate.p12
@@ -28,16 +29,31 @@ set timestamp_server_url=http://timestamp.comodoca.com
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 if "%arch%"=="" (
-  echo Usage: %0 [arch] 1>&2
+  echo Usage: %0 [command] [arch] 1>&2
+  exit /b 1
+)
+
+if "%command%"=="" (
+  echo Usage: %0 [command] [arch] 1>&2
   exit /b 1
 )
 
 :: Batch conditionals don't support logical operators.
 :: Simulate "and" with nested conditions.
+
 if not "%arch%"=="x86" (
   if not "%arch%"=="x64" (
     echo Unknown architecture: %arch% 1>&2
     exit /b 1
+  )
+)
+
+if not "%command%"=="install" (
+  if not "%command%"=="package" (
+    if not "%command%"=="all" (
+      echo Unknown command: %command% 1>&2
+      exit /b 1
+    )
   )
 )
 
@@ -162,9 +178,15 @@ set HOME=%homedrive%%homepath%\.electron-gyp
 :: Install dependencies
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-call rimraf node_modules bower_components
-call npm install --build-from-source
-call bower install --production
+if not "%command%"=="package" (
+  call rimraf node_modules bower_components
+  call npm install --build-from-source
+  call bower install --production
+)
+
+if "%command%"=="install" (
+  exit /b 0
+)
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Package application


### PR DESCRIPTION
Currently build scripts install dependencies and package everything on
every run. In order to allow more customisation, the build scripts now
accept the following commands:

- `install`: Only install dependencies.
- `package`: Only package the application.
- `all`: Install dependencies and package the application.

The above differentiation allows us to improve the documentation and CI
configuration files to point to the `install` commands instead of having
to explain how to configure NPM correctly, since that's done by the
build scripts by default.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>