### PR TITLE
chore: stop requiring a specific nodejs version to build Etcher

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,10 +22,6 @@ Running locally
 
 - Install [NodeJS](https://nodejs.org/en/).
 
-Sadly we need to enforce the same NodeJS version that the Electron version we
-use is running to avoid module version mismatches when building native
-dependencies (`electron-rebuild` doesn't seem to be enough).
-
 - Clone the repository.
 
 ```sh

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -55,13 +55,3 @@ Upgrading Electron
 
 - Upgrade the `electron-prebuilt` dependency version in `package.json` to an
 *exact version* (no `~`, `^`, etc).
-
-- Find the exact NodeJS version included in the desired Electron version and
-update `engines.node` in `package.json` appropriately. This can be usually
-found in the [Electron releases page][electron-releases].
-
-- Update the `NODE_VERSION` environment variable in `.travis.yml`.
-
-- Update the `nodejs_version` environment variable in `appveyor.yml`.
-
-[electron-releases]: https://github.com/electron/electron/releases

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -8,14 +8,6 @@ Common Pre-requisites
 ---------------------
 
 - [NodeJS](https://nodejs.org)
-
-Make sure you're running the exact same NodeJS version as the one included with
-the current Electron build being used by Etcher to avoid any strange native
-dependencies issues.
-
-The expected NodeJS version is determined by the `engines.node` property in
-[`package.json`][package-json].
-
 - [Bower](http://bower.io)
 - [UPX](http://upx.sourceforge.net)
 - [Python](https://www.python.org)

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "main": "lib/start.js",
   "description": "An image flasher with support for Windows, OS X and GNU/Linux.",
   "homepage": "https://github.com/resin-io/etcher",
-  "engines": {
-    "node": "6.1.0"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:resin-io/etcher.git"

--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -55,14 +55,16 @@ ELECTRON_VERSION=`node -e "console.log(require('./package.json').devDependencies
 APPLICATION_NAME=`node -e "console.log(require('./package.json').displayName)"`
 APPLICATION_COPYRIGHT=`node -e "console.log(require('./package.json').copyright)"`
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
-ELECTRON_NODE_VERSION=`node -e "console.log(require('./package.json').engines.node)"`
-
-if [[ "v$ELECTRON_NODE_VERSION" != "`node -v`" ]]; then
-  echo "Incompatible NodeJS version. Expected: $ELECTRON_NODE_VERSION" 1>&2
-  exit 1
-fi
 
 function install {
+
+  # Ensure native addons are compiled with the correct headers
+  # See https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md
+  export npm_config_disturl=https://atom.io/download/atom-shell
+  export npm_config_target=$ELECTRON_VERSION
+  export npm_config_arch=x64
+  export npm_config_runtime=electron
+
   rm -rf node_modules bower_components
   npm install --build-from-source
   bower install --production

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -64,12 +64,6 @@ ELECTRON_VERSION=`node -e "console.log(require('./package.json').devDependencies
 APPLICATION_NAME=`node -e "console.log(require('./package.json').displayName)"`
 APPLICATION_COPYRIGHT=`node -e "console.log(require('./package.json').copyright)"`
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
-ELECTRON_NODE_VERSION=`node -e "console.log(require('./package.json').engines.node)"`
-
-if [[ "v$ELECTRON_NODE_VERSION" != "`node -v`" ]]; then
-  echo "Incompatible NodeJS version. Expected: $ELECTRON_NODE_VERSION" 1>&2
-  exit 1
-fi
 
 function install {
 

--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -147,17 +147,8 @@ for /f %%i in (' "node -e ""console.log(require('./package.json').version)""" ')
   set etcher_version=%%i
 )
 
-for /f %%i in (' "node -e ""console.log(require('./package.json').engines.node)""" ') do (
-  set electron_node_version=%%i
-)
-
 for /f %%i in (' "node -v" ') do (
   set node_version=%%i
-)
-
-if not "v%electron_node_version%"=="%node_version%" (
-  echo Incompatible NodeJS version. Expected: %electron_node_version% 1>&2
-  exit /b 1
 )
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
We were previously requiring users to run the exact same NodeJS version as
Electron bundled in order to avoid native add-on compilation incompatibilities,
however this problem is completely mitigated by configuring NPM to build
against an Electron specific V8.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>