### PR TITLE
style(CLI): don't wrap CLI help outputdrives

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -30,6 +30,10 @@ const packageJSON = require('../../package.json');
  * @public
  */
 module.exports = yargs
+
+  // Don't wrap at all
+  .wrap(null)
+
   .demand(1, 'Missing image')
 
   // Usage help


### PR DESCRIPTION
`yargs` wraps help output lines, causing the examples to be displayed
like this:

```
Examples:
/usr/bin/nodejs bin/etcher
raspberry-pi.img
/usr/bin/nodejs bin/etcher --no-check
raspberry-pi.img
/usr/bin/nodejs bin/etcher -d /dev/disk2
ubuntu.iso
/usr/bin/nodejs bin/etcher -d /dev/disk2
-y rpi.img
```

As a solution, we can set `.wrap(null)` to completely disable wrapping.

Fixes: https://github.com/resin-io/etcher/issues/810
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>