### PR TITLE
refactor(GUI): store drive as a reference to available drives

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -235,7 +235,7 @@ app.controller('AppController', function(
       return;
     }
 
-    this.selection.setDrive(drive);
+    this.selection.setDrive(drive.device);
 
     AnalyticsService.logEvent('Select drive', {
       device: drive.device

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -7,7 +7,7 @@
   <ul class="list-group">
     <li class="list-group-item" ng-repeat="drive in modal.drives.getDrives() track by drive.device"
       ng-disabled="!modal.state.isDriveValid(drive)"
-      ng-click="modal.state.isDriveValid(drive) && modal.state.toggleSetDrive(drive)">
+      ng-click="modal.state.isDriveValid(drive) && modal.state.toggleSetDrive(drive.device)">
         <div>
           <h4 class="list-group-item-heading">{{ drive.description }} - {{ drive.size | gigabyte | number:1 }} GB</h4>
           <p class="list-group-item-text">{{ drive.name }}</p>
@@ -33,7 +33,7 @@
         </div>
         <span class="tick tick--success"
           ng-show="modal.state.isDriveValid(drive)"
-          ng-disabled="!modal.state.isCurrentDrive(drive)"></span>
+          ng-disabled="!modal.state.isCurrentDrive(drive.device)"></span>
     </li>
   </ul>
 </div>

--- a/lib/gui/models/selection-state.js
+++ b/lib/gui/models/selection-state.js
@@ -24,23 +24,21 @@ const _ = require('lodash');
 const angular = require('angular');
 const Store = require('./store');
 const MODULE_NAME = 'Etcher.Models.SelectionState';
-const SelectionStateModel = angular.module(MODULE_NAME, []);
+const SelectionStateModel = angular.module(MODULE_NAME, [
+  require('./drives')
+]);
 
-SelectionStateModel.service('SelectionStateModel', function() {
+SelectionStateModel.service('SelectionStateModel', function(DrivesModel) {
 
   /**
    * @summary Set a drive
    * @function
    * @public
    *
-   * @param {Object} drive - drive
+   * @param {String} drive - drive device
    *
    * @example
-   * SelectionStateModel.setDrive({
-   *   device: '/dev/disk2',
-   *   name: 'USB drive',
-   *   size: 999999999
-   * });
+   * SelectionStateModel.setDrive('/dev/disk2');
    */
   this.setDrive = (drive) => {
     Store.dispatch({
@@ -144,12 +142,10 @@ SelectionStateModel.service('SelectionStateModel', function() {
    * @function
    * @public
    *
-   * @param {Object} drive - drive
+   * @param {String} drive - drive device
    *
    * @example
-   * SelectionStateModel.toggleSetDrive({
-   *   device: '/dev/disk2'
-   * });
+   * SelectionStateModel.toggleSetDrive('/dev/disk2');
    */
   this.toggleSetDrive = (drive) => {
     if (this.isCurrentDrive(drive)) {
@@ -189,7 +185,9 @@ SelectionStateModel.service('SelectionStateModel', function() {
    * const drive = SelectionStateModel.getDrive();
    */
   this.getDrive = () => {
-    return _.get(Store.getState().toJS(), 'selection.drive');
+    return _.find(DrivesModel.getDrives(), {
+      device: Store.getState().getIn([ 'selection', 'drive' ])
+    });
   };
 
   /**
@@ -355,27 +353,20 @@ SelectionStateModel.service('SelectionStateModel', function() {
    * @function
    * @public
    *
-   * @param {Object} drive - drive
+   * @param {String} drive - drive device
    * @returns {Boolean} whether the drive is the current drive
    *
    * @example
-   * if (SelectionStateModel.isCurrentDrive({
-   *   device: '/dev/sdb',
-   *   description: 'DataTraveler 2.0',
-   *   size: '7.3G',
-   *   mountpoint: '/media/UNTITLED',
-   *   name: '/dev/sdb',
-   *   system: false
-   * })) {
+   * if (SelectionStateModel.isCurrentDrive('/dev/sdb')) {
    *   console.log('This is the current drive!');
    * }
    */
   this.isCurrentDrive = (drive) => {
-    if (!drive || !drive.device) {
+    if (!drive) {
       return false;
     }
 
-    return drive.device === _.get(this.getDrive(), 'device');
+    return drive === _.get(this.getDrive(), 'device');
   };
 
 });

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -102,7 +102,7 @@ const storeReducer = (state, action) => {
         if (state.getIn([ 'selection', 'image', 'size' ], 0) <= drive.size && !drive.protected) {
           return storeReducer(newState, {
             type: ACTIONS.SELECT_DRIVE,
-            data: drive
+            data: drive.device
           });
         }
 
@@ -217,40 +217,28 @@ const storeReducer = (state, action) => {
     }
 
     case ACTIONS.SELECT_DRIVE: {
-      if (!action.data.device) {
-        throw new Error('Missing drive device');
+      if (!action.data) {
+        throw new Error('Missing drive');
       }
 
-      if (!_.isString(action.data.device)) {
-        throw new Error(`Invalid drive device: ${action.data.device}`);
+      if (!_.isString(action.data)) {
+        throw new Error(`Invalid drive: ${action.data}`);
       }
 
-      if (!action.data.name) {
-        throw new Error('Missing drive name');
+      const selectedDrive = state.get('availableDrives').find((drive) => {
+        return drive.get('device') === action.data;
+      });
+
+      if (!selectedDrive) {
+        throw new Error(`The drive is not available: ${action.data}`);
       }
 
-      if (!_.isString(action.data.name)) {
-        throw new Error(`Invalid drive name: ${action.data.name}`);
-      }
-
-      if (!action.data.size) {
-        throw new Error('Missing drive size');
-      }
-
-      if (!_.isNumber(action.data.size)) {
-        throw new Error(`Invalid drive size: ${action.data.size}`);
-      }
-
-      if (!_.isBoolean(action.data.protected)) {
-        throw new Error(`Invalid drive protected state: ${action.data.protected}`);
-      }
-
-      if (action.data.protected) {
+      if (selectedDrive.get('protected')) {
         throw new Error('The drive is write-protected');
       }
 
       // TODO: Reuse from SelectionStateModel.isDriveLargeEnough()
-      if (state.getIn([ 'selection', 'image', 'size' ], 0) > action.data.size) {
+      if (state.getIn([ 'selection', 'image', 'size' ], 0) > selectedDrive.get('size')) {
         throw new Error('The drive is not large enough');
       }
 

--- a/tests/gui/models/drives.spec.js
+++ b/tests/gui/models/drives.spec.js
@@ -235,21 +235,25 @@ describe('Browser: DrivesModel', function() {
       describe('given one of the drives was selected', function() {
 
         beforeEach(function() {
-          SelectionStateModel.setDrive({
-            device: '/dev/sdc',
-            name: 'USB Drive',
-            size: 9999999,
-            mountpoint: '/mnt/bar',
-            system: false,
-            protected: false
-          });
+          DrivesModel.setDrives([
+            {
+              device: '/dev/sdc',
+              name: 'USB Drive',
+              size: 9999999,
+              mountpoint: '/mnt/bar',
+              system: false,
+              protected: false
+            }
+          ]);
+
+          SelectionStateModel.setDrive('/dev/sdc');
         });
 
         afterEach(function() {
           SelectionStateModel.removeDrive();
         });
 
-        it('should be delected if its not contain in the available drives anymore', function() {
+        it('should be deleted if its not contain in the available drives anymore', function() {
           m.chai.expect(SelectionStateModel.hasDrive()).to.be.true;
           DrivesModel.setDrives([
             {


### PR DESCRIPTION
Instead of storing the whole selected drive object, we barely store a
reference to the corresponding drive in the available drives array (the
reference being the drive device).

This greatly simplifies the application state in the following ways:

- The drive metadata (size, description, etc) is not duplicated in the
  state, enforcing a single source of truth.
- If the selected drive stops being available (e.g: is unplugged), the
  reference doesn't hold anymore, making this functionality very natural
  to implement.
- Makes `SelectionStateModel.isCurrentDrive()` much more inuitive, since
  we don't have to document that changes in the metadata of the drive
  object, or extra keys such as `$$hashKey` don't change the result of
  this function.
- Ensures the state never goes into a problematic state where we try to
  to write to an unavailable drive.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>