### PR TITLE
minifix(CLI): only show final checksum if one exists

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -102,7 +102,11 @@ form.run([
     }
 
     console.log('Your flash is complete!');
-    console.log(`Checksum: ${results.sourceChecksum}`);
+
+    if (results.sourceChecksum) {
+      console.log(`Checksum: ${results.sourceChecksum}`);
+    }
+
   }).then(() => {
     process.exit(EXIT_CODES.SUCCESS);
   });


### PR DESCRIPTION
The Etcher CLI displays a nice `Checksum: $checksum` message upon
completion. Since the addition of bmap support, a checksum for an image
might not be calculated, causing the CLI to display `Checksum:
undefined`.

This PR takes care of this small UX issue by only showing the checksum
message if one indeed exists.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>