### PR TITLE
upgrade: `drivelist` to v3.3.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1153,9 +1153,9 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "3.2.6",
-      "from": "drivelist@3.2.6",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.2.6.tgz",
+      "version": "3.3.0",
+      "from": "drivelist@3.3.0",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^3.2.6",
+    "drivelist": "^3.3.0",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^3.1.1",
     "etcher-image-write": "^6.1.1",


### PR DESCRIPTION
The changes we're interested in are:

- https://github.com/resin-io-modules/drivelist/pull/89
- https://github.com/resin-io-modules/drivelist/pull/91

Change-Type: patch
Changelog-Entry: Upgrade `drivelist` to v3.3.0.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>