### PR TITLE
upgrade: `removedrive` to v1.1.1

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -121,6 +121,7 @@ form.run([
       command: 'error',
       data: {
         message: error.message,
+        description: error.description,
         code: error.code
       }
     }));

--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -52,7 +52,7 @@ module.exports = function(
       return;
     }
 
-    OSDialogService.showError(error);
+    OSDialogService.showError(error, error.description);
 
     // Also throw it so it gets displayed in DevTools
     // and its reported by TrackJS.

--- a/lib/src/child-writer/index.js
+++ b/lib/src/child-writer/index.js
@@ -93,6 +93,7 @@ exports.write = (image, drive, options) => {
       if (message.command === 'error') {
         const error = new Error(message.data.message);
         error.code = message.data.code;
+        error.description = message.data.description;
         return emitter.emit('error', error);
       }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1740,6 +1740,28 @@
       "from": "fs-extra-p@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-0.1.0.tgz"
     },
+    "fs-plus": {
+      "version": "2.9.1",
+      "from": "fs-plus@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.9.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@>=0.3.5 <0.4.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.2 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        }
+      }
+    },
     "fs-temp": {
       "version": "1.1.0",
       "from": "fs-temp@>=1.0.0 <2.0.0",
@@ -5043,6 +5065,18 @@
       "version": "1.7.0",
       "from": "underscore@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "from": "underscore-plus@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "from": "underscore@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        }
+      }
     },
     "underscore.string": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   ],
   "shrinkwrapIgnore": [
     "macos-alias",
-    "fs-xattr"
+    "fs-xattr",
+    "diskpart"
   ],
   "builder": {
     "win": {
@@ -75,6 +76,7 @@
     "lodash": "^4.5.1",
     "redux": "^3.5.2",
     "redux-localstorage": "^0.4.1",
+    "removedrive": "^1.1.1",
     "resin-cli-errors": "^1.2.0",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",

--- a/scripts/shrinkwrap.js
+++ b/scripts/shrinkwrap.js
@@ -19,7 +19,8 @@ const _ = require('lodash');
 const path = require('path');
 const jsonfile = require('jsonfile');
 const childProcess = require('child_process');
-const shrinkwrapIgnore = require('../package.json').shrinkwrapIgnore;
+const packageJSON = require('../package.json');
+const shrinkwrapIgnore = _.union(packageJSON.shrinkwrapIgnore, _.keys(packageJSON.optionalDependencies));
 const SHRINKWRAP_PATH = path.join(__dirname, '..', 'npm-shrinkwrap.json');
 
 try {


### PR DESCRIPTION
This version contains the following improvements:

- https://github.com/jviotti/removedrive/pull/3
- https://github.com/jviotti/removedrive/pull/2

Change-Type: patch
Changelog-Entry: Upgrade `removedrive` to v1.1.1.
Link: https://github.com/jviotti/removedrive/blob/master/CHANGELOG.md
See: https://github.com/resin-io/etcher/issues/573
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>