### PR TITLE
refactor(GUI): move `_bootstrap.scss` alert rules to `.alert-ribbon`

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -5976,11 +5976,6 @@ body {
 .modal-backdrop.in {
   opacity: 0; }
 
-.alert, .alert-ribbon {
-  text-align: center;
-  border: 0;
-  border-radius: 2px; }
-
 [uib-tooltip] {
   cursor: default; }
 
@@ -6327,9 +6322,12 @@ body {
   border-color: #f7dbc3;
   width: 60%;
   position: fixed;
+  text-align: center;
   left: 0;
   right: 0;
   margin: 0 auto;
+  border: 0;
+  border-radius: 2px;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   top: -100%;

--- a/lib/gui/scss/components/_alert-ribbon.scss
+++ b/lib/gui/scss/components/_alert-ribbon.scss
@@ -23,11 +23,14 @@
 
   width: 60%;
   position: fixed;
+  text-align: center;
 
   left: 0;
   right: 0;
   margin: 0 auto;
 
+  border: 0;
+  border-radius: 2px;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 

--- a/lib/gui/scss/modules/_bootstrap.scss
+++ b/lib/gui/scss/modules/_bootstrap.scss
@@ -37,12 +37,6 @@ body {
   opacity: 0;
 }
 
-.alert {
-  text-align: center;
-  border: 0;
-  border-radius: 2px;
-}
-
 [uib-tooltip] {
   cursor: default;
 }


### PR DESCRIPTION
We have some global CSS rules that affect `.alert` living in
`_bootstrap.scss`, however `.alert` is only being used by our
`.alert-ribbon` component, so it makes sense to move those rules over
there.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>