### PR TITLE
chore: create standalone Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - npm install -g npm bower rimraf asar
   - choco install nsis -version 2.51
   - choco install upx
+  - choco install 7zip.commandline
   - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
   - set PATH=C:\Program Files (x86)\NSIS;%PATH%
   - set PATH=C:\Ruby22\bin;%PATH%

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -21,6 +21,7 @@ Prerequisites
 - [Asar](https://github.com/electron/asar)
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
 - [Visual Studio Community 2013](https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx)
+- [7z](http://www.7-zip.org) (command line version)
 
 ### OS X
 

--- a/scripts/build/windows.bat
+++ b/scripts/build/windows.bat
@@ -102,10 +102,17 @@ if %ERRORLEVEL% neq 0 (
   exit /b 1
 )
 
-:: Check that asar is installed.
+:: Check that python is installed.
 where python >nul 2>nul
 if %ERRORLEVEL% neq 0 (
   echo Dependency missing: python 1>&2
+  exit /b 1
+)
+
+:: Check that 7z is installed.
+where 7z >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Dependency missing: 7z 1>&2
   exit /b 1
 )
 
@@ -225,6 +232,10 @@ signtool sign^
 signtool verify /pa /v %package_output%\Etcher.exe
 
 upx -9 %package_output%\*.dll
+
+cd %package_output%^
+ && 7z a -tzip ..\installers\%package_name%.zip *^
+ && cd ..\..
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Generate installer


### PR DESCRIPTION
This PR zips the package that is built by running:

```sh
.\scripts\build\windows.bat package <arch>
```

And puts it in `etcher-release/installers`.

Fixes: https://github.com/resin-io/etcher/issues/760
Change-Type: minor
Changelog-Entry: Publish standalone Windows builds.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>