### PR TITLE
style(GUI): say "eject" instead of "unmount" in Windows

### DIFF
--- a/lib/gui/pages/settings/controllers/settings.js
+++ b/lib/gui/pages/settings/controllers/settings.js
@@ -16,7 +16,17 @@
 
 'use strict';
 
+const os = require('os');
+
 module.exports = function(WarningModalService, SettingsModel) {
+
+  /**
+   * @summary Client platform
+   * @type String
+   * @constant
+   * @public
+   */
+  this.platform = os.platform();
 
   /**
    * @summary Refresh current settings

--- a/lib/gui/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/pages/settings/templates/settings.tpl.html
@@ -17,7 +17,16 @@
         ng-model="settings.currentData.unmountOnSuccess"
         ng-change="settings.model.set('unmountOnSuccess', settings.currentData.unmountOnSuccess)">
 
-      <span>Auto-unmount on success</span>
+      <!-- On Windows, "Unmounting" basically means "ejecting". -->
+      <!-- On top of that, Windows users are usually not even -->
+      <!-- familiar with the meaning of "unmount", which comes -->
+      <!-- from the UNIX world. -->
+
+      <span>
+        <span ng-show="settings.platform == 'win32'">Eject</span>
+        <span ng-hide="settings.platform == 'win32'">Auto-unmount</span>
+        on success
+      </span>
     </label>
   </div>
 


### PR DESCRIPTION
In Windows, if the user unmounts a drive, then the drive becomes
inaccessible to the OS. Compare this to UNIX based operating systems,
where an unmounted drive is still available for many I/O operations.

To prevent confusion, we say "eject" instead of "unmount" when running
on Windows, despite "unmount" being the correct way of saying it.

See: https://github.com/resin-io/etcher/issues/750
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>