### PR TITLE
refactor: ditch `electron-osx-sign` for OS X signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "cz-conventional-changelog": "^1.1.6",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^3.1.1",
-    "electron-osx-sign": "^0.3.0",
     "electron-packager": "^7.0.1",
     "electron-prebuilt": "1.4.4",
     "eslint": "^2.13.1",


### PR DESCRIPTION
Making use of `codesign` directly allows us to have much more
flexibility in how we sign things, which will prove very valuable when
adapting this `sign.sh` script to code sign the Etcher CLI.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>