### PR TITLE
chore: Fix minor install script problems

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -88,7 +88,7 @@ function install {
 
   rm -rf node_modules bower_components
   npm install --build-from-source
-  bower install --production
+  bower install --production --allow-root
 }
 
 function package_x86 {
@@ -107,6 +107,7 @@ function package_x86 {
     --out=$output_directory
 
   # Change ia32 suffix to x86 for consistency
+  rm -r $output_package
   mv $output_directory/Etcher-linux-ia32 $output_package
 
   mv $output_package/Etcher $output_package/etcher


### PR DESCRIPTION
When running the install script as root (e.g. inside a Docker container), bower complained that it

"shouldn't" be run with sudo. When running the x86 install multiple times, it tried to move

Etcher-linux-ia32 inside the existing Etcher-linux-x86/ folder, rather than renaming it, which meant

later commands failed.