### PR TITLE
minifix(GUI): don't call shell.openExternal if resource is undefined

### DIFF
--- a/lib/gui/os/open-external/services/open-external.js
+++ b/lib/gui/os/open-external/services/open-external.js
@@ -30,6 +30,10 @@ module.exports = function() {
    * @example
    * OSOpenExternalService.open('https://www.google.com');
    */
-  this.open = electron.shell.openExternal;
+  this.open = (url) => {
+    if (url) {
+      electron.shell.openExternal(url);
+    }
+  };
 
 };

--- a/tests/gui/os/open-external.spec.js
+++ b/tests/gui/os/open-external.spec.js
@@ -52,6 +52,15 @@ describe('Browser: OSOpenExternal', function() {
       shellExternalStub.restore();
     });
 
+    it('should not call Electron shell.openExternal if the attribute value is not defined', function() {
+      const shellExternalStub = m.sinon.stub(electron.shell, 'openExternal');
+      const element = $compile('<span os-open-external>Resin.io</span>')($rootScope);
+      element.triggerHandler('click');
+      $rootScope.$digest();
+      m.chai.expect(shellExternalStub).to.not.have.been.called;
+      shellExternalStub.restore();
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR fixes an uncaught error being thrown when
`OSOpenExternalService.open()` is called with an undefined value.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>