### PR TITLE
refactor(GUI): move drive scanner logic to application entry point

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -26,6 +26,7 @@ var angular = require('angular');
 
 /* eslint-enable no-var */
 
+const _ = require('lodash');
 const Store = require('./models/store');
 
 const app = angular.module('Etcher', [
@@ -36,14 +37,17 @@ const app = angular.module('Etcher', [
   // Etcher modules
   require('./modules/analytics'),
   require('./modules/error'),
+  require('./modules/drive-scanner'),
 
   // Models
   require('./models/selection-state'),
   require('./models/flash-state'),
+  require('./models/drives'),
 
   // Components
   require('./components/svg-icon/svg-icon'),
   require('./components/update-notifier/update-notifier'),
+  require('./components/drive-selector/drive-selector'),
 
   // Pages
   require('./pages/main/main'),
@@ -104,6 +108,26 @@ app.run((AnalyticsService, OSWindowProgressService, FlashStateModel) => {
 
     OSWindowProgressService.set(flashState.percentage);
   });
+});
+
+app.run(($timeout, DriveScannerService, DrivesModel, ErrorService, DriveSelectorService) => {
+  DriveScannerService.on('drives', (drives) => {
+
+    // Safely trigger a digest cycle.
+    // In some cases, AngularJS doesn't aknowledge that the
+    // available drives list has changed, and incorrectly
+    // keeps asking the user to "Connect a drive".
+    $timeout(() => {
+      DrivesModel.setDrives(drives);
+    });
+
+    if (_.isEmpty(drives)) {
+      DriveSelectorService.close();
+    }
+  });
+
+  DriveScannerService.on('error', ErrorService.reportException);
+  DriveScannerService.start();
 });
 
 app.config(($urlRouterProvider) => {

--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -20,7 +20,6 @@ const _ = require('lodash');
 
 module.exports = function(
   $state,
-  $timeout,
   DriveScannerService,
   SelectionStateModel,
   FlashStateModel,
@@ -44,25 +43,6 @@ module.exports = function(
   this.state = FlashStateModel;
   this.settings = SettingsModel;
   this.tooltipModal = TooltipModalService;
-
-  DriveScannerService.start();
-
-  DriveScannerService.on('error', ErrorService.reportException);
-
-  DriveScannerService.on('drives', (drives) => {
-
-    // Safely trigger a digest cycle.
-    // In some cases, AngularJS doesn't aknowledge that the
-    // available drives list has changed, and incorrectly
-    // keeps asking the user to "Connect a drive".
-    $timeout(() => {
-      this.drives.setDrives(drives);
-    });
-
-    if (_.isEmpty(drives)) {
-      DriveSelectorService.close();
-    }
-  });
 
   this.getProgressButtonLabel = () => {
     const flashState = this.state.getFlashState();
@@ -212,7 +192,10 @@ module.exports = function(
 
       ErrorService.reportException(error);
     })
-    .finally(OSWindowProgressService.clear);
+    .finally(() => {
+      OSWindowProgressService.clear();
+      DriveScannerService.start();
+    });
   };
 
 };


### PR DESCRIPTION
Currently, the logic the controls the drive scanner and populates the
drive model lives in the main application controller.

This is not optimal because:

- The drive scanner stops populating the drives model when the
  application is not on the main screen.

- An event handler subscribes to the drive scanner every time the user
  navigates back to the main screen.

This PR moves the drive scanner logic to a run block in the entry point
of the application.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>