### PR TITLE
upgrade: etcher-image-write to v5.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1547,9 +1547,9 @@
       "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-2.3.0.tgz"
     },
     "etcher-image-write": {
-      "version": "5.0.2",
-      "from": "etcher-image-write@>=5.0.2 <6.0.0",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-5.0.2.tgz"
+      "version": "5.0.3",
+      "from": "etcher-image-write@>=5.0.3 <6.0.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-5.0.3.tgz"
     },
     "etcher-latest-version": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "drivelist": "^3.2.0",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^2.3.0",
-    "etcher-image-write": "^5.0.2",
+    "etcher-image-write": "^5.0.3",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This version contains a fix for a `diskpart` error on Windows.

Change-Type: patch
Changelog-Entry: Upgrade `etcher-image-write` to v5.0.2
Link: https://github.com/resin-io-modules/etcher-image-write/blob/master/CHANGELOG.md
See: https://github.com/resin-io/etcher/issues/552
See: https://github.com/resin-io/etcher/issues/571
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>