### PR TITLE
feat(GUI): use info icon instead of "SHOW FULL FILE NAME"

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6465,6 +6465,24 @@ body {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.modal-warning-modal .modal-title .glyphicon, .modal-warning-modal .modal-title .tick {
+  color: #d9534f; }
+
+/*
+ * Copyright 2016 Resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 .page-main .icon-caption {
   display: block;
   margin-left: auto;
@@ -6540,6 +6558,9 @@ body {
   border-radius: 0;
   padding: 0; }
 
+.page-main .glyphicon, .page-main .tick {
+  vertical-align: text-top; }
+
 /*
  * Copyright 2016 Resin.io
  *
@@ -6568,9 +6589,6 @@ body {
   color: #fff;
   margin-top: 30px;
   margin-bottom: 15px; }
-
-.modal-settings-dangerous-modal .modal-title .glyphicon, .modal-settings-dangerous-modal .modal-title .tick {
-  color: #d9534f; }
 
 /*
  * Copyright 2016 Resin.io

--- a/lib/gui/pages/main/styles/_main.scss
+++ b/lib/gui/pages/main/styles/_main.scss
@@ -114,3 +114,7 @@
   border-radius: 0;
   padding: 0;
 }
+
+.page-main .glyphicon {
+  vertical-align: text-top;
+}

--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -16,16 +16,16 @@
           </p>
         </div>
         <div ng-if="main.selection.hasImage()">
-          <div class="step-selection-text"
-            ng-click="main.external.open(main.selection.getImageUrl())"
-            ng-bind="main.selection.getImageName() || main.selection.getImagePath() | basename | middleEllipses:25"
-            uib-tooltip="{{ main.selection.getImagePath() | basename }}"></div>
+          <div class="step-selection-text">
+            <span ng-click="main.external.open(main.selection.getImageUrl())"
+              ng-bind="main.selection.getImageName() || main.selection.getImagePath() | basename | middleEllipses:20"
+              uib-tooltip="{{ main.selection.getImagePath() | basename }}"></span>
 
-          <button class="button button-link step-tooltip"
-            ng-click="main.tooltipModal.show({
+            <span class="glyphicon glyphicon-info-sign" ng-click="main.tooltipModal.show({
               title: 'IMAGE FILE NAME',
               message: main.selection.getImagePath()
-            })">SHOW FULL FILE NAME</button>
+            })"></span>
+          </div>
 
           <button class="button button-link step-footer"
             ng-click="image.reselectImage()"


### PR DESCRIPTION
The main purpose of this change is to simplify the interface and avoid
unnecessary text.

![screenshot 2016-10-24 14 17 36](https://cloud.githubusercontent.com/assets/2192773/19658178/f905a968-99f4-11e6-8f92-2a3eaa83da73.png)

Fixes: https://github.com/resin-io/etcher/issues/742
Change-Type: minor
Changelog-Entry: Use info icon instead of "SHOW FULL FILE NAME" in first step.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>