### PR TITLE
refactor: use local variables in shell functions in build scripts

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -76,7 +76,7 @@ function install {
 }
 
 function package {
-  output_directory=$1
+  local output_directory=$1
 
   $ELECTRON_PACKAGER . $APPLICATION_NAME \
     --platform=darwin \
@@ -100,7 +100,7 @@ function package {
 }
 
 function sign {
-  source_application=$1
+  local source_application=$1
 
   $ELECTRON_OSX_SIGN $source_application --platform darwin --verbose --identity "$SIGN_IDENTITY_OSX"
   codesign --verify --deep --display --verbose=4 $source_application
@@ -108,8 +108,8 @@ function sign {
 }
 
 function installer_zip {
-  source_directory=$1
-  output_directory=$2
+  local source_directory=$1
+  local output_directory=$2
 
   mkdir -p $output_directory
   sign $source_directory/$APPLICATION_NAME.app
@@ -120,11 +120,11 @@ function installer_zip {
 }
 
 function installer_dmg {
-  source_directory=$1
-  output_directory=$2
-  temporal_dmg=$source_directory.dmg
-  volume_directory=/Volumes/$APPLICATION_NAME
-  volume_app=$volume_directory/$APPLICATION_NAME.app
+  local source_directory=$1
+  local output_directory=$2
+  local temporal_dmg=$source_directory.dmg
+  local volume_directory=/Volumes/$APPLICATION_NAME
+  local volume_app=$volume_directory/$APPLICATION_NAME.app
 
   # Make sure any previous DMG was unmounted
   hdiutil detach $volume_directory || true

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -77,7 +77,7 @@ APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
 function install {
 
   # Can be either "x64" or "ia32"
-  architecture=$1
+  local architecture=$1
 
   # Ensure native addons are compiled with the correct headers
   # See https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md
@@ -92,8 +92,8 @@ function install {
 }
 
 function package_x86 {
-  output_directory=$1
-  output_package=$output_directory/Etcher-linux-x86
+  local output_directory=$1
+  local output_package=$output_directory/Etcher-linux-x86
 
   $ELECTRON_PACKAGER . $APPLICATION_NAME \
     --platform=linux \
@@ -114,8 +114,8 @@ function package_x86 {
 }
 
 function package_x64 {
-  output_directory=$1
-  output_package=$output_directory/Etcher-linux-x64
+  local output_directory=$1
+  local output_package=$output_directory/Etcher-linux-x64
 
   $ELECTRON_PACKAGER . $APPLICATION_NAME \
     --platform=linux \
@@ -133,9 +133,9 @@ function package_x64 {
 }
 
 function app_dir_create {
-  source_directory=$1
-  architecture=$2
-  output_directory=$3
+  local source_directory=$1
+  local architecture=$2
+  local output_directory=$3
 
   mkdir -p $output_directory/usr/bin
   cp ./scripts/build/AppImages/AppRun-$architecture $output_directory/AppRun
@@ -146,11 +146,11 @@ function app_dir_create {
 }
 
 function installer {
-  source_directory=$1
-  architecture=$2
-  output_directory=$3
-  appdir_temporary_location=$output_directory/Etcher-linux-$architecture.AppDir
-  output_file=$output_directory/Etcher-linux-$architecture.AppImage
+  local source_directory=$1
+  local architecture=$2
+  local output_directory=$3
+  local appdir_temporary_location=$output_directory/Etcher-linux-$architecture.AppDir
+  local output_file=$output_directory/Etcher-linux-$architecture.AppImage
 
   mkdir -p $output_directory
   app_dir_create $source_directory $architecture $appdir_temporary_location


### PR DESCRIPTION
We translate function arguments (e.g: `$1`, `$2`, etc) to readable names
using shell variables in the top of every shell function in the build
scripts.

Since we were not declaring these variables as `local`, two functions
using the same "argument name" would override each other.

For example:

```sh
function foo() {
  variable=$1
  # Do something with $variable
}

function bar() {
  variable=$1
  # Do something with $variable
}

foo "Hello World"
echo $variable
> Hello World

bar "Changed variable"
echo $variable
> Changed variable
```

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>