### PR TITLE
chore: omit `appdmg` from `npm-shrinkwrap.json`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - gem install scss_lint
   - npm install -g bower
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/linux.sh install x64;
+      ./scripts/build/linux.sh install x64; cat /home/travis/build/resin-io/etcher/npm-debug.log;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       ./scripts/build/darwin.sh install;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -101,23 +101,6 @@
       "from": "any-promise@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
     },
-    "appdmg": {
-      "version": "0.3.10",
-      "from": "appdmg@>=0.3.6 <0.4.0",
-      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.3.10.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        }
-      }
-    },
     "aproba": {
       "version": "1.0.4",
       "from": "aproba@>=1.0.3 <2.0.0",
@@ -473,7 +456,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
@@ -1417,7 +1400,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
@@ -4679,7 +4662,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bin/etcher"
   ],
   "shrinkwrapIgnore": [
+    "appdmg",
     "macos-alias",
     "fs-xattr",
     "diskpart"


### PR DESCRIPTION
This causes some issues on certain Arch Linux systems.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>