### PR TITLE
add travis triggers for website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: cpp
 sudo: false
-
 env:
+  matrix:
   - NODE_VERSION="6.1.0" RUBY_VERSION="2.3.1"
+  global:
+    secure: PtNVNtKSM3ps8SG3TfBQ91Gd4zcS+rPDI6Bn/OjTxVNdKj6ZXN3RUJYUQbM8ZIuIwjY9AK1Ho6SqS4/lB6MIj+WHnjBgcdzPl6LuQg4+m6MKi3I+qQdpcwqut9x7Cd0XRQzJt0XqdsULHmAK7NAAeh3fS1QjzB864IJsbxVfo/OVe5XXXTnWQmd5SsL301L0c9v6IW8IwscWnipBI32K8BVZza7vUFsGXapfSU9gOIMvGBomdcKTm2axNWmIdFSI+O6UV9kzEU68e9Q7y1crYjV/Yaljevy/pX9ISK1OW4FdOiJyBGKr9GEX6nN/ZrbD/vSywQTIUH4xCPNqp4kdi9e8UKU+sSLCyjFAQIRRgXkVZdv4owyWszKcYZcEv+8tdBK48e3YnMlhBVPm9yPsXG6SkgTvRTg2W8tKgL3zCHxH6A1/n/1Y/Z14dOmDIKdYHJe9M/NvrtyDWufIkZTK6R/qNrL2LC5PGUjsrTxQ9wnCg+KIqTW/UVWA8Pv/yhcnxaF5+a+JCbH+GlJMaPnwjSjluWunMSCRsubhQBgdO5ERsP0vJhG33F/8WLDF/rUFp5Vh7+F4ygoEt3DNXrty1jNn6Xq0QSo/2P/TlX5I3hD3LfwpDz7zbeCNN8FUr1YpsN5feoN24J7gbiNuJIBSNGSGGNOHJIeVLO3ALs9Qz+s=
 os:
   - linux
   - osx
@@ -62,7 +64,9 @@ before_script:
 
 script:
   - npm test
-
+after_success:
+  # only execute website build once per build
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then node scripts/triggerWebsiteBuild.js; fi
 notifications:
   email: false
   webhooks:

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "jsonfile": "^2.3.1",
     "mochainon": "^1.0.0",
     "node-sass": "^3.8.0",
-    "versionist": "^2.1.0"
+    "versionist": "^2.1.0",
+    "request": "2.76.0"
   },
   "config": {
     "commitizen": {

--- a/scripts/triggerWebsiteBuild.js
+++ b/scripts/triggerWebsiteBuild.js
@@ -1,0 +1,30 @@
+'use strict';
+const request = require('request');
+
+const options = {
+  url: 'https://api.travis-ci.org/repo/resin-io%2Fetcher-homepage/requests',
+  method: 'POST',
+  headers: {
+    'Accept': 'application/json',
+    'Travis-API-Version': '3',
+    'Authorization': 'token ' + process.env.TRAVIS_API_TOKEN
+  },
+  body: {
+    request: {
+      message: 'Trigger build at resin/etcher-homepage',
+      branch: 'master'
+    }
+  },
+  json: true
+};
+
+const callback = function(error, response) {
+  if (!error && response.statusCode === 202) {
+    console.log('Triggered website build');
+  } else {
+    console.log('Error', error);
+    process.exit(-1);
+  }
+};
+
+request(options, callback);


### PR DESCRIPTION
Trigger rebuilds of the website [`resin-io/etcher-homepage`](https://github.com/resin-io/etcher-homepage) via travis API. 

The build should only trigger **once** when commits are pushed to master. 

Depends on some work on [`resin-io/etcher-homepage`](https://github.com/resin-io/etcher-homepage) so we will need to wait for those PRs. 