### PR TITLE
refactor: get rid of `electron-packager` in GNU/Linux

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -75,10 +75,18 @@ if [ "$COMMAND" == "install" ] || [ "$COMMAND" == "all" ]; then
 fi
 
 if [ "$COMMAND" == "package" ] || [ "$COMMAND" == "all" ]; then
+  ./scripts/unix/dependencies.sh \
+    -r "$ARCH" \
+    -v "$ELECTRON_VERSION" \
+    -t electron \
+    -p
+
   ./scripts/linux/package.sh \
     -n "$APPLICATION_NAME" \
     -r "$ARCH" \
     -v "$APPLICATION_VERSION" \
+    -l LICENSE \
+    -f "package.json,lib,node_modules,bower_components,build,assets" \
     -e "$ELECTRON_VERSION" \
     -o etcher-release/$APPLICATION_NAME-linux-$ARCH
 fi


### PR DESCRIPTION
In order to take a whitelisting approach to dependencies, the
`unix/dependencies.sh` script is ran as part of packaging as well, but
passing the `-p` (production) flag.

In the future, the current `install`, `package`, and `installer` targets
will be deplaced by `develop-<type>`, `installer-<type>`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>