### PR TITLE
feat(GUI): allow disabling auto-update notifications

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -99,6 +99,26 @@ run Etcher on a GNU/Linux system.
 
 - liblzma (for xz decompression)
 
+Disable update notifications
+----------------------------
+
+You can disable update notifications, which can be useful when running Etcher
+outside a common desktop environment (like in a [Resin.io][resin.io]
+application), by setting the `ETCHER_DISABLE_UPDATES` environment variable.
+
+In GNU/Linux and Mac OS X:
+
+```sh
+export ETCHER_DISABLE_UPDATES=1
+```
+
+In Windows:
+
+```sh
+set ETCHER_DISABLE_UPDATES=1
+```
+
+[resin.io]: https://resin.io
 [appimage]: http://appimage.org
 [xwayland]: https://wayland.freedesktop.org/xserver.html
 [weston.ini]: http://manpages.ubuntu.com/manpages/wily/man5/weston.ini.5.html

--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -65,7 +65,7 @@ const app = angular.module('Etcher', [
 app.run((AnalyticsService, UpdateNotifierService, SelectionStateModel) => {
   AnalyticsService.logEvent('Application start');
 
-  if (UpdateNotifierService.shouldCheckForUpdates()) {
+  if (UpdateNotifierService.shouldCheckForUpdates() && !process.env.ETCHER_DISABLE_UPDATES) {
     AnalyticsService.logEvent('Checking for updates');
 
     UpdateNotifierService.isLatestVersion().then((isLatestVersion) => {


### PR DESCRIPTION
This feature is very appealing when running Etcher ouside a common
desktop environment, for example, as a Resin.io application. In such a
platform, an update notifier that points the user to the website makes
no sense, since the platform itself is responsible for the update.

For such cases, we added support for an environment variable called
`ETCHER_DISABLE_UPDATES`, that when set, will prevent the update check
altogether.

Change-Type: minor
Changelog-Entry: Allow the user to disable auto-update notifications with an environment variable.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>