### PR TITLE
refactor(GUI): increase encapsulation of flash results structure

### DIFF
--- a/lib/gui/models/flash-state.js
+++ b/lib/gui/models/flash-state.js
@@ -145,7 +145,7 @@ FlashState.service('FlashStateModel', function() {
   /**
    * @summary Get the flash results
    * @function
-   * @public
+   * @private
    *
    * @returns {Object} flash results
    *
@@ -168,6 +168,85 @@ FlashState.service('FlashStateModel', function() {
    */
   this.getFlashState = () => {
     return Store.getState().get('flashState').toJS();
+  };
+
+  /**
+   * @summary Determine if the last flash was successful
+   * @function
+   * @public
+   *
+   * @description
+   * This function returns true if the flash was cancelled, given
+   * a cancellation is a user request, and doesn't represent an
+   * actual flash error.
+   *
+   * This function returns true if there was no last flash.
+   *
+   * @returns {Boolean} whether the last flash was successful
+   *
+   * @example
+   * if (FlashStateModel.wasLastFlashSuccessful()) {
+   *   console.log('The last flash was successful');
+   * }
+   */
+  this.wasLastFlashSuccessful = () => {
+    return _.some([
+      this.wasLastFlashCancelled(),
+      _.get(this.getFlashResults(), 'passedValidation', true)
+    ]);
+  };
+
+  /**
+   * @summary Determine if the last flash was cancelled
+   * @function
+   * @public
+   *
+   * @description
+   * This function returns false if there was no last flash.
+   *
+   * @returns {Boolean} whether the last flash was cancelled
+   *
+   * @example
+   * if (FlashStateModel.wasLastFlashCancelled()) {
+   *   console.log('The last flash was cancelled');
+   * }
+   */
+  this.wasLastFlashCancelled = () => {
+    return _.get(this.getFlashResults(), 'cancelled', false);
+  };
+
+  /**
+   * @summary Get last flash source checksum
+   * @function
+   * @public
+   *
+   * @description
+   * This function returns undefined if there was no last flash.
+   *
+   * @returns {(String|Undefined)} the last flash source checksum
+   *
+   * @example
+   * const checksum = FlashStateModel.getLastFlashSourceChecksum();
+   */
+  this.getLastFlashSourceChecksum = () => {
+    return this.getFlashResults().sourceChecksum;
+  };
+
+  /**
+   * @summary Get last flash error code
+   * @function
+   * @public
+   *
+   * @description
+   * This function returns undefined if there was no last flash.
+   *
+   * @returns {(String|Undefined)} the last flash error code
+   *
+   * @example
+   * const errorCode = FlashStateModel.getLastFlashErrorCode();
+   */
+  this.getLastFlashErrorCode = () => {
+    return this.getFlashResults().errorCode;
   };
 
 });

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -170,16 +170,13 @@ const storeReducer = (state, action) => {
         throw new Error('Missing results');
       }
 
-      if (_.isUndefined(action.data.passedValidation) || _.isNull(action.data.passedValidation)) {
-        throw new Error('Missing results passedValidation');
-      }
+      _.defaults(action.data, {
+        passedValidation: false,
+        cancelled: false
+      });
 
       if (!_.isBoolean(action.data.passedValidation)) {
         throw new Error(`Invalid results passedValidation: ${action.data.passedValidation}`);
-      }
-
-      if (_.isUndefined(action.data.cancelled) || _.isNull(action.data.cancelled)) {
-        throw new Error('Missing results cancelled');
       }
 
       if (!_.isBoolean(action.data.cancelled)) {
@@ -200,6 +197,10 @@ const storeReducer = (state, action) => {
 
       if (action.data.passedValidation && !_.isString(action.data.sourceChecksum)) {
         throw new Error(`Invalid results sourceChecksum: ${action.data.sourceChecksum}`);
+      }
+
+      if (action.data.passedValidation && action.data.errorCode) {
+        throw new Error('The errorCode value can\'t be set if the flashing passed validation');
       }
 
       if (action.data.errorCode && !_.isString(action.data.errorCode)) {

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -21,7 +21,6 @@
  */
 
 const angular = require('angular');
-const _ = require('lodash');
 const childWriter = require('../../src/child-writer');
 
 const MODULE_NAME = 'Etcher.Modules.ImageWriter';
@@ -102,20 +101,8 @@ imageWriter.service('ImageWriterService', function($q, $rootScope, SettingsModel
         FlashStateModel.setProgressState(state);
       });
 
-    }).then((results) => {
-
-      // TODO: Make sure `etcher-image-write` always
-      // sends a `cancelled` and `passedValidation` property.
-      _.defaults(results, {
-        cancelled: false,
-        passedValidation: false
-      });
-
-      FlashStateModel.unsetFlashingFlag(results);
-    }).catch((error) => {
+    }).then(FlashStateModel.unsetFlashingFlag).catch((error) => {
       FlashStateModel.unsetFlashingFlag({
-        cancelled: false,
-        passedValidation: false,
         errorCode: error.code
       });
 

--- a/lib/gui/pages/finish/controllers/finish.js
+++ b/lib/gui/pages/finish/controllers/finish.js
@@ -30,7 +30,7 @@ module.exports = function($state, FlashStateModel, SelectionStateModel, Analytic
    * @type String
    * @public
    */
-  this.checksum = FlashStateModel.getFlashResults().sourceChecksum;
+  this.checksum = FlashStateModel.getLastFlashSourceChecksum();
 
   /**
    * @summary Restart the flashing process

--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -168,16 +168,6 @@ module.exports = function(
     AnalyticsService.logEvent('Restart after failure');
   };
 
-  this.wasLastFlashSuccessful = () => {
-    const flashResults = FlashStateModel.getFlashResults();
-
-    if (_.get(flashResults, 'cancelled', false)) {
-      return true;
-    }
-
-    return _.get(flashResults, 'passedValidation', true);
-  };
-
   this.flash = (image, drive) => {
 
     if (FlashStateModel.isFlashing()) {
@@ -194,13 +184,11 @@ module.exports = function(
     });
 
     return ImageWriterService.flash(image, drive).then(() => {
-      const results = FlashStateModel.getFlashResults();
-
-      if (results.cancelled) {
+      if (FlashStateModel.wasLastFlashCancelled()) {
         return;
       }
 
-      if (results.passedValidation) {
+      if (FlashStateModel.wasLastFlashSuccessful()) {
         OSNotificationService.send('Success!', 'Your flash is complete');
         AnalyticsService.logEvent('Done');
         $state.go('success');

--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -87,7 +87,7 @@
           percentage="main.state.getFlashState().percentage"
           striped="{{ main.state.getFlashState().type == 'check' }}"
           ng-attr-active="{{ main.state.isFlashing() }}"
-          ng-show="main.wasLastFlashSuccessful()"
+          ng-show="main.state.wasLastFlashSuccessful()"
           ng-click="main.flash(main.selection.getImagePath(), main.selection.getDrive())"
           ng-disabled="!main.selection.hasImage() || !main.selection.hasDrive()">
             <span ng-show="main.state.getFlashState().percentage == 100 && main.state.isFlashing()">Finishing...</span>
@@ -99,20 +99,20 @@
               ng-bind="main.state.getFlashState().percentage + '% Validating...'"></span>
         </progress-button>
 
-        <div class="alert-ribbon alert-warning" ng-class="{ 'alert-ribbon--open': !main.wasLastFlashSuccessful() }">
+        <div class="alert-ribbon alert-warning" ng-class="{ 'alert-ribbon--open': !main.state.wasLastFlashSuccessful() }">
           <span class="glyphicon glyphicon-warning-sign"></span>
-          <span ng-show="main.state.getFlashResults().errorCode === 'ENOSPC'">
+          <span ng-show="main.state.getLastFlashErrorCode() === 'ENOSPC'">
             Not enough space on the drive.<br>Please insert larger one and <button class="btn btn-link" ng-click="main.restartAfterFailure()">try again</button>
           </span>
-          <span ng-show="main.state.getFlashResults().errorCode !== 'ENOSPC' && main.settings.get('validateWriteOnSuccess')">
+          <span ng-show="main.state.getLastFlashErrorCode() !== 'ENOSPC' && main.settings.get('validateWriteOnSuccess')">
             Your removable drive may be corrupted.<br>Try inserting a different one and <button class="btn btn-link" ng-click="main.restartAfterFailure()">press "retry"</button>
           </span>
-          <span ng-show="main.state.getFlashResults().errorCode !== 'ENOSPC' && !main.settings.get('validateWriteOnSuccess')">
+          <span ng-show="main.state.getLastFlashErrorCode() !== 'ENOSPC' && !main.settings.get('validateWriteOnSuccess')">
             Oops, seems something went wrong. Click <button class="btn btn-link" ng-click="main.restartAfterFailure()">here</button> to retry
           </span>
         </div>
 
-        <button class="btn btn-warning btn-brick" ng-hide="main.wasLastFlashSuccessful()" ng-click="main.restartAfterFailure()">
+        <button class="btn btn-warning btn-brick" ng-hide="main.state.wasLastFlashSuccessful()" ng-click="main.restartAfterFailure()">
           <span class="glyphicon glyphicon-repeat"></span> Retry
         </button>
 


### PR DESCRIPTION
Currently, the client application knows too much about how the flash
results are stored in the internal state, and relies on its structure to
perform its logic.

This PR introduces several getters to `FlashStateModel` and makes
`FlashStateModel.getFlashResults()` private, ensuring clients don't
depend on the flash results object.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>