### PR TITLE
test: fix failing ImageSelectionController tests

### DIFF
--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const m = require('mochainon');
+const _ = require('lodash');
 const angular = require('angular');
 require('angular-mocks');
 
@@ -143,7 +144,7 @@ describe('Browser: MainPage', function() {
       });
 
       const extensions = controller.mainSupportedExtensions.concat(controller.extraSupportedExtensions);
-      m.chai.expect(extensions).to.deep.equal(SupportedFormatsModel.getAllExtensions());
+      m.chai.expect(_.sortBy(extensions)).to.deep.equal(_.sortBy(SupportedFormatsModel.getAllExtensions()));
     });
 
   });


### PR DESCRIPTION
This was a small issue affected due to the change in order of the
supported extensions in the ImageSelectionController.

Since we want to test that the array contents are equally the same
independently on the order, we sort both sides of the assertion.

This issue was not caught before since `electron-mocha` was reporting
exit code 0 even when there were changes failing, causing the CI
services to incorrectly support success.

See: https://github.com/resin-io/etcher/pull/854
See: https://github.com/resin-io/etcher/pull/806
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>