### PR TITLE
Use comments instead of plaintext in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,4 +2,4 @@
 - **Operating system and architecture:**
 - **Do you see any meaningful error information on DevTools?**
 
-*(You can open DevTools by pressing `Ctrl+Alt+I`, or `Cmd+Alt+I` if you're running OS X.)*
+<!-- You can open DevTools by pressing `Ctrl+Alt+I`, or `Cmd+Alt+I` if you're running OS X. -->


### PR DESCRIPTION
Doing it like this means that one does not have to delete the note before posting; it simply won't appear.