### PR TITLE
chore: distribute AppImage inside a zip

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -156,6 +156,12 @@ function installer {
   app_dir_create $source_directory $architecture $appdir_temporary_location
   rm -f $output_file
   ./scripts/build/AppImages/AppImageAssistant-$architecture $appdir_temporary_location $output_file
+
+  pushd $output_directory
+  zip Etcher-linux-$architecture.zip Etcher-linux-$architecture.AppImage
+  rm Etcher-linux-$architecture.AppImage
+  popd
+
   rm -rf $appdir_temporary_location
 }
 


### PR DESCRIPTION
AppImages need to be marked as executables before they can be used.
Distributing them directly means that virtually all web browsers will
automatically remove the execution permissions, leading us to have to
explain users how to add it back with `chmod`, etc.

For simplicity purposes, we'll be distributing AppImages inside ZIPs,
which ensure the execution permissions are added back when the user
decompresses it.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>