### PR TITLE
style(GUI): unify "close" top right corner X in all modals

### DIFF
--- a/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
+++ b/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
@@ -1,5 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title">New Update Available!</h4>
+  <button class="close" ng-click="modal.closeModal()">&times;</button>
 </div>
 
 <div class="modal-body">


### PR DESCRIPTION
Every modal in the application should contain the same "close" X at the
top right corner, for consistency purposes. The only modal lacking this
button was the update notifier modal.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>