### PR TITLE
minifix(GUI): improve image full file name modal tooltip

### DIFF
--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -23,7 +23,7 @@
             ng-click="main.tooltipModal.show({
               title: 'IMAGE FILE NAME',
               message: main.selection.getImagePath()
-            })">SHOW IN FULL</button>
+            })">SHOW FULL FILE NAME</button>
 
           <button class="btn btn-link step-footer"
             ng-click="image.reselectImage()"


### PR DESCRIPTION
The current tooltip, "SHOW IN FULL", proved to be a bit confusing for
users. We're using "SHOW FULL FILE NAME", as kindly suggested by @dlech.

![screenshot 2016-08-22 11 01 25](https://cloud.githubusercontent.com/assets/2192773/17861604/b999499a-685f-11e6-87cc-02db5d01756d.png)

Fixes: https://github.com/resin-io/etcher/issues/634
Change-Type: patch
Changelog-Entry: Improve image full file name modal tooltip.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>