### PR TITLE
upgrade: `etcher-image-write` to v7.0.0

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -19,6 +19,7 @@
 const imageWrite = require('etcher-image-write');
 const imageStream = require('etcher-image-stream');
 const Bluebird = require('bluebird');
+const fs = Bluebird.promisifyAll(require('fs'));
 const umount = Bluebird.promisifyAll(require('umount'));
 const os = require('os');
 const isWindows = os.platform() === 'win32';
@@ -57,11 +58,18 @@ const isWindows = os.platform() === 'win32';
  */
 exports.writeImage = (imagePath, drive, options, onProgress) => {
   return umount.umountAsync(drive.device).then(() => {
-    return imageStream.getFromFilePath(imagePath);
-  }).then((image) => {
-    return imageWrite.write(drive, image, {
+    return Bluebird.props({
+      image: imageStream.getFromFilePath(imagePath),
+      driveFileDescriptor: fs.openAsync(drive.raw, 'rs+')
+    });
+  }).then((results) => {
+    return imageWrite.write({
+      fd: results.driveFileDescriptor,
+      device: drive.raw,
+      size: drive.size
+    }, results.image, {
       check: options.validateWriteOnSuccess,
-      transform: image.transform,
+      transform: results.image.transform,
       bmap: options.bmapContents
     });
   }).then((writer) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1073,11 +1073,6 @@
       "from": "delegates@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
     },
-    "denymount": {
-      "version": "2.2.0",
-      "from": "denymount@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/denymount/-/denymount-2.2.0.tgz"
-    },
     "deps-sort": {
       "version": "2.0.0",
       "from": "deps-sort@>=2.0.0 <3.0.0",
@@ -1408,9 +1403,9 @@
       }
     },
     "etcher-image-write": {
-      "version": "6.1.1",
-      "from": "etcher-image-write@6.1.1",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-6.1.1.tgz",
+      "version": "7.0.0",
+      "from": "etcher-image-write@7.0.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-7.0.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -3657,11 +3652,6 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
         }
       }
-    },
-    "macmount": {
-      "version": "1.0.0",
-      "from": "macmount@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/macmount/-/macmount-1.0.0.tgz"
     },
     "make-iterator": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "drivelist": "^3.3.0",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^3.1.1",
-    "etcher-image-write": "^6.1.1",
+    "etcher-image-write": "^7.0.0",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
The change we're interested in is:

- https://github.com/resin-io-modules/etcher-image-write/pull/51

Change-Type: patch
Changelog-Entry: Prevent failed validation due to drive getting auto-mounted in GNU/Linux.
Fixes: https://github.com/resin-io/etcher/issues/574
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>