### PR TITLE
refactor: extract OS X build script into many files

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -27,21 +27,6 @@ if [[ "$OS" != "Darwin" ]]; then
   exit 1
 fi
 
-if ! command -v bower 2>/dev/null; then
-  echo "Dependency missing: bower" 1>&2
-  exit 1
-fi
-
-if ! command -v python 2>/dev/null; then
-  echo "Dependency missing: python" 1>&2
-  exit 1
-fi
-
-if ! command -v afsctool 2>/dev/null; then
-  echo "Dependency missing: afsctool" 1>&2
-  exit 1
-fi
-
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <command>" 1>&2
   exit 1
@@ -53,180 +38,42 @@ if [ "$COMMAND" != "install" ] && [ "$COMMAND" != "package" ] && [ "$COMMAND" !=
   exit 1
 fi
 
-ELECTRON_OSX_SIGN=./node_modules/.bin/electron-osx-sign
-ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
 SIGN_IDENTITY_OSX="Developer ID Application: Rulemotion Ltd (66H43P8FRG)"
 ELECTRON_VERSION=`node -e "console.log(require('./package.json').devDependencies['electron-prebuilt'])"`
 APPLICATION_NAME=`node -e "console.log(require('./package.json').displayName)"`
 APPLICATION_COPYRIGHT=`node -e "console.log(require('./package.json').copyright)"`
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
 
-function install {
-
-  # Ensure native addons are compiled with the correct headers
-  # See https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md
-  export npm_config_disturl=https://atom.io/download/atom-shell
-  export npm_config_target=$ELECTRON_VERSION
-  export npm_config_arch=x64
-  export npm_config_runtime=electron
-
-  rm -rf node_modules bower_components
-  npm install --build-from-source
-  bower install --production
-}
-
-function package {
-  local output_directory=$1
-
-  $ELECTRON_PACKAGER . $APPLICATION_NAME \
-    --platform=darwin \
-    --arch=x64 \
-    --version=$ELECTRON_VERSION \
-    --ignore="`node scripts/packageignore.js`" \
-    --asar \
-    --app-copyright="$APPLICATION_COPYRIGHT" \
-    --app-version="$APPLICATION_VERSION" \
-    --build-version="$APPLICATION_VERSION" \
-    --helper-bundle-id="io.resin.etcher-helper" \
-    --app-bundle-id="io.resin.etcher" \
-    --app-category-type="public.app-category.developer-tools" \
-    --icon="assets/icon.icns" \
-    --overwrite \
-    --out=$output_directory
-
-  rm $output_directory/Etcher-darwin-x64/LICENSE
-  rm $output_directory/Etcher-darwin-x64/LICENSES.chromium.html
-  rm $output_directory/Etcher-darwin-x64/version
-}
-
-function sign {
-  local source_application=$1
-
-  $ELECTRON_OSX_SIGN $source_application --platform darwin --verbose --identity "$SIGN_IDENTITY_OSX"
-  codesign --verify --deep --display --verbose=4 $source_application
-  spctl --ignore-cache --no-cache --assess --type execute --verbose=4 $source_application
-}
-
-function installer_zip {
-  local source_directory=$1
-  local output_directory=$2
-
-  mkdir -p $output_directory
-  sign $source_directory/$APPLICATION_NAME.app
-  pushd $source_directory
-  zip -r -9 Etcher-$APPLICATION_VERSION-darwin-x64.zip $APPLICATION_NAME.app
-  popd
-  mv $source_directory/Etcher-$APPLICATION_VERSION-darwin-x64.zip $output_directory
-}
-
-function installer_dmg {
-  local source_directory=$1
-  local output_directory=$2
-  local temporary_dmg=$source_directory.dmg
-  local volume_directory=/Volumes/$APPLICATION_NAME
-  local volume_app=$volume_directory/$APPLICATION_NAME.app
-
-  # Make sure any previous DMG was unmounted
-  hdiutil detach $volume_directory || true
-
-  # Create temporary read-write DMG image
-  rm -f $temporary_dmg
-  hdiutil create \
-    -srcfolder $source_directory \
-    -volname "$APPLICATION_NAME" \
-    -fs HFS+ \
-    -fsargs "-c c=64,a=16,e=16" \
-    -format UDRW \
-    -size 600M $temporary_dmg
-
-  # Mount temporary DMG image, so we can modify it
-  hdiutil attach $temporary_dmg -readwrite -noverify
-
-  # Wait for a bit to ensure the image is mounted
-  sleep 2
-
-  # Link to /Applications within the DMG
-  pushd $volume_directory
-  ln -s /Applications
-  popd
-
-  # Symlink MacOS/Etcher to MacOS/Electron since for some reason, the Electron
-  # binary tries to be ran in some systems.
-  # See https://github.com/Microsoft/vscode/issues/92
-  cp -p $volume_app/Contents/MacOS/Etcher $volume_app/Contents/MacOS/Electron
-
-  # Set the DMG icon image
-  # Writing this hexadecimal buffer to the com.apple.FinderInfo
-  # extended attribute does the trick.
-  # See https://github.com/LinusU/node-appdmg/issues/14#issuecomment-29080500
-  cp assets/icon.icns $volume_directory/.VolumeIcon.icns
-  xattr -wx com.apple.FinderInfo \
-    "0000000000000000040000000000000000000000000000000000000000000000" $volume_directory
-
-  # Configure background image.
-  # We use tiffutil to create a "Multirepresentation Tiff file".
-  # This allows us to show the retina and non-retina image when appropriate.
-  mkdir $volume_directory/.background
-  tiffutil -cathidpicheck assets/osx/installer.png assets/osx/installer@2x.png \
-    -out $volume_directory/.background/installer.tiff
-
-  # This AppleScript performs the following tasks
-  # - Set the window basic properties.
-  # - Set the window size and position.
-  # - Set the icon size.
-  # - Arrange the icons.
-  echo '
-     tell application "Finder"
-       tell disk "'${APPLICATION_NAME}'"
-         open
-         set current view of container window to icon view
-         set toolbar visible of container window to false
-         set statusbar visible of container window to false
-         set the bounds of container window to {400, 100, 944, 530}
-         set viewOptions to the icon view options of container window
-         set arrangement of viewOptions to not arranged
-         set icon size of viewOptions to 110
-         set background picture of viewOptions to file ".background:installer.tiff"
-         set position of item "'${APPLICATION_NAME}.app'" of container window to {140, 225}
-         set position of item "Applications" of container window to {415, 225}
-         close
-         open
-         update without registering applications
-         delay 2
-         close
-       end tell
-     end tell
-  ' | osascript
-  sync
-
-  # Apply HFS+ compression
-  afsctool -ci -9 $volume_app
-
-  sign $volume_app
-
-  # Unmount temporary DMG image.
-  hdiutil detach $volume_directory
-
-  # Convert temporary DMG image into a production-ready
-  # compressed and read-only DMG image.
-  mkdir -p $output_directory
-  rm -f $output_directory/Etcher-darwin-x64.dmg
-  hdiutil convert $temporary_dmg \
-    -format UDZO \
-    -imagekey zlib-level=9 \
-    -o $output_directory/Etcher-$APPLICATION_VERSION-darwin-x64.dmg
-
-  # Cleanup temporary DMG image.
-  rm $temporary_dmg
-
-}
-
 if [ "$COMMAND" == "install" ] || [ "$COMMAND" == "all" ]; then
-  install
+  ./scripts/darwin/dependencies.sh -r x64 -e $ELECTRON_VERSION
 fi
 
 if [ "$COMMAND" == "package" ] || [ "$COMMAND" == "all" ]; then
-  package etcher-release
-  installer_dmg etcher-release/Etcher-darwin-x64 etcher-release/installers
-  installer_zip etcher-release/Etcher-darwin-x64 etcher-release/installers
+  ./scripts/darwin/package.sh \
+    -n $APPLICATION_NAME \
+    -r x64 \
+    -v $APPLICATION_VERSION \
+    -b io.resin.etcher \
+    -c "$APPLICATION_COPYRIGHT" \
+    -t public.app-category.developer-tools \
+    -i assets/icon.icns \
+    -e $ELECTRON_VERSION \
+    -o etcher-release/$APPLICATION_NAME-darwin-x64
+
+  ./scripts/darwin/installer-dmg.sh \
+    -n $APPLICATION_NAME \
+    -v $APPLICATION_VERSION \
+    -p etcher-release/$APPLICATION_NAME-darwin-x64 \
+    -d "$SIGN_IDENTITY_OSX" \
+    -i assets/icon.icns \
+    -b assets/osx/installer.png \
+    -o etcher-release/installers/$APPLICATION_NAME-$APPLICATION_VERSION-darwin-x64.dmg
+
+  ./scripts/darwin/sign.sh \
+    -a etcher-release/$APPLICATION_NAME-darwin-x64/$APPLICATION_NAME.app \
+    -i "$SIGN_IDENTITY_OSX"
+
+  ./scripts/darwin/installer-zip.sh \
+    -a etcher-release/$APPLICATION_NAME-darwin-x64/$APPLICATION_NAME.app \
+    -o etcher-release/installers/$APPLICATION_NAME-$APPLICATION_VERSION-darwin-x64.zip
 fi

--- a/scripts/darwin/dependencies.sh
+++ b/scripts/darwin/dependencies.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+OS=$(uname)
+if [[ "$OS" != "Darwin" ]]; then
+  echo "This script is only meant to be run in OS X" 1>&2
+  exit 1
+fi
+
+if ! command -v npm 2>/dev/null 1>&2; then
+  echo "Dependency missing: npm" 1>&2
+  exit 1
+fi
+
+if ! command -v bower 2>/dev/null 1>&2; then
+  echo "Dependency missing: bower" 1>&2
+  exit 1
+fi
+
+if ! command -v python 2>/dev/null 1>&2; then
+  echo "Dependency missing: python" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -r <architecture>"
+  echo "    -e <electron version>"
+  exit 0
+}
+
+ARGV_ARCHITECTURE=""
+ARGV_ELECTRON_VERSION=""
+
+while getopts ":r:e:" option; do
+  case $option in
+    r) ARGV_ARCHITECTURE=$OPTARG ;;
+    e) ARGV_ELECTRON_VERSION=$OPTARG ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_ARCHITECTURE" ] || [ -z "$ARGV_ELECTRON_VERSION" ]; then
+  usage
+fi
+
+# Ensure native addons are compiled with the correct headers
+# See https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md
+export npm_config_disturl=https://atom.io/download/atom-shell
+export npm_config_target=$ARGV_ELECTRON_VERSION
+export npm_config_arch=$ARGV_ARCHITECTURE
+export npm_config_runtime=electron
+
+rm -rf node_modules bower_components
+npm install --build-from-source
+bower install --production

--- a/scripts/darwin/installer-dmg.sh
+++ b/scripts/darwin/installer-dmg.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+OS=$(uname)
+if [[ "$OS" != "Darwin" ]]; then
+  echo "This script is only meant to be run in OS X" 1>&2
+  exit 1
+fi
+
+if ! command -v afsctool 2>/dev/null 1>&2; then
+  echo "Dependency missing: afsctool" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -n <application name>"
+  echo "    -v <application version>"
+  echo "    -p <application package>"
+  echo "    -d <identity>"
+  echo "    -i <application icon (.icns)>"
+  echo "    -b <application background (.png)>"
+  echo "    -o <output>"
+  exit 0
+}
+
+ARGV_APPLICATION_NAME=""
+ARGV_VERSION=""
+ARGV_PACKAGE=""
+ARGV_IDENTITY=""
+ARGV_ICON=""
+ARGV_BACKGROUND=""
+ARGV_OUTPUT=""
+
+while getopts ":n:v:p:d:i:b:o:" option; do
+  case $option in
+    n) ARGV_APPLICATION_NAME="$OPTARG" ;;
+    v) ARGV_VERSION="$OPTARG" ;;
+    p) ARGV_PACKAGE="$OPTARG" ;;
+    d) ARGV_IDENTITY="$OPTARG" ;;
+    i) ARGV_ICON="$OPTARG" ;;
+    b) ARGV_BACKGROUND="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_APPLICATION_NAME" ] \
+  || [ -z "$ARGV_VERSION" ] \
+  || [ -z "$ARGV_IDENTITY" ] \
+  || [ -z "$ARGV_ICON" ] \
+  || [ -z "$ARGV_OUTPUT" ]
+then
+  usage
+fi
+
+TEMPORARY_DMG=$ARGV_PACKAGE.dmg
+VOLUME_DIRECTORY=/Volumes/$ARGV_APPLICATION_NAME
+VOLUME_APPLICATION=$VOLUME_DIRECTORY/$ARGV_APPLICATION_NAME.app
+
+# Make sure any previous DMG was unmounted
+hdiutil detach "$VOLUME_DIRECTORY" || true
+
+# Create temporary read-write DMG image
+rm -f "$TEMPORARY_DMG"
+hdiutil create \
+  -srcfolder "$ARGV_PACKAGE" \
+  -volname "$ARGV_APPLICATION_NAME" \
+  -fs HFS+ \
+  -fsargs "-c c=64,a=16,e=16" \
+  -format UDRW \
+  -size 600M "$TEMPORARY_DMG"
+
+# Mount temporary DMG image, so we can modify it
+hdiutil attach "$TEMPORARY_DMG" -readwrite -noverify
+
+# Wait for a bit to ensure the image is mounted
+sleep 2
+
+# Link to /Applications within the DMG
+pushd "$VOLUME_DIRECTORY"
+ln -s /Applications
+popd
+
+# Symlink MacOS/Etcher to MacOS/Electron since for some reason, the Electron
+# binary tries to be ran in some systems.
+# See https://github.com/Microsoft/vscode/issues/92
+cp -p "$VOLUME_APPLICATION/Contents/MacOS/Etcher" "$VOLUME_APPLICATION/Contents/MacOS/Electron"
+
+# Set the DMG icon image
+# Writing this hexadecimal buffer to the com.apple.FinderInfo
+# extended attribute does the trick.
+# See https://github.com/LinusU/node-appdmg/issues/14#issuecomment-29080500
+cp "$ARGV_ICON" "$VOLUME_DIRECTORY/.VolumeIcon.icns"
+xattr -wx com.apple.FinderInfo \
+  "0000000000000000040000000000000000000000000000000000000000000000" "$VOLUME_DIRECTORY"
+
+# Configure background image.
+# We use tiffutil to create a "Multirepresentation Tiff file".
+# This allows us to show the retina and non-retina image when appropriate.
+mkdir "$VOLUME_DIRECTORY/.background"
+BACKGROUND_RETINA=$(echo "$ARGV_BACKGROUND" | sed 's/\(.*\)\./\1@2x./')
+tiffutil -cathidpicheck "$ARGV_BACKGROUND" "$BACKGROUND_RETINA" \
+  -out "$VOLUME_DIRECTORY/.background/installer.tiff"
+
+# This AppleScript performs the following tasks
+# - Set the window basic properties.
+# - Set the window size and position.
+# - Set the icon size.
+# - Arrange the icons.
+echo '
+   tell application "Finder"
+     tell disk "'"${ARGV_APPLICATION_NAME}"'"
+       open
+       set current view of container window to icon view
+       set toolbar visible of container window to false
+       set statusbar visible of container window to false
+       set the bounds of container window to {400, 100, 944, 530}
+       set viewOptions to the icon view options of container window
+       set arrangement of viewOptions to not arranged
+       set icon size of viewOptions to 110
+       set background picture of viewOptions to file ".background:installer.tiff"
+       set position of item "'"${ARGV_APPLICATION_NAME}".app'" of container window to {140, 225}
+       set position of item "Applications" of container window to {415, 225}
+       close
+       open
+       update without registering applications
+       delay 2
+       close
+     end tell
+   end tell
+' | osascript
+sync
+
+# Apply HFS+ compression
+afsctool -ci -9 "$VOLUME_APPLICATION"
+
+# TODO: this should be decoupled from this script
+./scripts/darwin/sign.sh -a "$VOLUME_APPLICATION" -i "$ARGV_IDENTITY"
+
+# Unmount temporary DMG image.
+hdiutil detach "$VOLUME_DIRECTORY"
+
+# Convert temporary DMG image into a production-ready
+# compressed and read-only DMG image.
+mkdir -p "$(dirname "$ARGV_OUTPUT")"
+hdiutil convert "$TEMPORARY_DMG" \
+  -format UDZO \
+  -imagekey zlib-level=9 \
+  -o "$ARGV_OUTPUT"

--- a/scripts/darwin/installer-zip.sh
+++ b/scripts/darwin/installer-zip.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+OS=$(uname)
+if [[ "$OS" != "Darwin" ]]; then
+  echo "This script is only meant to be run in OS X" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -a <application (.app)>"
+  echo "    -o <output>"
+  exit 0
+}
+
+ARGV_APPLICATION=""
+ARGV_OUTPUT=""
+
+while getopts ":a:o:" option; do
+  case $option in
+    a) ARGV_APPLICATION="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_APPLICATION" ] || [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+mkdir -p "$(dirname "$ARGV_OUTPUT")"
+CWD=$(pwd)
+pushd "$(dirname "$ARGV_APPLICATION")"
+zip -r -9 "$CWD/$ARGV_OUTPUT" "$(basename "$ARGV_APPLICATION")"
+popd

--- a/scripts/darwin/package.sh
+++ b/scripts/darwin/package.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+OS=$(uname)
+if [[ "$OS" != "Darwin" ]]; then
+  echo "This script is only meant to be run in OS X" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -n <application name>"
+  echo "    -r <application architecture>"
+  echo "    -v <application version>"
+  echo "    -b <application bundle id>"
+  echo "    -c <application copyright>"
+  echo "    -t <application category>"
+  echo "    -i <application icon (.icns)>"
+  echo "    -e <electron version>"
+  echo "    -o <output>"
+  exit 0
+}
+
+ARGV_APPLICATION_NAME=""
+ARGV_ARCHITECTURE=""
+ARGV_VERSION=""
+ARGV_BUNDLE_ID=""
+ARGV_COPYRIGHT=""
+ARGV_CATEGORY=""
+ARGV_ICON=""
+ARGV_ELECTRON_VERSION=""
+ARGV_OUTPUT=""
+
+while getopts ":n:r:v:b:c:t:i:e:o:" option; do
+  case $option in
+    n) ARGV_APPLICATION_NAME="$OPTARG" ;;
+    r) ARGV_ARCHITECTURE="$OPTARG" ;;
+    v) ARGV_VERSION="$OPTARG" ;;
+    b) ARGV_BUNDLE_ID="$OPTARG" ;;
+    c) ARGV_COPYRIGHT="$OPTARG" ;;
+    t) ARGV_CATEGORY="$OPTARG" ;;
+    i) ARGV_ICON="$OPTARG" ;;
+    e) ARGV_ELECTRON_VERSION="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_APPLICATION_NAME" ] \
+  || [ -z "$ARGV_ARCHITECTURE" ] \
+  || [ -z "$ARGV_VERSION" ] \
+  || [ -z "$ARGV_BUNDLE_ID" ] \
+  || [ -z "$ARGV_COPYRIGHT" ] \
+  || [ -z "$ARGV_CATEGORY" ] \
+  || [ -z "$ARGV_ICON" ] \
+  || [ -z "$ARGV_ELECTRON_VERSION" ] \
+  || [ -z "$ARGV_OUTPUT" ]
+then
+  usage
+fi
+
+ELECTRON_PACKAGER=./node_modules/.bin/electron-packager
+
+if [ ! -x $ELECTRON_PACKAGER ]; then
+  echo "Couldn't find $ELECTRON_PACKAGER" 1>&2
+  echo "Have you installed the dependencies first?" 1>&2
+  exit 1
+fi
+
+OUTPUT_DIRNAME=$(dirname "$ARGV_OUTPUT")
+
+mkdir -p "$OUTPUT_DIRNAME"
+
+$ELECTRON_PACKAGER . "$ARGV_APPLICATION_NAME" \
+  --platform=darwin \
+  --arch="$ARGV_ARCHITECTURE" \
+  --version="$ARGV_ELECTRON_VERSION" \
+  --ignore="$(node scripts/packageignore.js)" \
+  --asar \
+  --app-copyright="$ARGV_COPYRIGHT" \
+  --app-version="$ARGV_VERSION" \
+  --build-version="$ARGV_VERSION" \
+  --helper-bundle-id="$ARGV_BUNDLE_ID-helper" \
+  --app-bundle-id="$ARGV_BUNDLE_ID" \
+  --app-category-type="$ARGV_CATEGORY" \
+  --icon="$ARGV_ICON" \
+  --overwrite \
+  --out="$OUTPUT_DIRNAME"
+
+ELECTRON_PACKAGE_OUTPUT=$OUTPUT_DIRNAME/$ARGV_APPLICATION_NAME-darwin-$ARGV_ARCHITECTURE
+
+if [ "$ELECTRON_PACKAGE_OUTPUT" != "$ARGV_OUTPUT" ]; then
+  mv "$ELECTRON_PACKAGE_OUTPUT" "$ARGV_OUTPUT"
+fi
+
+rm "$ARGV_OUTPUT/LICENSE"
+rm "$ARGV_OUTPUT/LICENSES.chromium.html"
+rm "$ARGV_OUTPUT/version"

--- a/scripts/darwin/sign.sh
+++ b/scripts/darwin/sign.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+OS=$(uname)
+if [[ "$OS" != "Darwin" ]]; then
+  echo "This script is only meant to be run in OS X" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -a <application (.app)>"
+  echo "    -i <identity>"
+  exit 0
+}
+
+ARGV_APPLICATION=""
+ARGV_IDENTITY=""
+
+while getopts ":a:i:" option; do
+  case $option in
+    a) ARGV_APPLICATION="$OPTARG" ;;
+    i) ARGV_IDENTITY="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_APPLICATION" ] || [ -z "$ARGV_IDENTITY" ]; then
+  usage
+fi
+
+ELECTRON_OSX_SIGN=./node_modules/.bin/electron-osx-sign
+
+if [ ! -x $ELECTRON_OSX_SIGN ]; then
+  echo "Couldn't find $ELECTRON_OSX_SIGN" 1>&2
+  echo "Have you installed the dependencies first?" 1>&2
+  exit 1
+fi
+
+$ELECTRON_OSX_SIGN "$ARGV_APPLICATION" \
+  --platform darwin \
+  --verbose \
+  --identity "$ARGV_IDENTITY"
+
+codesign \
+  --verify \
+  --deep \
+  --display \
+  --verbose=4 "$ARGV_APPLICATION"
+
+spctl \
+  --ignore-cache \
+  --no-cache \
+  --assess \
+  --type execute \
+  --verbose=4 "$ARGV_APPLICATION"


### PR DESCRIPTION
This is the first step towards decoupling the build system as many
different scripts, for maintainability and convenience purposes.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>