### PR TITLE
minifix(GUI): keep settings checkboxes unchecked until user confirms

### DIFF
--- a/lib/gui/pages/settings/controllers/settings.js
+++ b/lib/gui/pages/settings/controllers/settings.js
@@ -70,9 +70,14 @@ module.exports = function(WarningModalService, SettingsModel) {
       return this.refreshSettings();
     }
 
+    // Keep the checkbox unchecked until the user confirms
+    this.currentData[name] = false;
+
     WarningModalService.display(message).then((userAccepted) => {
-      this.model.set(name, Boolean(userAccepted));
-      this.refreshSettings();
+      if (userAccepted) {
+        this.model.set(name, true);
+        this.refreshSettings();
+      }
     });
   };
 


### PR DESCRIPTION
There are some settings, such as "unsafe mode", that prompt the user for
confirmation before actually confirming the setting. In these cases,
when the user attempts to check the checkbox, the checkbox remains
checked unless the user rejects the confirmation dialog, in which case
the checkbox value is reverted.

In order to provide a better UX, we now keep the checkbox unchecked
until the user confirms.

See: https://github.com/resin-io/etcher/issues/729
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>