### PR TITLE
fix(GUI): no write after elevation in GNU/Linux

### DIFF
--- a/lib/src/child-writer/writer-proxy.js
+++ b/lib/src/child-writer/writer-proxy.js
@@ -131,6 +131,12 @@ return isElevated().then((elevated) => {
       if (process.env.APPIMAGE && process.env.APPDIR) {
         const mountPoint = process.env.APPDIR + '-elevated';
 
+        // Translate the current arguments to
+        // point to the new mount location.
+        const translatedArguments = _.map(process.argv, (argv) => {
+          return argv.replace(process.env.APPDIR, mountPoint);
+        });
+
         // We wrap the command with `sh -c` since it seems
         // the only way to effectively run many commands
         // with a graphical sudo interface,
@@ -155,13 +161,7 @@ return isElevated().then((elevated) => {
           '&&'
         ]
         .concat(commandPrefix)
-
-        // Translate the current arguments to
-        // point to the new mount location.
-        .concat(_.map(process.argv, (argv) => {
-          return argv.replace(process.env.APPDIR, mountPoint);
-        }))
-
+        .concat(utils.escapeWhiteSpacesFromArguments(translatedArguments))
         .concat([
           ';',
 


### PR DESCRIPTION
When the application is packaged as an AppImage, we're accidentally not
applying the whitespace escaping routine, causing images that contain
white spaces to cause Etcher to stall and never start the write.

The issue was even harder to debug given that the problem was not
reproducible when running Etcher from `npm start`.

Change-Type: patch
Changelog-Entry: Fix flashing never starting after elevation in GNU/Linux.
Fixes: https://github.com/resin-io/etcher/issues/631
Fixes: https://github.com/resin-io/etcher/issues/665
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>