### PR TITLE
style(GUI): make "Connect a drive" button blue

### DIFF
--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -78,7 +78,7 @@
           </div>
 
           <div ng-hide="main.drives.hasAvailableDrives() || main.shouldDriveStepBeDisabled()">
-            <button class="button button-danger button-brick button-no-hover">Connect a drive</button>
+            <button class="button button-primary button-brick button-no-hover">Connect a drive</button>
           </div>
 
         </div>


### PR DESCRIPTION
For consistency purposes on the main screen, we switch the "Connect a
drive" button to be the classic primary blue button as the other ones.

![screenshot 2016-09-06 10 45 36](https://cloud.githubusercontent.com/assets/2192773/18284499/11d5d004-741f-11e6-8ebe-b739b3b4adce.png)

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>