### PR TITLE
refactor(GUI): explicitly declare `.label-danger` coloring

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6056,6 +6056,10 @@ body {
   background-color: #3b3e45;
   color: #919191; }
 
+.label-danger {
+  background-color: #d9534f;
+  color: #fff; }
+
 /*
  * Copyright 2016 Resin.io
  *

--- a/lib/gui/scss/components/_label.scss
+++ b/lib/gui/scss/components/_label.scss
@@ -28,3 +28,8 @@
   background-color: darken($palette-theme-dark-background, 10%);
   color: darken($palette-theme-dark-foreground, 43%);
 }
+
+.label-danger {
+  background-color: $palette-theme-danger-background;
+  color: $palette-theme-danger-foreground;
+}


### PR DESCRIPTION
`.label-danger` is defined by Bootstrap, and its coloring re-uses what
was defined in `$brand-danger`, which is currently unset.

To prevent the module from going out of sync with our new CSS palette,
we explicitly declare the colorings in the component file.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>