### PR TITLE
chore(debian): add depedency on polkit package

### DIFF
--- a/scripts/build/debian/config.json
+++ b/scripts/build/debian/config.json
@@ -39,7 +39,8 @@
     "libxrandr2",
     "libxrender1",
     "libxss1",
-    "libxtst6"
+    "libxtst6",
+    "polkit-1-auth-agent | policykit-1-gnome | polkit-kde-1"
   ],
   "recommends": [
     "libnotify4"


### PR DESCRIPTION
A policy kit authentication agent is needed for privilege escalation.

See: https://github.com/resin-io/etcher/issues/756#issuecomment-253298322