### PR TITLE
fix(CLI): check CLI elevation early on

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -18,6 +18,7 @@
 
 const _ = require('lodash');
 const Bluebird = require('bluebird');
+const isElevated = Bluebird.promisify(require('is-elevated'));
 const visuals = require('resin-cli-visuals');
 const form = require('resin-cli-form');
 const drivelist = Bluebird.promisifyAll(require('drivelist'));
@@ -26,28 +27,34 @@ const utils = require('./utils');
 const options = require('./cli');
 const EXIT_CODES = require('../src/exit-codes');
 
-form.run([
-  {
-    message: 'Select drive',
-    type: 'drive',
-    name: 'drive'
-  },
-  {
-    message: 'This will erase the selected drive. Are you sure?',
-    type: 'confirm',
-    name: 'yes',
-    default: false
+isElevated().then((elevated) => {
+  if (!elevated) {
+    throw new Error('This should should be run with root/administrator permissions');
   }
-], {
-  override: {
-    drive: options.drive,
 
-    // If `options.yes` is `false`, pass `undefined`,
-    // otherwise the question will not be asked because
-    // `false` is a defined value.
-    yes: options.robot || options.yes || undefined
+  return form.run([
+    {
+      message: 'Select drive',
+      type: 'drive',
+      name: 'drive'
+    },
+    {
+      message: 'This will erase the selected drive. Are you sure?',
+      type: 'confirm',
+      name: 'yes',
+      default: false
+    }
+  ], {
+    override: {
+      drive: options.drive,
 
-  }
+      // If `options.yes` is `false`, pass `undefined`,
+      // otherwise the question will not be asked because
+      // `false` is a defined value.
+      yes: options.robot || options.yes || undefined
+
+    }
+  });
 }).then((answers) => {
   if (!answers.yes) {
     throw new Error('Aborted');


### PR DESCRIPTION
The CLI requires elevation permissions to actually be able to write to
drives. For this reason, it makes sense that we introduce such a check
early on.

See: https://github.com/resin-io/etcher/issues/726
Change-Type: patch
Changelog-Entry: Check available permissions in the CLI early on.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>