### PR TITLE
fix(GUI): don't clear selection state when re-selecting an image

### DIFF
--- a/lib/gui/pages/main/controllers/image-selection.js
+++ b/lib/gui/pages/main/controllers/image-selection.js
@@ -97,13 +97,6 @@ module.exports = function(SupportedFormatsModel, SelectionStateModel, AnalyticsS
    * ImageSelectionController.reselectImage();
    */
   this.reselectImage = () => {
-
-    // Reselecting an image automatically
-    // de-selects the current drive, if any.
-    // This is made so the user effectively
-    // "returns" to the first step.
-    SelectionStateModel.clear();
-
     this.openImageSelector();
     AnalyticsService.logEvent('Reselect image');
   };


### PR DESCRIPTION
Currently, if the "CHANGE" label at the bottom of the image selection
step, once an image has been selected, is clicked, the selection state
is cleared.

Since https://github.com/resin-io/etcher/pull/602, we allow the drive
state to change independently of the image selection state, so the above
behaviour doesn't make sense anymore.

Fixes: https://github.com/resin-io/etcher/issues/730
Change-Type: patch
Changelog-Entry: Don't clear selection state when re-selecting an image.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>