### PR TITLE
minifix(GUI): warning modal size class

### DIFF
--- a/lib/gui/components/warning-modal/services/warning-modal.js
+++ b/lib/gui/components/warning-modal/services/warning-modal.js
@@ -36,7 +36,7 @@ module.exports = function(ModalService) {
     return ModalService.open({
       template: './components/warning-modal/templates/warning-modal.tpl.html',
       controller: 'WarningModalController as modal',
-      size: 'settings-dangerous-modal',
+      size: 'warning-modal',
       resolve: {
         message: _.constant(message)
       }


### PR DESCRIPTION
The `settings-dangerous-modal` modal size class doesn't exist anymore,
and was renamed to `warning-modal`. This was causing the exclamation
sign from the header to not be displayed in red, as it should.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>