### PR TITLE
refactor(GUI): remove `ErrorService.reportException()` ENOSPC workaround

### DIFF
--- a/lib/gui/modules/error.js
+++ b/lib/gui/modules/error.js
@@ -41,14 +41,6 @@ error.service('ErrorService', function(AnalyticsService, OSDialogService) {
    * ErrorService.reportException(new Error('Something happened'));
    */
   this.reportException = (exception) => {
-
-    // This particular error is handled by the alert ribbon
-    // on the main application page.
-    if (exception.code === 'ENOSPC') {
-      AnalyticsService.logEvent('Drive ran out of space');
-      return;
-    }
-
     OSDialogService.showError(exception, exception.description);
     AnalyticsService.logException(exception);
   };


### PR DESCRIPTION
This function used to handle `ENOSPC` as a corner case in order to
prevent it from being shown using the default Analytics/Dialog
machinery. This was because the "alert ribbon" used to react to changes
automatically from the templates, however, now that the "alert ribbon"
was removed, and replaced it with modals, we have finer control of how
and when this error gets shown, so the workaround is no longer
necessary.

See: https://github.com/resin-io/etcher/commit/951b8de9fc76821cf3140bd7e75c2d57ee8def21
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>