### PR TITLE
fix(GUI): close IPC server after writing

### DIFF
--- a/lib/src/child-writer/index.js
+++ b/lib/src/child-writer/index.js
@@ -117,13 +117,20 @@ exports.write = (image, drive, options) => {
 
     child.stderr.on('data', (data) => {
       emitter.emit('error', new Error(data.toString()));
+
+      // This function causes the `close` event to be emitted
+      child.kill();
+
     });
 
     child.on('error', (error) => {
+      ipc.server.stop();
       emitter.emit('error', error);
     });
 
     child.on('close', (code) => {
+      ipc.server.stop();
+
       if (code === EXIT_CODES.CANCELLED) {
         return emitter.emit('done', {
           cancelled: true


### PR DESCRIPTION
Currently, we are not making sure the IPC server we start at
`lib/src/child-writer/index.js` gets closed when the child process exits
(successfully or not). This eventually causes issues when the user click
"flash again", since the stateful `ipc` global exposed by `node-ipc`
gets initialised again, causing the module to get to an invalid state
that eventually results in `this.log is not a function`.

- We've added `ipc.server.stop()` to both the `error` and `close` event
  handlers (which are self exclusive, according to the docs).

- We've added `child.kill()` to the child `stderr` handler, since that
  function causes the `close` event to be triggered, which in turns
  calls `ipc.server.stop()`.

Change-Type: patch
Changelog-Entry: Fix `this.log is not a function` error when clicking "flash again".
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>