### PR TITLE
upgrade: `drivelist` to v5.0.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1158,14 +1158,14 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "5.0.1",
-      "from": "drivelist@5.0.1",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.1.tgz",
+      "version": "5.0.3",
+      "from": "drivelist@5.0.3",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.3.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.0",
+          "version": "4.17.2",
           "from": "lodash@>=4.16.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.1",
+    "drivelist": "^5.0.3",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^5.1.0",
     "etcher-image-write": "^8.1.4",


### PR DESCRIPTION
See: https://github.com/resin-io-modules/drivelist/pull/120
Fixes: https://github.com/resin-io/etcher/issues/870
Change-Type: patch
Changelog-Entry: Fix `0x80131700` error when scanning drives on Windows.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>