### PR TITLE
chore: remove `.hound.yml`

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,9 +1,0 @@
-javascript:
-  config_file: .jshintrc
-
-jscs:
-  enabled: true
-  config_file: .jscsrc
-
-scss:
-  enabled: false


### PR DESCRIPTION
We are not using Hound CI to display lint warnings anymore. The CI
servers are in charge of running the linters now.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>