### PR TITLE
upgrade: `drivelist` to v5.0.1

### DIFF
--- a/lib/cli/unmount.js
+++ b/lib/cli/unmount.js
@@ -97,7 +97,9 @@ exports.unmountDrive = (drive) => {
 
   if (platform === 'win32') {
     const removedrive = Bluebird.promisifyAll(require('removedrive'));
-    return removedrive.ejectAsync(drive.mountpoint);
+    return Bluebird.each(drive.mountpoints, (mountpoint) => {
+      return removedrive.ejectAsync(mountpoint.path);
+    });
   }
 
   const command = exports.getUNIXUnmountCommand(platform, drive);

--- a/lib/gui/modules/drive-scanner.js
+++ b/lib/gui/modules/drive-scanner.js
@@ -46,8 +46,8 @@ driveScanner.factory('DriveScannerService', (SettingsModel) => {
       drives = _.map(drives, (drive) => {
         drive.name = drive.device;
 
-        if (os.platform() === 'win32' && drive.mountpoint) {
-          drive.name = drive.mountpoint;
+        if (os.platform() === 'win32' && !_.isEmpty(drive.mountpoints)) {
+          drive.name = _.join(_.map(drive.mountpoints, 'path'), ', ');
         }
 
         return drive;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -545,7 +545,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
@@ -1158,14 +1158,14 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "4.0.0",
-      "from": "drivelist@4.0.0",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-4.0.0.tgz",
+      "version": "5.0.1",
+      "from": "drivelist@5.0.1",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.1.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.16.4",
+          "version": "4.17.0",
           "from": "lodash@>=4.16.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.0.tgz"
         }
       }
     },
@@ -4744,7 +4744,7 @@
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^4.0.0",
+    "drivelist": "^5.0.1",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^5.1.0",
     "etcher-image-write": "^8.1.4",

--- a/tests/gui/modules/drive-scanner.spec.js
+++ b/tests/gui/modules/drive-scanner.spec.js
@@ -52,7 +52,11 @@ describe('Browser: DriveScanner', function() {
             device: '/dev/sda',
             description: 'WDC WD10JPVX-75J',
             size: '931.5G',
-            mountpoint: '/',
+            mountpoints: [
+              {
+                path: '/'
+              }
+            ],
             system: true
           }
         ]);
@@ -94,21 +98,33 @@ describe('Browser: DriveScanner', function() {
               device: '/dev/sda',
               description: 'WDC WD10JPVX-75J',
               size: '931.5G',
-              mountpoint: '/',
+              mountpoints: [
+                {
+                  path: '/'
+                }
+              ],
               system: true
             },
             {
               device: '/dev/sdb',
               description: 'Foo',
               size: '14G',
-              mountpoint: '/mnt/foo',
+              mountpoints: [
+                {
+                  path: '/mnt/foo'
+                }
+              ],
               system: false
             },
             {
               device: '/dev/sdc',
               description: 'Bar',
               size: '14G',
-              mountpoint: '/mnt/bar',
+              mountpoints: [
+                {
+                  path: '/mnt/bar'
+                }
+              ],
               system: false
             }
           ]);
@@ -126,7 +142,11 @@ describe('Browser: DriveScanner', function() {
                 name: '/dev/sdb',
                 description: 'Foo',
                 size: '14G',
-                mountpoint: '/mnt/foo',
+                mountpoints: [
+                  {
+                    path: '/mnt/foo'
+                  }
+                ],
                 system: false
               },
               {
@@ -134,7 +154,11 @@ describe('Browser: DriveScanner', function() {
                 name: '/dev/sdc',
                 description: 'Bar',
                 size: '14G',
-                mountpoint: '/mnt/bar',
+                mountpoints: [
+                  {
+                    path: '/mnt/bar'
+                  }
+                ],
                 system: false
               }
             ]);
@@ -170,21 +194,29 @@ describe('Browser: DriveScanner', function() {
               device: '\\\\.\\PHYSICALDRIVE1',
               description: 'WDC WD10JPVX-75J',
               size: '931.5G',
-              mountpoint: 'C:',
+              mountpoints: [
+                {
+                  path: 'C:'
+                }
+              ],
               system: true
             },
             {
               device: '\\\\.\\PHYSICALDRIVE2',
               description: 'Foo',
               size: '14G',
-              mountpoint: null,
+              mountpoints: [],
               system: false
             },
             {
               device: '\\\\.\\PHYSICALDRIVE3',
               description: 'Bar',
               size: '14G',
-              mountpoint: 'F:',
+              mountpoints: [
+                {
+                  path: 'F:'
+                }
+              ],
               system: false
             }
           ]);
@@ -202,7 +234,7 @@ describe('Browser: DriveScanner', function() {
                 name: '\\\\.\\PHYSICALDRIVE2',
                 description: 'Foo',
                 size: '14G',
-                mountpoint: null,
+                mountpoints: [],
                 system: false
               },
               {
@@ -210,11 +242,93 @@ describe('Browser: DriveScanner', function() {
                 name: 'F:',
                 description: 'Bar',
                 size: '14G',
-                mountpoint: 'F:',
+                mountpoints: [
+                  {
+                    path: 'F:'
+                  }
+                ],
                 system: false
               }
             ]);
 
+            DriveScannerService.stop();
+            done();
+          });
+
+          DriveScannerService.start();
+        });
+
+      });
+
+      describe('given a drive with a single drive letters', function() {
+
+        beforeEach(function() {
+          this.drivesListStub = m.sinon.stub(drivelist, 'list');
+          this.drivesListStub.yields(null, [
+            {
+              device: '\\\\.\\PHYSICALDRIVE3',
+              description: 'Bar',
+              size: '14G',
+              mountpoints: [
+                {
+                  path: 'F:'
+                }
+              ],
+              system: false
+            }
+          ]);
+        });
+
+        afterEach(function() {
+          this.drivesListStub.restore();
+        });
+
+        it('should use the drive letter as the name', function(done) {
+          DriveScannerService.on('drives', function(drives) {
+            m.chai.expect(drives).to.have.length(1);
+            m.chai.expect(drives[0].name).to.equal('F:');
+            DriveScannerService.stop();
+            done();
+          });
+
+          DriveScannerService.start();
+        });
+
+      });
+
+      describe('given a drive with multiple drive letters', function() {
+
+        beforeEach(function() {
+          this.drivesListStub = m.sinon.stub(drivelist, 'list');
+          this.drivesListStub.yields(null, [
+            {
+              device: '\\\\.\\PHYSICALDRIVE3',
+              description: 'Bar',
+              size: '14G',
+              mountpoints: [
+                {
+                  path: 'F:'
+                },
+                {
+                  path: 'G:'
+                },
+                {
+                  path: 'H:'
+                }
+              ],
+              system: false
+            }
+          ]);
+        });
+
+        afterEach(function() {
+          this.drivesListStub.restore();
+        });
+
+        it('should join all the mountpoints in `name`', function(done) {
+          DriveScannerService.on('drives', function(drives) {
+            m.chai.expect(drives).to.have.length(1);
+            m.chai.expect(drives[0].name).to.equal('F:, G:, H:');
             DriveScannerService.stop();
             done();
           });


### PR DESCRIPTION
- Fix internal SDCard reader descriptions in GNU/Linux.
- Transform `mountpoint` into an array of mountpoints.

Change-Type: patch
Changelog-Entry: Fix internal SDCard drive descriptions.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>