### PR TITLE
fix(GUI): ignore casing when checking an image extension validity

### DIFF
--- a/lib/gui/models/supported-formats.js
+++ b/lib/gui/models/supported-formats.js
@@ -115,7 +115,7 @@ SupportedFormats.service('SupportedFormatsModel', function() {
    * }
    */
   this.isSupportedImage = (image) => {
-    const extension = path.extname(image).slice(1);
+    const extension = path.extname(image).slice(1).toLowerCase();
 
     if (_.some([
       _.includes(this.getNonCompressedExtensions(), extension),

--- a/tests/gui/models/supported-formats.spec.js
+++ b/tests/gui/models/supported-formats.spec.js
@@ -78,6 +78,13 @@ describe('Browser: SupportedFormats', function() {
         m.chai.expect(isSupported).to.be.true;
       });
 
+      it('should ignore casing when determining extension validity', function() {
+        const nonCompressedExtension = _.first(SupportedFormatsModel.getNonCompressedExtensions());
+        const imagePath = '/path/to/foo.' + nonCompressedExtension.toUpperCase();
+        const isSupported = SupportedFormatsModel.isSupportedImage(imagePath);
+        m.chai.expect(isSupported).to.be.true;
+      });
+
       it('should not consider an extension before a non compressed extension', function() {
         const nonCompressedExtension = _.first(SupportedFormatsModel.getNonCompressedExtensions());
         const imagePath = '/path/to/foo.1234.' + nonCompressedExtension;


### PR DESCRIPTION
Currently, we take the image extension casing into account when
determining if the extension is a recognised one (e.g: `img`, `iso`,
etc). This causes an "Invalid image" error to be thrown when selecting
an image with an uppercase extension, like `UBUNTU.ISO`.

Change-Type: patch
Changelog-Entry: Don't throw an "Invalid image" error if the extension is not in lowercase.
Fixes: https://github.com/resin-io/etcher/issues/567
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>