### PR TITLE
docs: nsis required version

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -19,7 +19,7 @@ Prerequisites
 
 - [Rimraf](https://github.com/isaacs/rimraf)
 - [Asar](https://github.com/electron/asar)
-- [NSIS](http://nsis.sourceforge.net/Main_Page)
+- [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
 - [Visual Studio Community 2013](https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx)
 
 ### OS X


### PR DESCRIPTION
Packaging Etcher with NSIS v3.x results in weird errors. We only support
v2.x, for which the latest version is v2.51.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>