### PR TITLE
docs(GUI): skip AppImage desktop integration prompt with SKIP

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -16,6 +16,13 @@ To deactivate this feature, `touch` any of the files listed below:
 - `/usr/share/appimagekit/no_desktopintegration`
 - `/etc/appimagekit/no_desktopintegration`
 
+Alternatively, set the `SKIP` environment variable before executing the
+AppImage:
+
+```sh
+SKIP=1 ./Etcher-linux-x64.AppImage
+```
+
 Flashing Ubuntu ISOs
 --------------------
 


### PR DESCRIPTION
The AppImage `desktopintegration` prompt can also be disabled by setting
the `SKIP` environment variable.

As a matter of fact, we use this trick inside Etcher itself when
executing the Etcher CLI as a child process of the Etcher GUI.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>