### PR TITLE
fix(GUI): drag and drop not working anymore

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -57,6 +57,7 @@ const app = angular.module('Etcher', [
   // OS
   require('./os/window-progress/window-progress'),
   require('./os/open-external/open-external'),
+  require('./os/dropzone/dropzone'),
 
   // Utils
   require('./utils/manifest-bind/manifest-bind')

--- a/lib/gui/pages/main/main.js
+++ b/lib/gui/pages/main/main.js
@@ -40,6 +40,7 @@ const MainPage = angular.module(MODULE_NAME, [
   require('../../os/notification/notification'),
   require('../../os/dialog/dialog'),
   require('../../os/open-external/open-external'),
+  require('../../os/dropzone/dropzone'),
 
   require('../../modules/drive-scanner'),
   require('../../modules/image-writer'),


### PR DESCRIPTION
The "dropzone" directive, which we use to implement drag and drop
support, was not being loaded in the application at all for some reason.
It was probably accidentally deleted during major refactorings.

Change-Type: patch
Changelog-Entry: Fix drag and drop not working anymore.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>