### PR TITLE
fix(GUI): force Etcher to auto-detect newly available drives

### DIFF
--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -20,6 +20,7 @@ const _ = require('lodash');
 
 module.exports = function(
   $state,
+  $timeout,
   DriveScannerService,
   SelectionStateModel,
   FlashStateModel,
@@ -78,7 +79,14 @@ module.exports = function(
   DriveScannerService.on('error', handleError);
 
   DriveScannerService.on('drives', (drives) => {
-    this.drives.setDrives(drives);
+
+    // Safely trigger a digest cycle.
+    // In some cases, AngularJS doesn't aknowledge that the
+    // available drives list has changed, and incorrectly
+    // keeps asking the user to "Connect a drive".
+    $timeout(() => {
+      this.drives.setDrives(drives);
+    });
 
     if (_.isEmpty(drives)) {
       DriveSelectorService.close();


### PR DESCRIPTION
There are some cases where AngularJS won't recognise that the available
drive list has changed, and incorrectly keeps asking the user to connect
a drive.

This problem was mainly witnessed in Windows, and could be reproduced
with the following steps:

- Start Etcher with no available drive.
- Select an image.
- Plug a drive.

Etcher keeps showing "Connect a drive" in the second step.

Change-Type: patch
Changelog-Entry: Fix new available drives not being recognised automatically in Windows.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>