### PR TITLE
fix(GUI): only enable error reporting if running inside an asar

### DIFF
--- a/lib/gui/modules/analytics.js
+++ b/lib/gui/modules/analytics.js
@@ -23,6 +23,7 @@
 const _ = require('lodash');
 const angular = require('angular');
 const username = require('username');
+const isRunningInAsar = require('electron-is-running-in-asar');
 const app = require('electron').remote.app;
 const packageJSON = require('../../../package.json');
 
@@ -78,7 +79,7 @@ analytics.config(($provide) => {
     return (exception, cause) => {
       const SettingsModel = $injector.get('SettingsModel');
 
-      if (SettingsModel.get('errorReporting')) {
+      if (SettingsModel.get('errorReporting') && isRunningInAsar()) {
         $window.trackJs.track(exception);
       }
 
@@ -96,7 +97,7 @@ analytics.config(($provide) => {
 
       const SettingsModel = $injector.get('SettingsModel');
 
-      if (SettingsModel.get('errorReporting')) {
+      if (SettingsModel.get('errorReporting') && isRunningInAsar()) {
         $window.trackJs.console.debug(message);
       }
 
@@ -144,7 +145,7 @@ analytics.service('AnalyticsService', function($log, $mixpanel, SettingsModel) {
    */
   this.logEvent = (message, data) => {
 
-    if (SettingsModel.get('errorReporting')) {
+    if (SettingsModel.get('errorReporting') && isRunningInAsar()) {
 
       // Clone data before passing it to `mixpanel.track`
       // since this function mutates the object adding


### PR DESCRIPTION
Currently, TrackJS would receive errors when running Etcher locally.
Most of the errors reported from those environments are due to
developing Etcher, and create a lot of noise in TrackJS.

With this PR, we ensure Etcher will only report errors when running
inside an `asar` archive, which means its a "packaged" Etcher version.

Change-Type: patch
Changelog-Entry: Only enable error reporting if running inside an `asar`.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>