### PR TITLE
fix(GUI): correctly escape single quotes when running inside AppImage

### DIFF
--- a/lib/src/child-writer/utils.js
+++ b/lib/src/child-writer/utils.js
@@ -111,19 +111,32 @@ exports.getCLIWriterArguments = (options) => {
 };
 
 /**
- * @summary Escape white spaces from arguments
+ * @summary Escape arguments
  * @function
  * @public
  *
  * @param {String[]} argv - argv
+ * @param {Object} [options={}] - options
+ * @param {Boolean} [options.willBeSurroundedInSingleQuotes=false] - will be surrounded in single quotes
  * @returns {String[]} escaped arguments
  *
  * @example
- * const escapedArguments = utils.escapeWhiteSpacesFromArguments(process.argv);
+ * const escapedArguments = utils.escapeArguments(process.argv, {
+ *   willBeSurroundedInSingleQuotes: true
+ * });
  */
-exports.escapeWhiteSpacesFromArguments = (argv) => {
+exports.escapeArguments = (argv, options = {}) => {
   return _.map(argv, (argument) => {
-    return argument.replace(/\s/g, '\\ ');
+    const escapedArgument = argument.replace(/\s/g, '\\ ');
+
+    if (options.willBeSurroundedInSingleQuotes) {
+
+      // See http://stackoverflow.com/a/1250279/1641422
+      return escapedArgument.replace(/'/g, '\'"\'"\'');
+
+    }
+
+    return escapedArgument;
   });
 };
 

--- a/lib/src/child-writer/writer-proxy.js
+++ b/lib/src/child-writer/writer-proxy.js
@@ -161,7 +161,9 @@ return isElevated().then((elevated) => {
           '&&'
         ]
         .concat(commandPrefix)
-        .concat(utils.escapeWhiteSpacesFromArguments(translatedArguments))
+        .concat(utils.escapeArguments(translatedArguments, {
+          willBeSurroundedInSingleQuotes: true
+        }))
         .concat([
           ';',
 
@@ -177,7 +179,7 @@ return isElevated().then((elevated) => {
       }
 
       return commandPrefix.concat(
-        utils.escapeWhiteSpacesFromArguments(process.argv)
+        utils.escapeArguments(process.argv)
       ).join(' ');
     });
 


### PR DESCRIPTION
If the application is running from inside an AppImage, the command that
is elevated gets passed as an argument to `sh -c` surrounded by single
quotes.

This means that the usual way of escaping single quotes (with a
backslash), takes no effect:

> Enclosing characters in single quotes preserves the literal value of
> each character within the quotes. A single quote may not occur between
> single quotes, even when preceded by a backslash.
>
> From http://stackoverflow.com/a/1250098/1641422

In this case, the solution is really hacky and obscure: replace single
quotes with `'"'"'`, which ends up being parsed as `'` by the shell.

The following changes have been introduced to accomodate to the above
workaround:

- Rename `utils.escapeWhiteSpacesFromArguments` to
  `utils.escapeArguments`.

- Accept an `willBeSurroundedInSingleQuotes` boolean option in
  `utils.escapeArguments`.

- Make `writer-proxy.js` pass the `willBeSurroundedInSingleQuotes` when
  elevating inside an AppImage.

See: http://stackoverflow.com/a/1250279/1641422
Fixes: https://github.com/resin-io/etcher/issues/738
Change-Type: patch
Changelog-Entry: Fix "Command Failed" error when attempting to flash an image containing a single quote anywhere in the path in GNU/Linux.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>