### PR TITLE
chore: adopt new build script command convention in GNU/Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - npm install -g bower
   - npm install -g electron-installer-debian
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/linux.sh install x64;
+      ./scripts/build/linux.sh develop-electron x64;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install afsctool;

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -44,7 +44,8 @@ $ ./scripts/build/darwin.sh all
 Run the following command:
 
 ```sh
-$ ./scripts/build/linux.sh all <x64|x86>
+$ ./scripts/build/linux.sh installer-appimage <x64|x86>
+$ ./scripts/build/linux.sh installer-debian <x64|x86>
 ```
 
 ### Windows

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -56,7 +56,7 @@ the application might not run successfully.
 ### GNU/Linux
 
 ```sh
-./scripts/build/linux.sh install <x64|x86>
+./scripts/build/linux.sh develop-electron <x64|x86>
 ```
 
 ### Windows

--- a/scripts/linux/installer-appimage.sh
+++ b/scripts/linux/installer-appimage.sh
@@ -130,6 +130,9 @@ download_executable \
 # Compress binaries
 upx -9 "$APPDIR_PATH/usr/bin/$ARGV_BINARY"
 
+# upx fails with an error if .so are not executables
+chmod +x "$APPDIR_PATH"/usr/bin/*.so*
+
 # UPX fails for some reason with some other so libraries
 # other than libnode.so in the x86 build
 if [ "$ARGV_ARCHITECTURE" == "x86" ]; then

--- a/scripts/linux/package.sh
+++ b/scripts/linux/package.sh
@@ -18,7 +18,6 @@
 
 set -u
 set -e
-set -x
 
 OS=$(uname)
 if [[ "$OS" != "Linux" ]]; then
@@ -84,6 +83,7 @@ then
 fi
 
 OUTPUT_DIRNAME=$(dirname "$ARGV_OUTPUT")
+rm -rf "$ARGV_OUTPUT"
 mkdir -p "$OUTPUT_DIRNAME"
 
 ELECTRON_ARCHITECTURE=$ARGV_ARCHITECTURE


### PR DESCRIPTION
The GNU/Linux build script (as the rest of the OSes will in the near
future), now accepts the following command:

- `develop-electron`
- `develop-cli`
- `installer-cli`
- `installer-appimage`
- `installer-debian`

Each of the commands is now completely independent from the others.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>