### PR TITLE
chore: remove `removedrive` from `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "optionalDependencies": {
     "elevator": "^2.1.0",
-    "removedrive": "^1.0.0"
+    "removedrive": "^1.1.1"
   },
   "dependencies": {
     "angular": "^1.5.3",
@@ -79,7 +79,6 @@
     "node-ipc": "^8.9.2",
     "redux": "^3.5.2",
     "redux-localstorage": "^0.4.1",
-    "removedrive": "^1.1.1",
     "resin-cli-errors": "^1.2.0",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",


### PR DESCRIPTION
This dependency is already being listed in `optionalDependencies`, which
the place it really belongs to.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>