### PR TITLE
fix(GUI): "modal.dismiss" is not a function

### DIFF
--- a/lib/gui/components/drive-selector/services/drive-selector.js
+++ b/lib/gui/components/drive-selector/services/drive-selector.js
@@ -56,7 +56,7 @@ module.exports = function(ModalService, $q) {
   this.close = () => {
 
     if (modal) {
-      return modal.dismiss();
+      return modal.close();
     }
 
     // Resolve `undefined` if the modal


### PR DESCRIPTION
Steps to reproduce:

- Insert a single drive.
- Open drive selector modal.
- Extract the drive while drive selectector modal is open.
- Check DevTools.

The solution is to use `.close()` instead of `.dismiss()`. After some
diving into the documentation and the code, `.dismiss()` is only
available from within the modal controller, however if you want to close
the modal from outside, `.close()` is the way to go.

Notice that `.close()` returns a rejected promise when being called from
the modal itself, but thats not the case from outside, which is quite
confusing, but means we can safely use `.close()` in this context.

Change-Type: patch
Changelog-Entry: Fix "`modal.dismiss` is not a function" exception.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>