### PR TITLE
upgrade: `etcher-image-stream` to v5.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "etcher",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -1403,9 +1403,9 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "etcher-image-stream": {
-      "version": "4.3.0",
-      "from": "etcher-image-stream@4.3.0",
-      "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-4.3.0.tgz",
+      "version": "5.1.0",
+      "from": "etcher-image-stream@5.1.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-stream/-/etcher-image-stream-5.1.0.tgz",
       "dependencies": {
         "yauzl": {
           "version": "2.6.0",
@@ -4716,7 +4716,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@~1.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.5",
@@ -5341,7 +5341,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "chalk": "^1.1.3",
     "drivelist": "^3.3.4",
     "electron-is-running-in-asar": "^1.0.0",
-    "etcher-image-stream": "^4.3.0",
+    "etcher-image-stream": "^5.1.0",
     "etcher-image-write": "^8.1.3",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",

--- a/tests/gui/models/supported-formats.spec.js
+++ b/tests/gui/models/supported-formats.spec.js
@@ -41,7 +41,7 @@ describe('Browser: SupportedFormats', function() {
 
       it('should return the supported archive extensions', function() {
         const extensions = SupportedFormatsModel.getArchiveExtensions();
-        m.chai.expect(extensions).to.deep.equal([ 'zip' ]);
+        m.chai.expect(extensions).to.deep.equal([ 'zip', 'etch' ]);
       });
 
     });


### PR DESCRIPTION
We're particularly interested in the following change:

- Add `etch` support.

Also:

- Add a `.description` property to all archive related errors.
- Rename archive metadata base path from `_info` to `.meta`.

Change-Type: minor
Changelog-Entry: Add support for `etch` images.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>