### PR TITLE
docs: explicitly list all dependencies in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,6 +16,14 @@ Prerequisites
 - [NodeJS](https://nodejs.org).
 - [Bower](http://bower.io).
 - [Gulp](http://gulpjs.com).
+- [UPX](http://upx.sourceforge.net).
+- [Python](https://www.python.org).
+
+### Windows
+
+- [rimraf](https://github.com/isaacs/rimraf).
+- [asar](https://github.com/electron/asar).
+- [NSIS](http://nsis.sourceforge.net/Main_Page).
 
 Running locally
 ---------------


### PR DESCRIPTION
The dependencies are checked for in the build scripts, but for the user
convenience, we should also list them explicitly in the `CONTRIBUTING.md`
guide.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>