### PR TITLE
chore: apply HFS+ compression to *.app in OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ install:
       ./scripts/build/linux.sh install x64;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew install afsctool;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       ./scripts/build/darwin.sh install;
     fi
 

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -25,6 +25,7 @@ Prerequisites
 ### OS X
 
 - [XCode](https://developer.apple.com/xcode/)
+- [afsctool](https://brkirch.wordpress.com/afsctool/)
 
 Cloning the project
 -------------------

--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -37,6 +37,11 @@ if ! command -v python 2>/dev/null; then
   exit 1
 fi
 
+if ! command -v afsctool 2>/dev/null; then
+  echo "Dependency missing: afsctool" 1>&2
+  exit 1
+fi
+
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <command>" 1>&2
   exit 1
@@ -193,6 +198,9 @@ function installer_dmg {
      end tell
   ' | osascript
   sync
+
+  # Apply HFS+ compression
+  afsctool -ci -9 $volume_app
 
   sign $volume_app
 


### PR DESCRIPTION
This results in ~10MB savings, which is not much, but still worth
reducing as much as we can.

See: https://github.com/resin-io/etcher/issues/711
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>