### PR TITLE
feat(CLI): validate drive

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -16,8 +16,11 @@
 
 'use strict';
 
+const _ = require('lodash');
+const Bluebird = require('bluebird');
 const visuals = require('resin-cli-visuals');
 const form = require('resin-cli-form');
+const drivelist = Bluebird.promisifyAll(require('drivelist'));
 const writer = require('./writer');
 const utils = require('./utils');
 const options = require('./cli');
@@ -56,27 +59,35 @@ form.run([
     check: new visuals.Progress('Validating')
   };
 
-  return writer.writeImage(options._[0], {
-    device: answers.drive
-  }, {
-    unmountOnSuccess: options.unmount,
-    validateWriteOnSuccess: options.check
-  }, (state) => {
+  return drivelist.listAsync().then((drives) => {
+    const selectedDrive = _.find(drives, {
+      device: answers.drive
+    });
 
-    if (options.robot) {
-      log.toStdout(JSON.stringify({
-        command: 'progress',
-        data: {
-          type: state.type,
-          percentage: Math.floor(state.percentage),
-          eta: state.eta,
-          speed: Math.floor(state.speed)
-        }
-      }));
-    } else {
-      progressBars[state.type].update(state);
+    if (!selectedDrive) {
+      throw new Error(`Drive not found: ${selectedDrive}`);
     }
 
+    return writer.writeImage(options._[0], selectedDrive, {
+      unmountOnSuccess: options.unmount,
+      validateWriteOnSuccess: options.check
+    }, (state) => {
+
+      if (options.robot) {
+        log.toStdout(JSON.stringify({
+          command: 'progress',
+          data: {
+            type: state.type,
+            percentage: Math.floor(state.percentage),
+            eta: state.eta,
+            speed: Math.floor(state.speed)
+          }
+        }));
+      } else {
+        progressBars[state.type].update(state);
+      }
+
+    });
   });
 }).then((results) => {
 


### PR DESCRIPTION
The Etcher CLI doesn't care if the drive exists or not. The user will
eventually find out since the CLI will output an `ENOENT` when trying to
actually write data, however its nicer from a UX perspective to catch
this early on.

Change-Type: minor
Changelog-Entry: Validate the existence of the passed drive.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>