### PR TITLE
fix(GUI): drive is removed everytime user navigates to main screen

### DIFF
--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -60,20 +60,6 @@ module.exports = function(
     throw error;
   };
 
-  // This catches the case where the user enters
-  // the settings screen when a flash finished
-  // and goes back to the main screen with the back button.
-  if (!FlashStateModel.isFlashing()) {
-
-    this.selection.clear({
-
-      // Preserve image, in case there is one, otherwise
-      // we revert the behaviour of "Use same image".
-      preserveImage: true
-
-    });
-  }
-
   DriveScannerService.start();
 
   DriveScannerService.on('error', handleError);


### PR DESCRIPTION
The problem can be reproduced with the following steps:

- Start Etcher.
- Plug a single drive, and let Etcher auto-select it.
- Navigate to the settings screen.
- Go back to the main screen.

The drive is auto-removed for a very small amount of time, until
auto-selection takes care of selecting it again. This behaviour causes
no harm, but its a bit annoying.

The problem was caused by a previous fix, which auto-removed the drive
if navigating back to the main screen after a flash finished, however
the fix no longer makes a lot of sense now that we allow a drive to be
selected even when no image has been chosen.

Change-Type: patch
Changelog-Entry: Prevent selected drive from getting auto-removed when navigating back to the main screen from another screen.
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>