### PR TITLE
Change where the "Image Name" gets displayed, and display basename(imagepath) as a tooltip on the truncated imagename

### DIFF
--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -2,7 +2,7 @@
   <div class="col-xs" ng-controller="ImageSelectionController as image">
     <div class="box text-center" os-dropzone="image.selectImage($file)">
       <svg-icon class="center-block" path="{{ main.selection.getImageLogo() || '../../../assets/image.svg' }}"></svg-icon>
-      <span class="icon-caption">SELECT IMAGE</span>
+      <span class="icon-caption">{{ main.selection.getImageName() || "SELECT IMAGE" }}</span>
       <span class="badge space-top-medium">1</span>
 
       <div class="space-vertical-large">
@@ -18,7 +18,8 @@
         <div ng-if="main.selection.hasImage()">
           <div class="step-selection-text"
             ng-click="main.external.open(main.selection.getImageUrl())"
-            ng-bind="main.selection.getImageName() || main.selection.getImagePath() | basename | middleEllipses:25"></div>
+            ng-bind="main.selection.getImagePath() | basename | middleEllipses:25"
+            uib-tooltip="{{ main.selection.getImagePath() | basename }}"></div>
 
           <button class="button button-link step-tooltip"
             ng-click="main.tooltipModal.show({


### PR DESCRIPTION
Fixes a couple of the problems identified in #716 
