### PR TITLE
fix(GUI): wrap long words in drivelist

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6410,6 +6410,10 @@ body {
 .component-drive-selector-body .list-group-item-footer {
   margin-top: 8px; }
 
+.component-drive-selector-body .list-group-item-heading,
+.component-drive-selector-body .list-group-item-text {
+  word-break: break-all; }
+
 /*
  * Copyright 2016 resin.io
  *

--- a/lib/gui/components/drive-selector/styles/_drive-selector.scss
+++ b/lib/gui/components/drive-selector/styles/_drive-selector.scss
@@ -19,6 +19,15 @@
   height: 320px;
 }
 
-.component-drive-selector-body .list-group-item-footer {
-  margin-top: 8px;
+.component-drive-selector-body {
+
+  .list-group-item-footer {
+    margin-top: 8px;
+  }
+
+  .list-group-item-heading,
+  .list-group-item-text {
+    word-break: break-all;
+  }
 }
+


### PR DESCRIPTION
Drives with long names or descriptions expand outside the drivelist,
this commit fixes that using CSS `word-break: break-all`.

Change-Type: patch
Changelog-Entry: Wrap drive names and descriptions in drivelist.