### PR TITLE
docs(GUI): generic appimage name in desktopintegration SKIP instructions

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -20,7 +20,7 @@ Alternatively, set the `SKIP` environment variable before executing the
 AppImage:
 
 ```sh
-SKIP=1 ./Etcher-linux-x64.AppImage
+SKIP=1 ./Etcher-<version>-linux-<arch>.AppImage
 ```
 
 Flashing Ubuntu ISOs


### PR DESCRIPTION
We're now including the version as part of the filename, which means
`Etcher-linux-x64` is no longer 100% accurate. As a solution, we include
a filename with "placeholders" for the version and architecture, to
avoid harcoding a specific version.

See: https://github.com/resin-io/etcher/commit/18e9d1eb11104daab92448f07a3cdfeaa4735c15#commitcomment-19619181
See: https://github.com/resin-io/etcher/pull/764
Signed-off-by: Juan Cruz Viotti jviotti@openmailbox.org
