### PR TITLE
refactor(GUI): badge coloring

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6077,13 +6077,7 @@ body {
   padding: 7px 10px;
   position: relative;
   z-index: 10;
-  letter-spacing: 0;
-  background-color: #535760;
-  color: #fff; }
-
-.badge[disabled] {
-  background-color: #5a5d60;
-  color: #787c7f; }
+  letter-spacing: 0; }
 
 /*
  * Copyright 2016 Resin.io
@@ -6521,6 +6515,13 @@ body {
   margin-top: 10px;
   color: #fff; }
   .page-main .icon-caption[disabled] {
+    color: #787c7f; }
+
+.page-main .badge {
+  background-color: #535760;
+  color: #fff; }
+  .page-main .badge[disabled] {
+    background-color: #5a5d60;
     color: #787c7f; }
 
 .svg-icon[disabled] path {

--- a/lib/gui/pages/main/styles/_main.scss
+++ b/lib/gui/pages/main/styles/_main.scss
@@ -29,6 +29,16 @@
   }
 }
 
+.page-main .badge {
+  background-color: $palette-theme-dark-background;
+  color: $palette-theme-dark-foreground;
+
+  &[disabled] {
+    background-color: darken($palette-theme-dark-disabled-foreground, 12%);
+    color: $palette-theme-dark-disabled-foreground;
+  }
+}
+
 .svg-icon[disabled] path {
   fill: $palette-theme-dark-disabled-foreground;
 }

--- a/lib/gui/scss/components/_badge.scss
+++ b/lib/gui/scss/components/_badge.scss
@@ -21,11 +21,4 @@
   position: relative;
   z-index: 10;
   letter-spacing: 0;
-  background-color: $palette-theme-dark-background;
-  color: $palette-theme-dark-foreground;
-}
-
-.badge[disabled] {
-  background-color: darken($palette-theme-dark-disabled-foreground, 12%);
-  color: $palette-theme-dark-disabled-foreground;
 }


### PR DESCRIPTION
Move `.badge` coloring to the main page's style file, since the style we
currently hardcode on the component itself is very tied to the
particular context the badge is being instantiated in.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>