### PR TITLE
chore: update homepage URL to https://www.etcher.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ License
 Etcher is free software, and may be redistributed under the terms specified in
 the [license].
 
-[etcher]: http://etcher.io
+[etcher]: https://www.etcher.io
 [SUPPORT]: https://github.com/resin-io/etcher/blob/master/SUPPORT.md
 [CONTRIBUTING]: https://github.com/resin-io/etcher/blob/master/docs/CONTRIBUTING.md
 [CLI]: https://github.com/resin-io/etcher/blob/master/docs/CLI.md

--- a/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
+++ b/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
@@ -11,7 +11,7 @@
 <div class="modal-footer">
   <div class="modal-menu">
     <button class="button button-primary"
-      os-open-external="http://etcher.io">DOWNLOAD</button>
+      os-open-external="https://www.etcher.io">DOWNLOAD</button>
     <button class="button button-default"
       ng-click="modal.closeModal()">SKIP</button>
   </div>

--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -38,7 +38,7 @@
       <svg-icon path="../../../assets/etcher.svg"
         width="83px"
         height="13px"
-        os-open-external="http://etcher.io"></svg-icon>
+        os-open-external="https://www.etcher.io"></svg-icon>
 
       <span class="caption">
         IS <span class="caption" os-open-external="https://github.com/resin-io/etcher">AN OPEN SOURCE PROJECT</span> BY


### PR DESCRIPTION
The current url we use, http://etcher.io, now redirects to
https://www.etcher.io.

Fixes: https://github.com/resin-io/etcher/issues/794
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>