### PR TITLE
upgrade: `drivelist` to v3.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1143,9 +1143,9 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "3.3.0",
-      "from": "drivelist@3.3.0",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.0.tgz",
+      "version": "3.3.1",
+      "from": "drivelist@3.3.1",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^3.3.0",
+    "drivelist": "^3.3.1",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^3.1.2",
     "etcher-image-write": "^7.0.1",


### PR DESCRIPTION
This version contains a fix for the `blkid: command not found` error in
certain GNU/Linux distributions.

- https://github.com/resin-io-modules/drivelist/pull/92

Change-Type: patch
Changelog-Entry: Fix `blkid: command not found` error in certain GNU/Linux distributions.
Fixes: https://github.com/resin-io/etcher/issues/640
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>