### PR TITLE
fix(gui): clarify wording at finished flash prompt (new → different)

### DIFF
--- a/lib/gui/pages/finish/templates/success.tpl.html
+++ b/lib/gui/pages/finish/templates/success.tpl.html
@@ -19,10 +19,10 @@
 
         <div class="col-xs-4 space-medium">
           <div class="box">
-            <p class="soft button-label">Would you like to flash a new image?</p>
+            <p class="soft button-label">Would you like to flash a different image?</p>
 
             <button class="button button-primary button-brick" ng-click="finish.restart()">
-              Use <b>new</b> image
+              Use <b>different</b> image
             </button>
           </div>
         </div>


### PR DESCRIPTION
Currently, the wording "same" versus "new" on the completion screen
is ambiguous when they respectively mean use the same image file, or use a new
and different image file. Therefore, change the wording from "new" to
"different".

Closes: https://github.com/resin-io/etcher/issues/839
Change-Type: patch
Changelog-Entry: Clarify wording on completion page.