### PR TITLE
feat(GUI): show "Unmounting..." while unmounting a drive

### DIFF
--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -93,6 +93,32 @@ module.exports = function(
     }
   });
 
+  this.getProgressButtonLabel = () => {
+    const flashState = this.state.getFlashState();
+
+    if (!this.state.isFlashing()) {
+      return 'Flash!';
+    }
+
+    if (flashState.percentage === 100) {
+      if (flashState.type === 'check' && this.settings.get('unmountOnSuccess')) {
+        return 'Unmounting...';
+      }
+
+      return 'Finishing...';
+    }
+
+    if (flashState.percentage === 0) {
+      return 'Starting...';
+    }
+
+    if (flashState.type === 'check') {
+      return `${flashState.percentage}% Validating...`;
+    }
+
+    return `${flashState.percentage}%`;
+  };
+
   this.selectImage = (image) => {
     if (!SupportedFormatsModel.isSupportedImage(image.path)) {
       OSDialogService.showError('Invalid image', `${image.path} is not a supported image type.`);

--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -90,13 +90,7 @@
           ng-show="main.state.wasLastFlashSuccessful()"
           ng-click="main.flash(main.selection.getImagePath(), main.selection.getDrive())"
           ng-disabled="!main.selection.hasImage() || !main.selection.hasDrive()">
-            <span ng-show="main.state.getFlashState().percentage == 100 && main.state.isFlashing()">Finishing...</span>
-            <span ng-show="main.state.getFlashState().percentage == 0 && !main.state.isFlashing()">Flash!</span>
-            <span ng-show="main.state.getFlashState().percentage == 0 && main.state.isFlashing() && !main.state.getFlashState().speed">Starting...</span>
-            <span ng-show="main.state.getFlashState().speed && main.state.getFlashState().percentage != 100 && main.state.getFlashState().type != 'check'"
-              ng-bind="main.state.getFlashState().percentage + '% '"></span>
-            <span ng-show="main.state.getFlashState().speed && main.state.getFlashState().percentage != 100 && main.state.getFlashState().type == 'check'"
-              ng-bind="main.state.getFlashState().percentage + '% Validating...'"></span>
+            <span ng-bind="main.getProgressButtonLabel()"></span>
         </progress-button>
 
         <div class="alert-ribbon alert-warning" ng-class="{ 'alert-ribbon--open': !main.state.wasLastFlashSuccessful() }">


### PR DESCRIPTION
Currently, we show "Finishing..." indenpendently on if we're waiting for
the flash to emit the "done" event, or we're waiting for the drive to be
unmounted.

As a way to simplify things, we move the hairy `ngShow` stack from the
main template to a nice function in the controller.

![screenshot 2016-08-03 10 51 54](https://cloud.githubusercontent.com/assets/2192773/17370216/373890d2-5969-11e6-97b5-308dae9b23d7.png)

Change-Type: minor
Changelog-Entry: Show "Unmounting..." while unmounting a drive.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>