### PR TITLE
refactor(GUI): move button min-width rules to page styles

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6142,9 +6142,6 @@ body {
 .button-no-hover, .button[disabled], [disabled].progress-button, .progress-button[active="true"] {
   pointer-events: none; }
 
-.button-brick {
-  min-width: 170px; }
-
 .button-default,
 .button-default:focus {
   background-color: #ececec;
@@ -6535,6 +6532,9 @@ body {
 .page-main .relative {
   position: relative; }
 
+.page-main .button-brick {
+  min-width: 170px; }
+
 .page-main .step-border-left, .page-main .step-border-right {
   height: 2px;
   background-color: #fff;
@@ -6637,6 +6637,9 @@ body {
 .page-finish .button-label {
   margin: 0 auto 15px;
   max-width: 165px; }
+
+.page-finish .button-primary, .page-finish .progress-button {
+  min-width: 170px; }
 
 .page-finish .title {
   color: #fff; }

--- a/lib/gui/pages/finish/styles/_finish.scss
+++ b/lib/gui/pages/finish/styles/_finish.scss
@@ -21,6 +21,10 @@
   max-width: $btn-min-width - 5px;
 }
 
+.page-finish .button-primary {
+  min-width: $btn-min-width;
+}
+
 .page-finish .title {
   color: $palette-theme-dark-foreground;
 }

--- a/lib/gui/pages/main/styles/_main.scss
+++ b/lib/gui/pages/main/styles/_main.scss
@@ -45,6 +45,10 @@
   position: relative;
 }
 
+.page-main .button-brick {
+  min-width: $btn-min-width;
+}
+
 %step-border {
   height: 2px;
   background-color: $palette-theme-dark-foreground;

--- a/lib/gui/scss/components/_button.scss
+++ b/lib/gui/scss/components/_button.scss
@@ -53,10 +53,6 @@
   pointer-events: none;
 }
 
-.button-brick {
-  min-width: $btn-min-width;
-}
-
 // Create map from Bootstrap `.btn` type styles
 // since its not possible to perform variable
 // interpolation (e.g: `$btn-${type}-bg`).


### PR DESCRIPTION
The `.button` component is not the responsible of knowing the
`min-width` it should occupy in the actual pages.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>