### PR TITLE
docs(GUI): no polkit authentication agent found Linux error

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -166,6 +166,15 @@ command as `root`, replacing `xxx` by your actual device path:
 dd if=/dev/zero of=/dev/xxx bs=512 count=1 conv=notrunc
 ```
 
+"No polkit authentication agent found" error in GNU/Linux
+----------------------------------------------------------
+
+Etcher requires an available [polkit authentication
+agent](https://wiki.archlinux.org/index.php/Polkit#Authentication_agents) in
+your system in order to show a secure password prompt dialog to perform
+elevation. Make sure you have one installed for the desktop environment of your
+choice.
+
 [resin.io]: https://resin.io
 [appimage]: http://appimage.org
 [xwayland]: https://wayland.freedesktop.org/xserver.html


### PR DESCRIPTION
Document the need to have a polkit authentication running in GNU/Linux
to be able to go through the authentication system.

Fixes: https://github.com/resin-io/etcher/issues/756
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>