### PR TITLE
chore: fix output_package unbound variable in GNU/Linux

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -197,15 +197,19 @@ if [ "$COMMAND" == "debian" ] || [ "$COMMAND" == "all" ]; then
 fi
 
 if [ "$COMMAND" == "appimage" ] || [ "$COMMAND" == "all" ]; then
+  package_directory=etcher-release/Etcher-linux-$ARCH
+
   if [ "$ARCH" == "x86" ]; then
+
     # UPX fails for some reason with some other so libraries
     # other than libnode.so in the x86 build
-    upx -9 $output_package/etcher $output_package/libnode.so
+    upx -9 $package_directory/etcher $package_directory/libnode.so
+
   fi
 
   if [ "$ARCH" == "x64" ]; then
-    upx -9 $output_package/etcher $output_package/*.so*
+    upx -9 $package_directory/etcher $package_directory/*.so*
   fi
 
-  installer etcher-release/Etcher-linux-$ARCH $ARCH etcher-release/installers
+  installer $package_directory $ARCH etcher-release/installers
 fi


### PR DESCRIPTION
The `$output_package` variable is defined inside the `package_x$ARCH`
functions, which means that if we run the following commands:

```sh
./scripts/build/linux.sh package x64
./scripts/build/linux.sh appimage x64
```

The `$output_package` variable will not be defined when the script runs
the `appimage` command.

To workaround this issue, we declare a new `$package_directory` variable
inside the `appimage` command clause.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>