### PR TITLE
upgrade: drivelist to v3.2.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1311,9 +1311,9 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "drivelist": {
-      "version": "3.2.0",
-      "from": "drivelist@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.2.0.tgz",
+      "version": "3.2.2",
+      "from": "drivelist@>=3.2.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.2.2.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^3.2.0",
+    "drivelist": "^3.2.2",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^2.3.0",
     "etcher-image-write": "^5.0.3",


### PR DESCRIPTION
This version contains a fix to check the removable state of drives without a
file system in Windows.

Link: https://github.com/resin-io-modules/drivelist/blob/master/CHANGELOG.md
Change-Type: patch
Changelog-Entry: Upgrade `drivelist` to v3.2.2.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>