### PR TITLE
upgrade: `drivelist` to v3.2.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1111,9 +1111,9 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "3.2.2",
-      "from": "drivelist@>=3.2.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.2.2.tgz",
+      "version": "3.2.4",
+      "from": "drivelist@3.2.4",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.2.4.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^3.2.2",
+    "drivelist": "^3.2.4",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^3.0.1",
     "etcher-image-write": "^6.0.0",


### PR DESCRIPTION
This version contains the following fixes:

- Correctly handle mount points with spaces in GNU/Linux.
- Correctly report drive sizes in macOS Sierra.

Change-Type: patch
Changelog-Entry: Upgrade `drivelist` to v3.2.4.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>