### PR TITLE
upgrade: `drivelist` to v3.3.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1143,9 +1143,9 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "3.3.1",
-      "from": "drivelist@3.3.1",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.1.tgz",
+      "version": "3.3.3",
+      "from": "drivelist@3.3.3",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.3.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^3.3.1",
+    "drivelist": "^3.3.3",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^3.1.2",
     "etcher-image-write": "^7.0.1",


### PR DESCRIPTION
- https://github.com/resin-io-modules/drivelist/pull/94

Change-Type: patch
Changelog-Entry: Show device id if device doesn't have an assigned drive letter in Windows.
Fixes: https://github.com/resin-io/etcher/issues/671
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>