### PR TITLE
style(GUI): fix `state` -> `step` typo in main controller

### DIFF
--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -75,11 +75,11 @@ module.exports = function(
    * @returns {Boolean} whether the flash step should be disabled
    *
    * @example
-   * if (MainController.shouldFlashStateBeDisabled()) {
+   * if (MainController.shouldFlashStepBeDisabled()) {
    *   console.log('The flash step should be disabled');
    * }
    */
-  this.shouldFlashStateBeDisabled = () => {
+  this.shouldFlashStepBeDisabled = () => {
     return this.shouldDriveStepBeDisabled() || !SelectionStateModel.hasDrive();
   };
 

--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -58,7 +58,7 @@
   <div class="col-xs" ng-controller="DriveSelectionController as drive">
     <div class="box text-center relative">
       <div class="step-border-left" ng-disabled="main.shouldDriveStepBeDisabled()"></div>
-      <div class="step-border-right" ng-disabled="main.shouldFlashStateBeDisabled()"></div>
+      <div class="step-border-right" ng-disabled="main.shouldFlashStepBeDisabled()"></div>
 
       <svg-icon class="center-block"
         path="../../../assets/drive.svg"
@@ -100,11 +100,11 @@
     <div class="box text-center">
       <svg-icon class="center-block"
         path="../../../assets/flash.svg"
-        ng-disabled="main.shouldFlashStateBeDisabled()"></svg-icon>
+        ng-disabled="main.shouldFlashStepBeDisabled()"></svg-icon>
       <span class="icon-caption"
-        ng-disabled="main.shouldFlashStateBeDisabled()">FLASH IMAGE</span>
+        ng-disabled="main.shouldFlashStepBeDisabled()">FLASH IMAGE</span>
 
-      <span class="badge space-top-medium" ng-disabled="main.shouldFlashStateBeDisabled()">3</span>
+      <span class="badge space-top-medium" ng-disabled="main.shouldFlashStepBeDisabled()">3</span>
 
       <div class="space-vertical-large">
         <progress-button class="button-brick"
@@ -113,7 +113,7 @@
           ng-attr-active="{{ main.state.isFlashing() }}"
           ng-show="main.state.wasLastFlashSuccessful()"
           ng-click="flash.flashImageToDrive(main.selection.getImagePath(), main.selection.getDrive())"
-          ng-disabled="main.shouldFlashStateBeDisabled()">
+          ng-disabled="main.shouldFlashStepBeDisabled()">
             <span ng-bind="flash.getProgressButtonLabel()"></span>
         </progress-button>
 

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -49,7 +49,7 @@ describe('Browser: MainPage', function() {
 
     });
 
-    describe('.shouldFlashStateBeDisabled()', function() {
+    describe('.shouldFlashStepBeDisabled()', function() {
 
       it('should return true if there is no selected drive nor image', function() {
         const controller = $controller('MainController', {
@@ -58,7 +58,7 @@ describe('Browser: MainPage', function() {
 
         SelectionStateModel.clear();
 
-        m.chai.expect(controller.shouldFlashStateBeDisabled()).to.be.true;
+        m.chai.expect(controller.shouldFlashStepBeDisabled()).to.be.true;
       });
 
       it('should return true if there is a selected image but no drive', function() {
@@ -72,7 +72,7 @@ describe('Browser: MainPage', function() {
           size: 99999
         });
 
-        m.chai.expect(controller.shouldFlashStateBeDisabled()).to.be.true;
+        m.chai.expect(controller.shouldFlashStepBeDisabled()).to.be.true;
       });
 
       it('should return true if there is a selected drive but no image', function() {
@@ -93,7 +93,7 @@ describe('Browser: MainPage', function() {
         SelectionStateModel.clear();
         SelectionStateModel.setDrive('/dev/disk2');
 
-        m.chai.expect(controller.shouldFlashStateBeDisabled()).to.be.true;
+        m.chai.expect(controller.shouldFlashStepBeDisabled()).to.be.true;
       });
 
       it('should return false if there is a selected drive and a selected image', function() {
@@ -119,7 +119,7 @@ describe('Browser: MainPage', function() {
           size: 99999
         });
 
-        m.chai.expect(controller.shouldFlashStateBeDisabled()).to.be.false;
+        m.chai.expect(controller.shouldFlashStepBeDisabled()).to.be.false;
       });
 
     });


### PR DESCRIPTION
A function in the `MainController` was being named
`shouldFlashStateBeDisabled`, however it should have been
`shouldFlashStepBeDisabled`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>