### PR TITLE
refactor: rely on `etcher-image-stream` to fetch bmap contents

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -39,7 +39,6 @@ Options
   --check, -c    validate write
   --robot, -r    parse-able output without interactivity
   --log, -l      output log file
-  --bmap, -b     bmap file
   --yes, -y      confirm non-interactively
   --unmount, -u  unmount on success
 ```

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -120,11 +120,6 @@ module.exports = yargs
       string: true,
       alias: 'l'
     },
-    bmap: {
-      describe: 'bmap file',
-      string: true,
-      alias: 'b'
-    },
     yes: {
       describe: 'confirm non-interactively',
       boolean: true,

--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -18,7 +18,6 @@
 
 const _ = require('lodash');
 const Bluebird = require('bluebird');
-const fs = Bluebird.promisifyAll(require('fs'));
 const visuals = require('resin-cli-visuals');
 const form = require('resin-cli-form');
 const drivelist = Bluebird.promisifyAll(require('drivelist'));
@@ -60,19 +59,8 @@ form.run([
     check: new visuals.Progress('Validating')
   };
 
-  return Bluebird.props({
-    drives: drivelist.listAsync(),
-    bmap: _.attempt(() => {
-      if (!options.bmap) {
-        return;
-      }
-
-      return fs.readFileAsync(options.bmap, {
-        encoding: 'utf8'
-      });
-    })
-  }).then((results) => {
-    const selectedDrive = _.find(results.drives, {
+  return drivelist.listAsync().then((drives) => {
+    const selectedDrive = _.find(drives, {
       device: answers.drive
     });
 
@@ -82,8 +70,7 @@ form.run([
 
     return writer.writeImage(options._[0], selectedDrive, {
       unmountOnSuccess: options.unmount,
-      validateWriteOnSuccess: options.check,
-      bmapContents: results.bmap
+      validateWriteOnSuccess: options.check
     }, (state) => {
 
       if (options.robot) {

--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -38,7 +38,6 @@ const isWindows = os.platform() === 'win32';
  * @param {Object} options - options
  * @param {Boolean} [options.unmountOnSuccess=false] - unmount on success
  * @param {Boolean} [options.validateWriteOnSuccess=false] - validate write on success
- * @param {String} [options.bmapContents] - bmap file contents
  * @param {Function} onProgress - on progress callback (state)
  *
  * @fulfil {Boolean} - whether the operation was successful
@@ -70,7 +69,7 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
     }, results.image, {
       check: options.validateWriteOnSuccess,
       transform: results.image.transform,
-      bmap: options.bmapContents
+      bmap: results.image.bmap
     });
   }).then((writer) => {
     return new Bluebird((resolve, reject) => {

--- a/lib/gui/models/selection-state.js
+++ b/lib/gui/models/selection-state.js
@@ -261,20 +261,6 @@ SelectionStateModel.service('SelectionStateModel', function(DrivesModel) {
   };
 
   /**
-   * @summary Get image bmap
-   * @function
-   * @public
-   *
-   * @returns {String} image bmap
-   *
-   * @example
-   * const imageBmap = SelectionStateModel.getImageBmap();
-   */
-  this.getImageBmap = () => {
-    return _.get(Store.getState().toJS(), 'selection.image.bmap');
-  };
-
-  /**
    * @summary Check if there is a selected drive
    * @function
    * @public

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -58,8 +58,7 @@ imageWriter.service('ImageWriterService', function($q, $rootScope, SettingsModel
     return $q((resolve, reject) => {
       const child = childWriter.write(image, drive, {
         validateWriteOnSuccess: SettingsModel.get('validateWriteOnSuccess'),
-        unmountOnSuccess: SettingsModel.get('unmountOnSuccess'),
-        bmapContents: SelectionStateModel.getImageBmap()
+        unmountOnSuccess: SettingsModel.get('unmountOnSuccess')
       });
       child.on('error', reject);
       child.on('done', resolve);

--- a/lib/src/child-writer/index.js
+++ b/lib/src/child-writer/index.js
@@ -17,9 +17,6 @@
 'use strict';
 
 const EventEmitter = require('events').EventEmitter;
-const _ = require('lodash');
-const Bluebird = require('bluebird');
-const fs = Bluebird.promisifyAll(require('fs'));
 const childProcess = require('child_process');
 const rendererUtils = require('./renderer-utils');
 const utils = require('./utils');
@@ -61,22 +58,10 @@ const EXIT_CODES = require('../exit-codes');
 exports.write = (image, drive, options) => {
   const emitter = new EventEmitter();
 
-  Bluebird.props({
-    logFile: utils.getTemporaryLogFilePath(),
-    bmapFile: _.attempt(() => {
-      if (!options.bmapContents) {
-        return;
-      }
-
-      return utils.getTemporaryBmapFilePath().tap((bmapFilePath) => {
-        return fs.writeFileAsync(bmapFilePath, options.bmapContents);
-      });
-    })
-  }).then((results) => {
+  utils.getTemporaryLogFilePath().then((logFile) => {
     const argv = utils.getCLIWriterArguments({
       entryPoint: rendererUtils.getApplicationEntryPoint(),
-      logFile: results.logFile,
-      bmap: results.bmapFile,
+      logFile: logFile,
       image: image,
       device: drive.device,
       validateWriteOnSuccess: options.validateWriteOnSuccess,
@@ -85,7 +70,7 @@ exports.write = (image, drive, options) => {
 
     // Make writer proxy inherit the temporary log file location
     // while keeping current environment variables intact.
-    process.env[CONSTANTS.TEMPORARY_LOG_FILE_ENVIRONMENT_VARIABLE] = results.logFile;
+    process.env[CONSTANTS.TEMPORARY_LOG_FILE_ENVIRONMENT_VARIABLE] = logFile;
 
     const child = childProcess.fork(CONSTANTS.WRITER_PROXY_SCRIPT, argv, {
       silent: true,

--- a/lib/src/child-writer/utils.js
+++ b/lib/src/child-writer/utils.js
@@ -60,7 +60,6 @@ exports.getBooleanArgumentForm = (argumentName, value) => {
  * @param {String} options.device - device
  * @param {String} options.entryPoint - entry point
  * @param {String} [options.logFile] - log file
- * @param {String} [options.bmap] - bmap file
  * @param {Boolean} [options.validateWriteOnSuccess] - validate write on success
  * @param {Boolean} [options.unmountOnSuccess] - unmount on success
  * @returns {String[]} arguments
@@ -108,10 +107,6 @@ exports.getCLIWriterArguments = (options) => {
     argv.push('--log', options.logFile);
   }
 
-  if (options.bmap) {
-    argv.push('--bmap', options.bmap);
-  }
-
   return argv;
 };
 
@@ -149,25 +144,5 @@ exports.getTemporaryLogFilePath = () => {
   return tmp.fileAsync({
     prefix: `${packageJSON.name}-`,
     postfix: '.log'
-  });
-};
-
-/**
- * @summary Get a temporary bmap file path
- * @function
- * @public
- *
- * @fulfil {String} - bmap path
- * @returns {Promise}
- *
- * @example
- * utils.getTemporaryBmapFilePath().then((bmapFilePath) => {
- *   console.log(bmapFilePath);
- * });
- */
-exports.getTemporaryBmapFilePath = () => {
-  return tmp.fileAsync({
-    prefix: `${packageJSON.name}-`,
-    postfix: '.bmap'
   });
 };

--- a/tests/gui/models/selection-state.spec.js
+++ b/tests/gui/models/selection-state.spec.js
@@ -55,10 +55,6 @@ describe('Browser: SelectionState', function() {
         m.chai.expect(SelectionStateModel.getImageLogo()).to.be.undefined;
       });
 
-      it('getImageBmap() should return undefined', function() {
-        m.chai.expect(SelectionStateModel.getImageBmap()).to.be.undefined;
-      });
-
       it('hasDrive() should return false', function() {
         const hasDrive = SelectionStateModel.hasDrive();
         m.chai.expect(hasDrive).to.be.false;
@@ -276,8 +272,7 @@ describe('Browser: SelectionState', function() {
           size: 999999999,
           url: 'https://www.raspbian.org',
           name: 'Raspbian',
-          logo: '<svg><text fill="red">Raspbian</text></svg>',
-          bmap: '<Range>Foo Bar</Range>'
+          logo: '<svg><text fill="red">Raspbian</text></svg>'
         });
       });
 
@@ -426,15 +421,6 @@ describe('Browser: SelectionState', function() {
         it('should return the image logo', function() {
           const imageLogo = SelectionStateModel.getImageLogo();
           m.chai.expect(imageLogo).to.equal('<svg><text fill="red">Raspbian</text></svg>');
-        });
-
-      });
-
-      describe('.getImageBmap()', function() {
-
-        it('should return the image bmap', function() {
-          const imageBmap = SelectionStateModel.getImageBmap();
-          m.chai.expect(imageBmap).to.equal('<Range>Foo Bar</Range>');
         });
 
       });


### PR DESCRIPTION
In order to get the bmap file contents to the Etcher CLI, we were
handling extraction, writing to a temporary file, then reading again,
and all sorts of other mumbo-jumbo, without realising that
`etcher-image-stream` already has this information right where we need
it (in the CLI's writer module) and in the way we need it (as plain
text).

Re-using from there hugely simplifies things.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>