### PR TITLE
upgrade: `etcher-image-write` to v8.1.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -343,6 +343,11 @@
       "from": "async-foreach@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+    },
     "autolinker": {
       "version": "0.15.3",
       "from": "autolinker@>=0.15.0 <0.16.0",
@@ -404,9 +409,9 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "lodash": {
-          "version": "4.15.0",
+          "version": "4.16.1",
           "from": "lodash@>=4.14.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.1.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
@@ -1410,9 +1415,9 @@
       }
     },
     "etcher-image-write": {
-      "version": "8.1.0",
-      "from": "etcher-image-write@8.1.0",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-8.1.0.tgz",
+      "version": "8.1.2",
+      "from": "etcher-image-write@8.1.2",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-8.1.2.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "drivelist": "^3.3.3",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^4.3.0",
-    "etcher-image-write": "^8.1.0",
+    "etcher-image-write": "^8.1.2",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This version contains a fix for incorrect validation errors being
reported when flashing bzip2 files due to incorrect slicing of the drive
stream when calculating the checksum.

See: https://github.com/resin-io-modules/etcher-image-write/pull/61
Change-Type: patch
Changelog-Entry: Fix incorrect validation errors when flashing bzip2 images.
Fixes: https://github.com/resin-io/etcher/issues/710
Fixes: https://github.com/resin-io/etcher/issues/709
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>