### PR TITLE
fix(GUI): kill CLI processes when child writer dies

### DIFF
--- a/lib/src/child-writer/writer-proxy.js
+++ b/lib/src/child-writer/writer-proxy.js
@@ -139,10 +139,20 @@ return isElevated().then((elevated) => {
   return new Bluebird((resolve, reject) => {
     ipc.config.id = process.env.IPC_CLIENT_ID;
     ipc.config.silent = true;
+
+    // > If set to 0, the client will NOT try to reconnect.
+    // See https://github.com/RIAEvangelist/node-ipc/
+    //
+    // The purpose behind this change is for this process
+    // to emit a "disconnect" event as soon as the GUI
+    // process is closed, so we can kill the CLI as well.
+    ipc.config.stopRetrying = 0;
+
     ipc.connectTo(process.env.IPC_SERVER_ID, () => {
       ipc.of[process.env.IPC_SERVER_ID].on('error', reject);
       ipc.of[process.env.IPC_SERVER_ID].on('connect', () => {
         const child = childProcess.spawn(EXECUTABLE, ETCHER_ARGUMENTS);
+        ipc.of[process.env.IPC_SERVER_ID].on('disconnect', _.bind(child.kill, child));
         child.on('error', reject);
         child.on('close', resolve);
 


### PR DESCRIPTION
Turns out that when the parent process gets SIGKILL, the children
process would still remain alive.

In order to mitigate this, we force the IPC client opened by the child
writer to not attempt to reconnect to the IPC server if this one dies,
so we can catch the "disconnect" event and kill the children as a
result.

Fixes: https://github.com/resin-io/etcher/issues/850
Change-Type: patch
Changelog-Entry: Fix writing process remaining alive after the GUI is closed.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>