### PR TITLE
fix(GUI): display an error if no polkit authentication agent was found

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4979,9 +4979,9 @@
       }
     },
     "sudo-prompt": {
-      "version": "5.1.0",
-      "from": "sudo-prompt@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-5.1.0.tgz"
+      "version": "6.1.0",
+      "from": "sudo-prompt@6.1.0",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-6.1.0.tgz"
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "resin-cli-visuals": "^1.2.8",
     "rx": "^4.1.0",
     "semver": "^5.1.0",
-    "sudo-prompt": "^5.1.0",
+    "sudo-prompt": "^6.1.0",
     "tail": "^1.1.0",
     "tmp": "0.0.28",
     "trackjs": "^2.1.16",


### PR DESCRIPTION
Currently, if no graphical polkit authentication agent is found,
`sudo-prompt` will yield a "User did not grant permission." error, which
gives the impression the user cancelled the dialog (or entered the wrong
password), causing confusion for the user.

Instead, Etcher will now display a nice "No polkit authentication agent
found." error dialog.

Change-Type: patch
Changelog-Entry: Display an error if no graphical polkit authentication agent was found.
See: https://github.com/jorangreef/sudo-prompt/pull/29
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>