### PR TITLE
style(GUI): improve unsafe mode dialog

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6468,6 +6468,9 @@ body {
 .modal-warning-modal .modal-title .glyphicon, .modal-warning-modal .modal-title .tick {
   color: #d9534f; }
 
+.modal-warning-modal .button, .modal-warning-modal .progress-button {
+  text-transform: uppercase; }
+
 /*
  * Copyright 2016 Resin.io
  *

--- a/lib/gui/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/components/drive-selector/controllers/drive-selector.js
@@ -67,11 +67,13 @@ module.exports = function($uibModalInstance, DrivesModel, SelectionStateModel, W
       return;
     }
 
-    WarningModalService.display([
-      `This image recommends a ${SelectionStateModel.getImageRecommendedDriveSize()}`,
-      `bytes drive, however ${drive.device} is only ${drive.size} bytes.`,
-      'Are you sure you want to continue?'
-    ].join(' ')).then((userAccepted) => {
+    WarningModalService.display({
+      message: [
+        `This image recommends a ${SelectionStateModel.getImageRecommendedDriveSize()}`,
+        `bytes drive, however ${drive.device} is only ${drive.size} bytes.`,
+        'Are you sure you want to continue?'
+      ].join(' ')
+    }).then((userAccepted) => {
       if (userAccepted) {
         SelectionStateModel.toggleSetDrive(drive.device);
       }

--- a/lib/gui/components/warning-modal/controllers/warning-modal.js
+++ b/lib/gui/components/warning-modal/controllers/warning-modal.js
@@ -16,14 +16,14 @@
 
 'use strict';
 
-module.exports = function($uibModalInstance, message) {
+module.exports = function($uibModalInstance, options) {
 
   /**
-   * @summary Modal message
+   * @summary Modal options
    * @property
    * @public
    */
-  this.message = message;
+  this.options = options;
 
   /**
    * @summary Reject the warning prompt

--- a/lib/gui/components/warning-modal/services/warning-modal.js
+++ b/lib/gui/components/warning-modal/services/warning-modal.js
@@ -25,20 +25,31 @@ module.exports = function(ModalService) {
    * @function
    * @public
    *
-   * @param {String} message - danger message
+   * @param {Object} options - options
+   * @param {String} options.message - danger message
+   * @param {String} [options.confirmButtonMessage='Yes, continue'] - confirm button message
+   * @param {String} [options.rejectButtonMessage='Cancel'] - reject button message
    * @fulfil {Boolean} - whether the user accepted or rejected the warning
    * @returns {Promise}
    *
    * @example
-   * WarningModalService.display('Don\'t do this!');
+   * WarningModalService.display({
+   *   message: 'Don\'t do this!'
+   * });
    */
-  this.display = (message) => {
+  this.display = (options) => {
+
+    _.defaults(options, {
+      confirmButtonMessage: 'Yes, continue',
+      rejectButtonMessage: 'Cancel'
+    });
+
     return ModalService.open({
       template: './components/warning-modal/templates/warning-modal.tpl.html',
       controller: 'WarningModalController as modal',
-      size: 'settings-dangerous-modal',
+      size: 'warning-modal',
       resolve: {
-        message: _.constant(message)
+        options: _.constant(options)
       }
     }).result;
   };

--- a/lib/gui/components/warning-modal/styles/_warning-modal.scss
+++ b/lib/gui/components/warning-modal/styles/_warning-modal.scss
@@ -17,3 +17,7 @@
 .modal-warning-modal .modal-title .glyphicon {
   color: $palette-theme-danger-background;
 }
+
+.modal-warning-modal .button {
+  text-transform: uppercase;
+}

--- a/lib/gui/components/warning-modal/templates/warning-modal.tpl.html
+++ b/lib/gui/components/warning-modal/templates/warning-modal.tpl.html
@@ -7,16 +7,16 @@
 
 <div class="modal-body">
   <div class="modal-text">
-    <p>{{ ::modal.message }}</p>
+    <p>{{ ::modal.options.message }}</p>
   </div>
 </div>
 
 <div class="modal-footer">
   <div class="modal-menu">
     <button class="button button-danger"
-      ng-click="modal.accept()">YES, CONTINUE</button>
+      ng-click="modal.accept()">{{ ::modal.options.confirmButtonMessage }}</button>
 
     <button class="button button-default"
-      ng-click="modal.reject()">CANCEL</button>
+      ng-click="modal.reject()">{{ ::modal.options.rejectButtonMessage }}</button>
   </div>
 </div>

--- a/lib/gui/pages/settings/controllers/settings.js
+++ b/lib/gui/pages/settings/controllers/settings.js
@@ -58,13 +58,20 @@ module.exports = function(WarningModalService, SettingsModel) {
    * @public
    *
    * @param {String} name - setting name
-   * @param {String} message - danger message
+   * @param {Object} options - options
+   * @param {String} options.message - danger message
+   * @param {String} [options.confirmButtonMessage] - confirm button message
+   * @param {String} [options.rejectButtonMessage] - reject button message
    * @returns {Undefined}
    *
    * @example
-   * SettingsController.enableDangerousSetting('unsafeMode', 'Don\'t do this!');
+   * SettingsController.enableDangerousSetting('unsafeMode', {
+   *   message: 'Don\'t do this!',
+   *   confirmButtonMessage: 'Go ahead!',
+   *   rejectButtonMessage: 'Go back!'
+   * });
    */
-  this.enableDangerousSetting = (name, message) => {
+  this.enableDangerousSetting = (name, options) => {
     if (!this.currentData[name]) {
       this.model.set(name, false);
       return this.refreshSettings();
@@ -73,7 +80,7 @@ module.exports = function(WarningModalService, SettingsModel) {
     // Keep the checkbox unchecked until the user confirms
     this.currentData[name] = false;
 
-    WarningModalService.display(message).then((userAccepted) => {
+    WarningModalService.display(options).then((userAccepted) => {
       if (userAccepted) {
         this.model.set(name, true);
         this.refreshSettings();

--- a/lib/gui/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/pages/settings/templates/settings.tpl.html
@@ -46,7 +46,11 @@
     <label>
       <input type="checkbox"
         ng-model="settings.currentData.unsafeMode"
-        ng-change="settings.enableDangerousSetting('unsafeMode', 'Are you sure you want to turn this on? You will be able to burn to your system drives.')">
+        ng-change="settings.enableDangerousSetting('unsafeMode', {
+          message: 'Are you sure you want to turn this on? You will be able to overwrite your system drives if you\'re not careful.',
+          confirmButtonMessage: 'Enable unsafe mode',
+          rejectButtonMessage: 'Stay in safe mode'
+        })">
 
       <span>Unsafe mode <span class="label label-danger">DANGEROUS</span></span>
     </label>


### PR DESCRIPTION
- Change dialog message to "Are you sure you want to turn this on? You
  will be able to overwrite your system drives if you're not careful."

- Change dialog button labels from "YES, CONTINUE", and "CANCEL", to
  "ENABLE UNSAFE MODE", and "STAY IN SAFE MODE", respectively.

In order to adapt to changes described above:

- `WarningModalService.display()` now takes an object including
  `message`, `confirmButtonMessage`, and `rejectButtonMessage`
  properties.

![screenshot 2016-11-03 09 59 00](https://cloud.githubusercontent.com/assets/2192773/19968758/4bf2f8b0-a1ac-11e6-8273-a30effe3e22f.png)

Fixes: https://github.com/resin-io/etcher/issues/729
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>