### PR TITLE
docs: require at least NodeJS v6 to build Etcher

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -9,7 +9,7 @@ Prerequisites
 
 ### Common
 
-- [NodeJS](https://nodejs.org)
+- [NodeJS](https://nodejs.org) (at least v6)
 - [Bower](http://bower.io)
 - [UPX](http://upx.sourceforge.net)
 - [Python](https://www.python.org)


### PR DESCRIPTION
Some of the packaging modules that we use don't work on previous NodeJS
versions.

Fixes: https://github.com/resin-io/etcher/issues/725
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>