### PR TITLE
upgrade: `etcher-image-write` to v8.1.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1415,9 +1415,9 @@
       }
     },
     "etcher-image-write": {
-      "version": "8.1.2",
-      "from": "etcher-image-write@8.1.2",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-8.1.2.tgz",
+      "version": "8.1.3",
+      "from": "etcher-image-write@8.1.3",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-8.1.3.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "drivelist": "^3.3.4",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^4.3.0",
-    "etcher-image-write": "^8.1.2",
+    "etcher-image-write": "^8.1.3",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This version contains an important fix for the sporadic EPERM issues
encountered on Windows systems.

Fixes: https://github.com/resin-io/etcher/issues/627
Link: https://github.com/resin-io-modules/etcher-image-write/blob/master/CHANGELOG.md
Change-Type: patch
Changelog-Entry: Fix sporadic EPERM write errors on Windows.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>