### PR TITLE
docs: more explicit key server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ installers for all supported operating systems.
 2. Trust Bintray.com's GPG key:
 
     ```sh
-    sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 379CE192D401AB61
+    sudo apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 379CE192D401AB61
     ```
 
 3. Update and install:


### PR DESCRIPTION
Use full URL with port for key server. Also use port 80 to work around firewalls and proxies.

Fixes: #859