### PR TITLE
feat(GUI): "Need help?" dynamically opens the image support url

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -143,3 +143,25 @@ app.config(($provide) => {
     };
   });
 });
+
+app.controller('HeaderController', function(SelectionStateModel, OSOpenExternalService) {
+
+  /**
+   * @summary Open help page
+   * @function
+   * @public
+   *
+   * @description
+   * This application will open either the image's support url, declared
+   * in the archive `manifest.json`, or the default Etcher help page.
+   *
+   * @example
+   * HeaderController.openHelpPage();
+   */
+  this.openHelpPage = () => {
+    const DEFAULT_SUPPORT_URL = 'https://github.com/resin-io/etcher/blob/master/SUPPORT.md';
+    const supportUrl = SelectionStateModel.getImageSupportUrl() || DEFAULT_SUPPORT_URL;
+    OSOpenExternalService.open(supportUrl);
+  };
+
+});

--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -18,8 +18,8 @@
     <script src="./app.js"></script>
   </head>
   <body ng-app="Etcher">
-    <header class="section-header">
-      <button class="button button-link" os-open-external="https://github.com/resin-io/etcher/blob/master/SUPPORT.md">
+    <header class="section-header" ng-controller="HeaderController as header">
+      <button class="button button-link" ng-click="header.openHelpPage()">
         <span class="glyphicon glyphicon-question-sign"></span> Need Help?
       </button>
 

--- a/lib/gui/models/selection-state.js
+++ b/lib/gui/models/selection-state.js
@@ -261,6 +261,20 @@ SelectionStateModel.service('SelectionStateModel', function(DrivesModel) {
   };
 
   /**
+   * @summary Get image support url
+   * @function
+   * @public
+   *
+   * @returns {String} image support url
+   *
+   * @example
+   * const imageSupportUrl = SelectionStateModel.getImageSupportUrl();
+   */
+  this.getImageSupportUrl = () => {
+    return _.get(Store.getState().toJS(), 'selection.image.supportUrl');
+  };
+
+  /**
    * @summary Check if there is a selected drive
    * @function
    * @public

--- a/tests/gui/models/selection-state.spec.js
+++ b/tests/gui/models/selection-state.spec.js
@@ -55,6 +55,10 @@ describe('Browser: SelectionState', function() {
         m.chai.expect(SelectionStateModel.getImageLogo()).to.be.undefined;
       });
 
+      it('getImageSupportUrl() should return undefined', function() {
+        m.chai.expect(SelectionStateModel.getImageSupportUrl()).to.be.undefined;
+      });
+
       it('hasDrive() should return false', function() {
         const hasDrive = SelectionStateModel.hasDrive();
         m.chai.expect(hasDrive).to.be.false;
@@ -271,6 +275,7 @@ describe('Browser: SelectionState', function() {
           path: 'foo.img',
           size: 999999999,
           url: 'https://www.raspbian.org',
+          supportUrl: 'https://www.raspbian.org/forums/',
           name: 'Raspbian',
           logo: '<svg><text fill="red">Raspbian</text></svg>'
         });
@@ -421,6 +426,15 @@ describe('Browser: SelectionState', function() {
         it('should return the image logo', function() {
           const imageLogo = SelectionStateModel.getImageLogo();
           m.chai.expect(imageLogo).to.equal('<svg><text fill="red">Raspbian</text></svg>');
+        });
+
+      });
+
+      describe('.getImageSupportUrl()', function() {
+
+        it('should return the image support url', function() {
+          const imageSupportUrl = SelectionStateModel.getImageSupportUrl();
+          m.chai.expect(imageSupportUrl).to.equal('https://www.raspbian.org/forums/');
         });
 
       });


### PR DESCRIPTION
We've recently added support for a `supportUrl` property in an archive
image `_info/manifest.json`, which the publisher can use to define the
URL where it would like to redirect users facing problems.

This PR makes the "Need help?" link at the top right corner open the
configured `supportUrl` url, and fallback to the original Etcher's help
page if no `supportUrl` is found.

In order to accomplish this, we made the following changes:

- Implement `SelectionStateModel.getImageSupportUrl()`
- Implement `HeaderController` controller

Change-Type: minor
Changelog-Entry: Make the "Need help?" link dynamically open the image support url.
Fixes: https://github.com/resin-io/etcher/issues/662
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>