### PR TITLE
docs(CLI): describe proper way to install dependencies

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,8 +20,11 @@ you can run it locally with the following steps:
 git clone https://github.com/resin-io/etcher
 ```
 
-- Install the dependencies, using the instructions from
-[`RUNNING-LOCALLY.md`][RUNNING-LOCALLY].
+- Install the dependencies by running:
+
+```sh
+npm install
+```
 
 - Run the Etcher CLI from `bin/etcher`.
 
@@ -71,5 +74,4 @@ The Etcher CLI uses certain exit codes to signal the result of the operation.
 These are documented in [`lib/src/exit-codes.js`][exit-codes] and are also
 printed on the Etcher CLI help page.
 
-[RUNNING-LOCALLY]: https://github.com/resin-io/etcher/blob/master/docs/RUNNING-LOCALLY.md
 [exit-codes]: https://github.com/resin-io/etcher/blob/master/lib/src/exit-codes.js


### PR DESCRIPTION
The `docs/CLI.md` points to user to `docs/CONTRIBUTING.md` for
instructions in how to install dependencies. This document previously
included the explicit `npm` commands to run, but was then changed to
point to the platform scripts, which means that if the user follows the
current instructions but has a NodeJS version which is not ABI
compatible with the NodeJS version used by the currently used Electron
version, the user will get an incompatibility error.

Fixes: https://github.com/resin-io/etcher/issues/801
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>