### PR TITLE
chore: add `appdmg` and `ds-store` to `shrinkwrapIgnore`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -101,23 +101,6 @@
       "from": "any-promise@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
     },
-    "appdmg": {
-      "version": "0.3.10",
-      "from": "appdmg@>=0.3.6 <0.4.0",
-      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.3.10.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        }
-      }
-    },
     "aproba": {
       "version": "1.0.4",
       "from": "aproba@>=1.0.3 <2.0.0",
@@ -1168,11 +1151,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
         }
       }
-    },
-    "ds-store": {
-      "version": "0.1.6",
-      "from": "ds-store@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz"
     },
     "duplexer2": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "shrinkwrapIgnore": [
     "macos-alias",
     "fs-xattr",
-    "diskpart"
+    "ds-store",
+    "diskpart",
+    "appdmg"
   ],
   "builder": {
     "win": {


### PR DESCRIPTION
These dependencies are suddently causing issues when running `npm
install` in platforms other than OS X.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>