### PR TITLE
fix(GUI): don't clear drive selection if clicking "Retry"

### DIFF
--- a/lib/gui/components/flash-error-modal/controllers/flash-error-modal.js
+++ b/lib/gui/components/flash-error-modal/controllers/flash-error-modal.js
@@ -18,7 +18,6 @@
 
 module.exports = function(
   $uibModalInstance,
-  SelectionStateModel,
   FlashStateModel,
   AnalyticsService,
   flashErrorData
@@ -40,10 +39,6 @@ module.exports = function(
    * FlashErrorModalController.retry();
    */
   this.retry = () => {
-    SelectionStateModel.clear({
-      preserveImage: true
-    });
-
     FlashStateModel.resetState();
     AnalyticsService.logEvent('Restart after failure');
     $uibModalInstance.dismiss();

--- a/lib/gui/components/flash-error-modal/flash-error-modal.js
+++ b/lib/gui/components/flash-error-modal/flash-error-modal.js
@@ -24,7 +24,6 @@ const angular = require('angular');
 const MODULE_NAME = 'Etcher.Components.FlashErrorModal';
 const FlashErrorModal = angular.module(MODULE_NAME, [
   require('../modal/modal'),
-  require('../../models/selection-state'),
   require('../../models/flash-state'),
   require('../../modules/analytics')
 ]);


### PR DESCRIPTION
If the user encounters a flash error, and then presses the "Retry"
button, the drive selection is cleared, but then is re-selected right
away because its probably the only available drive, leading to a very
strange behaviour UX-wise.

As a solution, we avoid clearing the drive selection.

Change-Type: patch
Changelog-Entry: Don't clear the drive selection if clicking the "Retry" button.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>