### PR TITLE
fix(GUI): pressing escape cancels modal dialogue

### DIFF
--- a/lib/gui/components/modal/services/modal.js
+++ b/lib/gui/components/modal/services/modal.js
@@ -59,10 +59,15 @@ module.exports = function($uibModal, $q) {
           .then(resolve)
           .catch((error) => {
 
+            // Bootstrap doesn't 'resolve' these but cancels the dialog;
+            // therefore call 'resolve' here applied to 'false'.
+            if (error === 'escape key press' || error === 'backdrop click') {
+              resolve(false);
+
             // For some annoying reason, UI Bootstrap Modal rejects
             // the result reason if the user clicks on the backdrop
             // (e.g: the area surrounding the modal).
-            if (error !== 'backdrop click') {
+            } else if (error !== 'backdrop click') {
               return reject(error);
             }
 


### PR DESCRIPTION
Pressing the ESC key in any modal dialogue currently just emits a
message. This change actually cancels the modal, closing it.

Closes: https://github.com/resin-io/etcher/issues/874
Change-Type: patch
Changelog-Entry: Allow the user to press ESC to cancel a modal dialog.