### PR TITLE
docs: clarify that the install script doesn't install pre-requisites

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -35,12 +35,15 @@ git clone https://github.com/resin-io/etcher
 cd etcher
 ```
 
-Installing dependencies
------------------------
+Installing npm dependencies
+---------------------------
 
-Please make use of the following scripts to install dependencies rather than
-simply running `npm install` given that we need to do extra configuration to
-make sure native dependencies are correctly compiled for Electron, otherwise
+**Make sure you have all the pre-requisites listed above installed in your
+system before running the `install` script.**
+
+Please make use of the following scripts to install npm dependencies rather
+than simply running `npm install` given that we need to do extra configuration
+to make sure native dependencies are correctly compiled for Electron, otherwise
 the application might not run successfully.
 
 ### OS X


### PR DESCRIPTION
We list all the pre-requisites needed to get up and running with Etcher,
and then say "run this script to install dependencies", which can be
interpreted as if the install script actually also installs the
pre-requisites, which is not the case.

To clarify this, we add a clear bold notice, and change "dependencies"
to "npm dependencies", to make the distinction clearer.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>