### PR TITLE
fix(GUI): escape quotes from image paths

### DIFF
--- a/lib/src/child-writer/utils.js
+++ b/lib/src/child-writer/utils.js
@@ -81,11 +81,10 @@ exports.getCLIWriterArguments = (options) => {
         return options.image;
       }
 
-      // Parenthesis need to be manually escaped,
-      // otherwise bash will complain about syntax
-      // errors when passing this string as an
-      // argument to the writer proxy script.
-      return options.image.replace(/([\(\)])/g, '\\$1');
+      // Parenthesis and quotes need to be manually escaped, otherwise
+      // bash will complain about syntax errors when passing this
+      // string as an argument to the writer proxy script.
+      return options.image.replace(/([\(\)'"])/g, '\\$1');
 
     }),
     '--robot',


### PR DESCRIPTION
Consider a directory name such as `Juan's Files`. When passing such path
as an argument to the child writer proxy script, Bash will complain
with:

> Unexpected EOF while looking for matching `'`

The solution is to manually escape quotes on the image path.

Change-Type: patch
Changelog-Entry: Escape quotes from image paths to prevent Bash errors on GNU/Linux and OS X.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>