### PR TITLE
minifix(GUI): deselect auto-selected drive if image is too large

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -270,7 +270,20 @@ const storeReducer = (state, action) => {
         throw new Error(`Invalid image logo: ${action.data.logo}`);
       }
 
-      return state.setIn([ 'selection', 'image' ], Immutable.fromJS(action.data));
+      const selectedDevice = state.getIn([ 'selection', 'drive' ]);
+      const selectedDrive = state.get('availableDrives').find((drive) => {
+        return drive.get('device') === selectedDevice;
+      });
+
+      return _.attempt(() => {
+        if (selectedDrive && selectedDrive.get('size', 0) < action.data.size) {
+          return storeReducer(state, {
+            type: ACTIONS.REMOVE_DRIVE
+          });
+        }
+
+        return state;
+      }).setIn([ 'selection', 'image' ], Immutable.fromJS(action.data));
     }
 
     case ACTIONS.REMOVE_DRIVE: {

--- a/tests/gui/models/selection-state.spec.js
+++ b/tests/gui/models/selection-state.spec.js
@@ -559,6 +559,28 @@ describe('Browser: SelectionState', function() {
           }).to.throw('Invalid image logo: 1234');
         });
 
+        it('should de-select a previously selected not-large-enough drive', function() {
+          DrivesModel.setDrives([
+            {
+              device: '/dev/disk1',
+              name: 'USB Drive',
+              size: 999999999,
+              protected: false
+            }
+          ]);
+
+          SelectionStateModel.setDrive('/dev/disk1');
+          m.chai.expect(SelectionStateModel.hasDrive()).to.be.true;
+
+          SelectionStateModel.setImage({
+            path: 'foo.img',
+            size: 9999999999
+          });
+
+          m.chai.expect(SelectionStateModel.hasDrive()).to.be.false;
+          SelectionStateModel.removeImage();
+        });
+
       });
 
     });


### PR DESCRIPTION
We recently introduced a feature where a single available drive would be
auto-selected even if the user didn't select an image.

This introduces a potential scenario that brings the state to an
incoherent state:

- Start Etcher.
- Let a drive get auto-selected.
- Select an image larger than the auto-selected drive.

In this case, the drive is known to not have enough space to hold the
image, but remains auto-selected.

This PR makes sure the drive is deselected automatically in the above
scenario.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>