### PR TITLE
docs(GUI): remove `<version>` from AppImage name

### DIFF
--- a/docs/USER-DOCUMENTATION.md
+++ b/docs/USER-DOCUMENTATION.md
@@ -34,7 +34,7 @@ Alternatively, set the `SKIP` environment variable before executing the
 AppImage:
 
 ```sh
-SKIP=1 ./Etcher-<version>-linux-<arch>.AppImage
+SKIP=1 ./Etcher-linux-<arch>.AppImage
 ```
 
 Flashing Ubuntu ISOs


### PR DESCRIPTION
The ZIP including the AppImage contains the version, but not the
AppImage itself.

See: https://github.com/resin-io/etcher/pull/786#issuecomment-257275494
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>