### PR TITLE
style(GUI): improve ordering of supported extensions

### DIFF
--- a/lib/gui/pages/main/controllers/image-selection.js
+++ b/lib/gui/pages/main/controllers/image-selection.js
@@ -26,7 +26,11 @@ module.exports = function(SupportedFormatsModel, SelectionStateModel, AnalyticsS
    * @type {String[]}
    * @public
    */
-  this.mainSupportedExtensions = _.slice(SupportedFormatsModel.getAllExtensions(), 0, 3);
+  this.mainSupportedExtensions = _.intersection([
+    'img',
+    'iso',
+    'zip'
+  ], SupportedFormatsModel.getAllExtensions());
 
   /**
    * @summary Extra supported extensions
@@ -37,7 +41,7 @@ module.exports = function(SupportedFormatsModel, SelectionStateModel, AnalyticsS
   this.extraSupportedExtensions = _.difference(
     SupportedFormatsModel.getAllExtensions(),
     this.mainSupportedExtensions
-  );
+  ).sort();
 
   /**
    * @summary Select image


### PR DESCRIPTION
The new ordering of the main supported extensions will be: `img`, `iso`,
`zip`.

We make use of `_.intersection` in order to ensure that the values we're
hardcoding indeed exist in the list of all supported format extensions,
otherwise they won't appear at all. This ensures we never show
extensions that are not supported.

Partly fixes: https://github.com/resin-io/etcher/issues/787
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>