### PR TITLE
upgrade: `umount` to v1.1.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5132,9 +5132,9 @@
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
     },
     "umount": {
-      "version": "1.1.3",
-      "from": "umount@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/umount/-/umount-1.1.3.tgz",
+      "version": "1.1.4",
+      "from": "umount@1.1.4",
+      "resolved": "https://registry.npmjs.org/umount/-/umount-1.1.4.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sudo-prompt": "^6.1.0",
     "tail": "^1.1.0",
     "trackjs": "^2.1.16",
-    "umount": "^1.1.3",
+    "umount": "^1.1.4",
     "username": "^2.1.0",
     "yargs": "^4.6.0"
   },


### PR DESCRIPTION
- This new version passes `force` to `diskutil unmountDisk`

Change-Type: patch
Changelog-Entry: Fix `at least one volume could not be unmounted` error in OS X.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>