### PR TITLE
Include Etcher version in installer/archive names

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -114,33 +114,33 @@ function installer_zip {
   mkdir -p $output_directory
   sign $source_directory/$APPLICATION_NAME.app
   pushd $source_directory
-  zip -r -9 Etcher-darwin-x64.zip $APPLICATION_NAME.app
+  zip -r -9 Etcher-$APPLICATION_VERSION-darwin-x64.zip $APPLICATION_NAME.app
   popd
-  mv $source_directory/Etcher-darwin-x64.zip $output_directory
+  mv $source_directory/Etcher-$APPLICATION_VERSION-darwin-x64.zip $output_directory
 }
 
 function installer_dmg {
   local source_directory=$1
   local output_directory=$2
-  local temporal_dmg=$source_directory.dmg
+  local temporary_dmg=$source_directory.dmg
   local volume_directory=/Volumes/$APPLICATION_NAME
   local volume_app=$volume_directory/$APPLICATION_NAME.app
 
   # Make sure any previous DMG was unmounted
   hdiutil detach $volume_directory || true
 
-  # Create temporal read-write DMG image
-  rm -f $temporal_dmg
+  # Create temporary read-write DMG image
+  rm -f $temporary_dmg
   hdiutil create \
     -srcfolder $source_directory \
     -volname "$APPLICATION_NAME" \
     -fs HFS+ \
     -fsargs "-c c=64,a=16,e=16" \
     -format UDRW \
-    -size 600M $temporal_dmg
+    -size 600M $temporary_dmg
 
-  # Mount temporal DMG image, so we can modify it
-  hdiutil attach $temporal_dmg -readwrite -noverify
+  # Mount temporary DMG image, so we can modify it
+  hdiutil attach $temporary_dmg -readwrite -noverify
 
   # Wait for a bit to ensure the image is mounted
   sleep 2
@@ -204,20 +204,20 @@ function installer_dmg {
 
   sign $volume_app
 
-  # Unmount temporal DMG image.
+  # Unmount temporary DMG image.
   hdiutil detach $volume_directory
 
-  # Convert temporal DMG image into a production-ready
+  # Convert temporary DMG image into a production-ready
   # compressed and read-only DMG image.
   mkdir -p $output_directory
   rm -f $output_directory/Etcher-darwin-x64.dmg
-  hdiutil convert $temporal_dmg \
+  hdiutil convert $temporary_dmg \
     -format UDZO \
     -imagekey zlib-level=9 \
-    -o $output_directory/Etcher-darwin-x64.dmg
+    -o $output_directory/Etcher-$APPLICATION_VERSION-darwin-x64.dmg
 
-  # Cleanup temporal DMG image.
-  rm $temporal_dmg
+  # Cleanup temporary DMG image.
+  rm $temporary_dmg
 
 }
 

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -158,7 +158,7 @@ function installer {
   ./scripts/build/AppImages/AppImageAssistant-$architecture $appdir_temporary_location $output_file
 
   pushd $output_directory
-  zip Etcher-linux-$architecture.zip Etcher-linux-$architecture.AppImage
+  zip Etcher-$APPLICATION_VERSION-linux-$architecture.zip Etcher-linux-$architecture.AppImage
   rm Etcher-linux-$architecture.AppImage
   popd
 

--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -132,8 +132,6 @@ if "%arch%"=="x64" (
   set electron_arch=x64
 )
 
-set package_name=Etcher-win32-%arch%
-
 for /f %%i in (' "node -e ""console.log(require('./package.json').devDependencies['electron-prebuilt'])""" ') do (
   set electron_version=%%i
 )
@@ -157,6 +155,8 @@ for /f %%i in (' "node -e ""console.log(require('./package.json').version)""" ')
 for /f %%i in (' "node -v" ') do (
   set node_version=%%i
 )
+
+set package_name=Etcher-%etcher_version%-win32-%arch%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Configure NPM to build native addons for Electron correctly
@@ -214,8 +214,10 @@ call %electron_packager% . %application_name%^
 set package_output=%output_build_directory%\%package_name%
 
 if not "%arch%"=="%electron_arch%" (
-  move %output_build_directory%\Etcher-win32-%electron_arch% %package_output%
-)
+    move %output_build_directory%\Etcher-win32-%electron_arch% %output_build_directory%\Etcher-win32-%arch%
+) 
+
+move %output_build_directory%\Etcher-win32-%arch% %package_output%
 
 :: Omit *.dll and *.node files from the asar package, otherwise
 :: `process.dlopen` and `module.require` can't load them correctly.
@@ -242,7 +244,7 @@ cd %package_output%^
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 set installer_tmp_output=%output_build_directory%\win32-%arch%-tmp-installer
-set installer_output=%output_directory%\Etcher-win32-%arch%.exe
+set installer_output=%output_directory%\%package_name%.exe
 
 call %electron_builder% %package_output%^
  --platform=win^


### PR DESCRIPTION
This works towards #763 on Windows, in theory. I haven't tested it (because installing the dependencies would be a pain) but it seems to be the right thing to do. This does not make any changes for other OSes.