### PR TITLE
upgrade: `etcher-image-write` to v7.0.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1403,9 +1403,9 @@
       }
     },
     "etcher-image-write": {
-      "version": "7.0.0",
-      "from": "etcher-image-write@7.0.0",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-7.0.0.tgz",
+      "version": "7.0.1",
+      "from": "etcher-image-write@7.0.1",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-7.0.1.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "drivelist": "^3.3.0",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^3.1.1",
-    "etcher-image-write": "^7.0.0",
+    "etcher-image-write": "^7.0.1",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
- https://github.com/resin-io-modules/etcher-image-write/pull/53

Change-Type: patch
Changelog-Entry: Prevent `ENOSPC` if the drive capacity is equal to the image size.
Fixes: https://github.com/resin-io/etcher/issues/629
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>