### PR TITLE
upgrade: `drivelist` to v3.3.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -343,6 +343,11 @@
       "from": "async-foreach@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+    },
     "autolinker": {
       "version": "0.15.3",
       "from": "autolinker@>=0.15.0 <0.16.0",
@@ -1143,9 +1148,9 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "3.3.3",
-      "from": "drivelist@3.3.3",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.3.tgz",
+      "version": "3.3.4",
+      "from": "drivelist@3.3.4",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.4.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^3.3.3",
+    "drivelist": "^3.3.4",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^4.3.0",
     "etcher-image-write": "^8.1.0",


### PR DESCRIPTION
This new version contains a fix for a very weird `cscript is not
recognised` error reported long ago.

Change-Type: patch
Changelog-Entry: Fix "cscript is not recognised as an internal or external command" Windows error.
Fixes: https://github.com/resin-io/etcher/issues/552
See: https://github.com/resin-io-modules/drivelist/pull/95
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>