### PR TITLE
minifix(GUI): permit a number error code in flash results

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -203,7 +203,7 @@ const storeReducer = (state, action) => {
         throw new Error('The errorCode value can\'t be set if the flashing passed validation');
       }
 
-      if (action.data.errorCode && !_.isString(action.data.errorCode)) {
+      if (action.data.errorCode && !_.isString(action.data.errorCode) && !_.isNumber(action.data.errorCode)) {
         throw new Error(`Invalid results errorCode: ${action.data.errorCode}`);
       }
 

--- a/tests/gui/models/flash-state.spec.js
+++ b/tests/gui/models/flash-state.spec.js
@@ -253,15 +253,39 @@ describe('Browser: FlashStateModel', function() {
         }).to.throw('Missing results');
       });
 
-      it('should throw if errorCode is defined but it is not a number', function() {
+      it('should be able to set a string error code', function() {
+        FlashStateModel.unsetFlashingFlag({
+          passedValidation: false,
+          cancelled: false,
+          sourceChecksum: '1234',
+          errorCode: 'EBUSY'
+        });
+
+        m.chai.expect(FlashStateModel.getLastFlashErrorCode()).to.equal('EBUSY');
+      });
+
+      it('should be able to set a number error code', function() {
+        FlashStateModel.unsetFlashingFlag({
+          passedValidation: false,
+          cancelled: false,
+          sourceChecksum: '1234',
+          errorCode: 123
+        });
+
+        m.chai.expect(FlashStateModel.getLastFlashErrorCode()).to.equal(123);
+      });
+
+      it('should throw if errorCode is not a number not a string', function() {
         m.chai.expect(function() {
           FlashStateModel.unsetFlashingFlag({
             passedValidation: false,
             cancelled: false,
             sourceChecksum: '1234',
-            errorCode: 123
+            errorCode: {
+              name: 'EBUSY'
+            }
           });
-        }).to.throw('Invalid results errorCode: 123');
+        }).to.throw('Invalid results errorCode: [object Object]');
       });
 
       it('should default passedValidation to false', function() {


### PR DESCRIPTION
We were currently throwing a validation error if the error code was not
string when setting the flash results, however a number error code makes
sense in some cases, and its what its returned by a `ChildProcess`
object.

Change-Type: patch
See: https://github.com/resin-io/etcher/issues/609
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>