### PR TITLE
fix(GUI): show not-allowed cursor over unselectable drives

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6407,6 +6407,9 @@ body {
   width: 300px;
   height: 320px; }
 
+.modal-drive-selector-modal .list-group-item[disabled] {
+  cursor: not-allowed; }
+
 .component-drive-selector-body .list-group-item-footer {
   margin-top: 8px; }
 

--- a/lib/gui/components/drive-selector/styles/_drive-selector.scss
+++ b/lib/gui/components/drive-selector/styles/_drive-selector.scss
@@ -19,6 +19,10 @@
   height: 320px;
 }
 
+.modal-drive-selector-modal .list-group-item[disabled] {
+  cursor: not-allowed;
+}
+
 .component-drive-selector-body {
 
   .list-group-item-footer {


### PR DESCRIPTION
The cursor is incorrectly a pointer on hover over a disabled and
unselectable drive in the drive selector widget. This patch changes the
cursor to `not-allowed`, providing the user with visual feedback that it is
not selectable.

Fixes: https://github.com/resin-io/etcher/issues/865
Change-Type: patch
Changelog-Entry: Use not-allowed cursor over disabled drives in the
drive selector widget.