### PR TITLE
chore: add `productDescription` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0-beta.16",
   "main": "lib/start.js",
   "description": "Flash OS images to SD cards & USB drives, safely and easily.",
+  "productDescription": "Etcher is a powerful OS image flasher built with web technologies to ensure flashing an SDCard or USB drive is a pleasant and safe experience. It protects you from accidentally writing to your hard-drives, ensures every byte of data was written correctly and much more.",
   "homepage": "https://github.com/resin-io/etcher",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This key is added as the long description of the Debian package.
Omitting this option means that `description` is duplicated two times,
which is of course not the desired outcome.

See: https://github.com/resin-io/etcher/issues/632
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>