### PR TITLE
Move upx compression to appimage command in linux build script

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -32,11 +32,6 @@ if ! command -v bower 2>/dev/null; then
   exit 1
 fi
 
-if ! command -v upx 2>/dev/null; then
-  echo "Dependency missing: upx" 1>&2
-  exit 1
-fi
-
 if ! command -v python 2>/dev/null; then
   echo "Dependency missing: python" 1>&2
   exit 1
@@ -51,6 +46,13 @@ COMMAND=$1
 if [ "$COMMAND" != "install" ] && [ "$COMMAND" != "package" ] && [ "$COMMAND" != "appimage" ] && [ "$COMMAND" != "all" ]; then
   echo "Unknown command: $COMMAND" 1>&2
   exit 1
+fi
+
+if [ "$COMMAND" == "appimage" ] || [ "$COMMAND" == "all" ]; then
+  if ! command -v upx 2>/dev/null; then
+    echo "Dependency missing: upx" 1>&2
+    exit 1
+  fi
 fi
 
 ARCH=$2

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -102,11 +102,6 @@ function package_x86 {
 
   mv $output_package/Etcher $output_package/etcher
   chmod a+x $output_package/*.so*
-
-  # UPX fails for some reason with some other so libraries
-  # other than libnode.so in the x86 build
-  upx -9 $output_package/etcher $output_package/libnode.so
-
 }
 
 function package_x64 {
@@ -126,7 +121,6 @@ function package_x64 {
 
   mv $output_package/Etcher $output_package/etcher
   chmod a+x $output_package/*.so*
-  upx -9 $output_package/etcher $output_package/*.so*
 }
 
 function app_dir_create {
@@ -177,5 +171,15 @@ if [ "$COMMAND" == "package" ] || [ "$COMMAND" == "all" ]; then
 fi
 
 if [ "$COMMAND" == "appimage" ] || [ "$COMMAND" == "all" ]; then
+  if [ "$ARCH" == "x86" ]; then
+    # UPX fails for some reason with some other so libraries
+    # other than libnode.so in the x86 build
+    upx -9 $output_package/etcher $output_package/libnode.so
+  fi
+
+  if [ "$ARCH" == "x64" ]; then
+    upx -9 $output_package/etcher $output_package/*.so*
+  fi
+
   installer etcher-release/Etcher-linux-$ARCH $ARCH etcher-release/installers
 fi


### PR DESCRIPTION
Debian packaging tools cannot analyze the binaries if they are compressed
with upx. If we move the compression to the appimage command, then the
output of the package command can be used for building debian packages.