### PR TITLE
chore: integrate versionist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v1.0.0-beta.11] - 2016-07-17
+## v1.0.0-beta.11 - 2016-07-17
 
 ### Features
 
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upgrade `etcher-image-write` to v5.0.2.
 
-## [v1.0.0-beta.10] - 2016-06-27
+## v1.0.0-beta.10 - 2016-06-27
 
 ### Features
 
@@ -49,13 +49,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add a GitHub issue template.
 - Open DevTools in "undocked" mode by default.
 
-## [v1.0.0-beta.9] - 2016-06-20
+## v1.0.0-beta.9 - 2016-06-20
 
 ### Fixes
 
 - Don't interpret image file name information between dots as image extensions.
 
-## [v1.0.0-beta.8] - 2016-06-15
+## v1.0.0-beta.8 - 2016-06-15
 
 ### Features
 
@@ -76,7 +76,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Write a document explaining Etcher's architecture.
 
-## [v1.0.0-beta.7] - 2016-05-26
+## v1.0.0-beta.7 - 2016-05-26
 
 ### Features
 
@@ -97,7 +97,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade Electron to v1.1.1.
 - Various improvements to the build system.
 
-## [v1.0.0-beta.6] - 2016-05-12
+## v1.0.0-beta.6 - 2016-05-12
 
 ### Features
 
@@ -112,7 +112,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Remove implicit "Enable" from settings screen items.
 
-## [v1.0.0-beta.5] - 2016-05-04
+## v1.0.0-beta.5 - 2016-05-04
 
 ### Features
 
@@ -127,7 +127,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Deprecate GNU/Linux `.tar.gz` installers in favor of AppImages.
 
-## [v1.0.0-beta.4] - 2016-04-22
+## v1.0.0-beta.4 - 2016-04-22
 
 ### Features
 
@@ -145,7 +145,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade Electron to v0.37.6.
 - Integrate Etcher CLI in this git repository.
 
-## [v1.0.0-beta.3] - 2016-04-17
+## v1.0.0-beta.3 - 2016-04-17
 
 ### Features
 
@@ -179,7 +179,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Make GNU/Linux binary lowercase.
 - Replace all occurrences of "burn" with "flash".
 
-## [v1.0.0-beta.2] - 2016-04-07
+## v1.0.0-beta.2 - 2016-04-07
 
 ### Features
 
@@ -203,7 +203,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Heavy general refactoring.
 
-## [v1.0.0-beta.1] - 2016-03-28
+## v1.0.0-beta.1 - 2016-03-28
 
 ### Features
 
@@ -218,15 +218,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Make sure error is logged if its trapped with an error dialog.
 - Fix broken state when going to settings from the success screen.
 - Fix `Cannot read property 'length' of undefined` frequent issue.
-
-[v1.0.0-beta.11]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.10...v1.0.0-beta.11
-[v1.0.0-beta.10]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.9...v1.0.0-beta.10
-[v1.0.0-beta.9]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.8...v1.0.0-beta.9
-[v1.0.0-beta.8]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.7...v1.0.0-beta.8
-[v1.0.0-beta.7]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.6...v1.0.0-beta.7
-[v1.0.0-beta.6]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.5...v1.0.0-beta.6
-[v1.0.0-beta.5]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.4...v1.0.0-beta.5
-[v1.0.0-beta.4]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.3...v1.0.0-beta.4
-[v1.0.0-beta.3]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.2...v1.0.0-beta.3
-[v1.0.0-beta.2]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.1...v1.0.0-beta.2
-[v1.0.0-beta.1]: https://github.com/resin-io/etcher/compare/v1.0.0-beta.0...v1.0.0-beta.1

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -12,16 +12,7 @@ Preparing a new version
 - Bump the version number in the `package.json`'s `builder.win.version`
 property.
 
-- Add a new entry to `CHANGELOG.md` describing what has been added, changed, or
-removed. Please use the imperative mode and capitalize the first letter of
-each item.
-
-- Link the `CHANGELOG.md` entry to the GitHub page displaying the diffs between
-the previous and the current version.
-
-```markdown
-https://github.com/resin-io/etcher/compare/<previous>...<current>
-```
+- Add a new entry to `CHANGELOG.md` by running `npm run changelog`.
 
 - Re-take `screenshot.png` so it displays the latest version in the bottom
 right corner.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "test": "npm run lint && electron-mocha --recursive --renderer tests/gui -R min",
     "sass": "node-sass ./lib/gui/scss/main.scss > build/css/main.css",
-    "lint": "eslint lib tests scripts bin",
+    "lint": "eslint lib tests scripts bin versionist.conf.js",
+    "changelog": "versionist",
     "start": "electron lib/start.js",
     "shrinkwrap": "node ./scripts/shrinkwrap.js"
   },
@@ -99,7 +100,8 @@
     "eslint": "^2.13.1",
     "jsonfile": "^2.3.1",
     "mochainon": "^1.0.0",
-    "node-sass": "^3.8.0"
+    "node-sass": "^3.8.0",
+    "versionist": "^2.1.0"
   },
   "config": {
     "commitizen": {

--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+module.exports = {
+
+  subjectParser: 'angular',
+
+  getGitReferenceFromVersion: 'v-prefix',
+
+  editChangelog: true,
+
+  editVersion: false,
+
+  addEntryToChangelog: {
+    preset: 'prepend',
+    fromLine: 5
+  },
+
+  includeCommitWhen: (commit) => {
+    return commit.footer['Changelog-Entry'];
+  },
+
+  getIncrementLevelFromCommit: (commit) => {
+    return commit.footer['Change-Type'];
+  },
+
+  transformTemplateData: (data) => {
+    data.features = data.commits.filter((commit) => {
+      return commit.subject.type === 'feat';
+    });
+
+    data.fixes = data.commits.filter((commit) => {
+      return commit.subject.type === 'fix';
+    });
+
+    data.misc = data.commits.filter((commit) => {
+      return ![ 'fix', 'feat' ].includes(commit.subject.type);
+    });
+
+    return data;
+  },
+
+  template: [
+    '## v{{version}} - {{moment date "Y-MM-DD"}}',
+    '{{#if features.length}}',
+    '',
+    '### Features',
+    '',
+    '{{#each features}}',
+    '{{#with footer}}',
+    '- {{capitalize Changelog-Entry}}',
+    '{{/with}}',
+    '{{/each}}',
+    '{{/if}}',
+    '{{#if fixes.length}}',
+    '',
+    '### Fixes',
+    '',
+    '{{#each fixes}}',
+    '{{#with footer}}',
+    '- {{capitalize Changelog-Entry}}',
+    '{{/with}}',
+    '{{/each}}',
+    '{{/if}}',
+    '{{#if misc.length}}',
+    '',
+    '### Misc',
+    '',
+    '{{#each misc}}',
+    '{{#with footer}}',
+    '- {{capitalize Changelog-Entry}}',
+    '{{/with}}',
+    '{{/each}}',
+    '{{/if}}'
+  ].join('\n')
+
+};


### PR DESCRIPTION
Versionist is a small utility to automatically generate CHANGELOGs based
on a certain commit convention.

This PR adds a new `changelog` npm script that calls Versionist to
preppend a new CHANGELOG entry based on our current structure.

Dealing with links to changes between versions in GitHub is hard to
automatise with a tool like Versionist. We chose to get rid of such
links since they are a nice to have, but don't provide any meaningful
value to maintainers, since they can manually see the diffs with `git
diff`.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>