### PR TITLE
upgrade: `drivelist` to v5.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1141,9 +1141,9 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "5.0.3",
-      "from": "drivelist@5.0.3",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.3.tgz",
+      "version": "5.0.4",
+      "from": "drivelist@5.0.4",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.4.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.3",
+    "drivelist": "^5.0.4",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^5.1.0",
     "etcher-image-write": "^8.1.4",


### PR DESCRIPTION
- https://github.com/resin-io-modules/drivelist/pull/125

Change-Type: patch
Changelog-Entry: Fix drive scanning exceptions on GNU/Linux systems with `net.ifnames` enabled.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>