### PR TITLE
refactor(GUI): resolve undefined on modal keyboard bindings

### DIFF
--- a/lib/gui/components/modal/services/modal.js
+++ b/lib/gui/components/modal/services/modal.js
@@ -62,7 +62,7 @@ module.exports = function($uibModal, $q) {
             // Bootstrap doesn't 'resolve' these but cancels the dialog;
             // therefore call 'resolve' here applied to 'false'.
             if (error === 'escape key press' || error === 'backdrop click') {
-              resolve(false);
+              resolve();
 
             // For some annoying reason, UI Bootstrap Modal rejects
             // the result reason if the user clicks on the backdrop


### PR DESCRIPTION
Currently we resolve `false`, which might not mean very much to some
modal use cases. `undefined` is a much more generic falsy value.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>