### PR TITLE
fix(CLI): always omit first two elements of process.argv

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -18,7 +18,6 @@
 
 const _ = require('lodash');
 const fs = require('fs');
-const path = require('path');
 const yargs = require('yargs');
 const utils = require('./utils');
 const EXIT_CODES = require('../src/exit-codes');
@@ -123,38 +122,4 @@ module.exports = yargs
       default: true
     }
   })
-
-  // Make sure arguments are parsed correctly when running
-  // in development mode (or NPM) and in a final package.
-  //
-  // We rely on the following heuristics to determine if the
-  // Etcher CLI is being run as a final packaged executable
-  // or by a tool passing the script as an argument:
-  .parse(_.attempt((argv) => {
-
-    // Excluding the extension makes sure we cover cases
-    // like *.exe and *.cmd in Windows systems.
-    const executable = path.basename(argv[0], path.extname(argv[0])).toLowerCase();
-
-    if (_.includes([
-      'node',
-      'electron',
-      'electron helper'
-    ], executable)) {
-
-      // In this case, the second argument (e.g: index 1)
-      // equals `lib/cli/etcher.js`, so the real arguments
-      // start from the third one.
-      return argv.slice(2);
-
-    }
-
-    // Handle the case where the CLI is executed by pointing
-    // the packaged electron `Etcher` binary to the application
-    // asar archive by using `ELECTRON_RUN_AS_NODE`.
-    if (argv[1] && path.basename(argv[1]) === 'app.asar') {
-      return argv.slice(2);
-    }
-
-    return argv.slice(1);
-  }, process.argv));
+  .parse(process.argv.slice(2));


### PR DESCRIPTION
This is a great simplification to the logic previously included in the
Yargs `.parse()` function on the Etcher CLI.

There is no scenario where the CLI script will be executed in a
standalone fashion (e.g: `etcher.js <options>`), so we can always safely
drop the first two elements from `process.argv`.

Change-Type: patch
Changelog-Entry: Fix command line arguments not interpreted correctly when running the CLI with a custom named NodeJS binary.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>