### PR TITLE
feat: add support for `raw` images

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1273,9 +1273,9 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etcher-image-stream": {
-      "version": "2.5.2",
-      "from": "etcher-image-stream@2.5.2",
-      "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-2.5.2.tgz"
+      "version": "2.6.0",
+      "from": "etcher-image-stream@2.6.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-2.6.0.tgz"
     },
     "etcher-image-write": {
       "version": "6.0.0",
@@ -1786,14 +1786,7 @@
     "gzip-uncompressed-size": {
       "version": "1.0.0",
       "from": "gzip-uncompressed-size@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.com/gzip-uncompressed-size/-/gzip-uncompressed-size-1.0.0.tgz",
-      "dependencies": {
-        "async": {
-          "version": "2.0.0",
-          "from": "async@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.com/gzip-uncompressed-size/-/gzip-uncompressed-size-1.0.0.tgz"
     },
     "har-validator": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chalk": "^1.1.3",
     "drivelist": "^3.2.2",
     "electron-is-running-in-asar": "^1.0.0",
-    "etcher-image-stream": "^2.5.2",
+    "etcher-image-stream": "^2.6.0",
     "etcher-image-write": "^6.0.0",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",

--- a/tests/gui/models/supported-formats.spec.js
+++ b/tests/gui/models/supported-formats.spec.js
@@ -32,7 +32,7 @@ describe('Browser: SupportedFormats', function() {
 
       it('should return the supported non compressed extensions', function() {
         const extensions = SupportedFormatsModel.getNonCompressedExtensions();
-        m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'dsk', 'hddimg' ]);
+        m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'dsk', 'hddimg', 'raw' ]);
       });
 
     });


### PR DESCRIPTION
Change-Type: minor
Changelog-Entry: Add support for `raw` images.
See: https://github.com/resin-io-modules/etcher-image-stream/pull/21
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>