### PR TITLE
chore: only alias CXX to specific gcc versions on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - rvm use $RUBY_VERSION
 
 install:
-  - if [ "$CXX" = "g++" ]; then
+  - if [ "$CXX" = "g++" ] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       export CXX="g++-4.8" CC="gcc-4.8";
     fi
   - gem install scss_lint


### PR DESCRIPTION
There is no `g++-4.8` binary in OS X in Travis CI anymore for some
reason.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>