### PR TITLE
chore: update package.json and README.md to match repo description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Etcher
 ======
 
-> Flash OS images to SD cards & USB drives, safe & easy.
+> Flash OS images to SD cards & USB drives, safely and easily.
 
 Etcher is a powerful OS image flasher built with web technologies to ensure
 flashing an SDCard or USB drive is a pleasant and safe experience. It protects

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Etcher",
   "version": "1.0.0-beta.16",
   "main": "lib/start.js",
-  "description": "An image flasher with support for Windows, OS X and GNU/Linux.",
+  "description": "Flash OS images to SD cards & USB drives, safely and easily.",
   "homepage": "https://github.com/resin-io/etcher",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Repository description says "Flash OS images to SD cards & USB drives,
safely and easily.", while `package.json` currently says "An image
flasher with support for Windows, OS X and GNU/Linux.", and `README.md`
contains "Flash OS images to SD cards & USB drives, safe & easy."

See: https://github.com/resin-io/etcher/issues/797
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>