### PR TITLE
chore: don't force a linebreak style in ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -293,9 +293,6 @@ rules:
     - error
     - before: true
       after: true
-  linebreak-style:
-    - error
-    - unix
   lines-around-comment:
     - error
     - beforeBlockComment: true


### PR DESCRIPTION
We're currently forcing a UNIX linebreak style, which causes hundreds of
complaints from the linter when cloning the project in a Windows machine
with a default configuration.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>