### PR TITLE
chore: upgrade ruby version in CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 sudo: false
 
 env:
-  - NODE_VERSION="6.1.0"
+  - NODE_VERSION="6.1.0" RUBY_VERSION="2.3.1"
 os:
   - linux
   - osx
@@ -32,6 +32,8 @@ before_install:
   - node --version
   - npm --version
   - npm config set spin=false
+  - rvm install $RUBY_VERSION
+  - rvm use $RUBY_VERSION
 
 install:
   - if [ "$CXX" = "g++" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,10 +22,10 @@ install:
   - npm install -g npm bower rimraf asar
   - choco install nsis -version 2.51
   - choco install upx
-  - choco install ruby
-  - gem install scss_lint
   - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
   - set PATH=C:\Program Files (x86)\NSIS;%PATH%
+  - set PATH=C:\Ruby22\bin;%PATH%
+  - gem install scss_lint
   - .\scripts\build\windows.bat install x64
 
 build: off


### PR DESCRIPTION
`scss_lint` suddenly requires Ruby 2, which is breaking all our Travis
CI and Appveyor builds, which ship older versions.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>