### PR TITLE
chore: fix linux x86 build script

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -107,7 +107,7 @@ function package_x86 {
     --out=$output_directory
 
   # Change ia32 suffix to x86 for consistency
-  rm -r $output_package
+  rm -rf $output_package
   mv $output_directory/Etcher-linux-ia32 $output_package
 
   mv $output_package/Etcher $output_package/etcher


### PR DESCRIPTION
While the previous fix in #777 fixed repeated builds, it accidentally broke the first build!