### PR TITLE
chore: adopt new build command convention for OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
       brew install afsctool;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      ./scripts/build/darwin.sh install;
+      ./scripts/build/darwin.sh develop-electron;
     fi
 
 before_script:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -36,7 +36,8 @@ The resulting installers will be saved to `etcher-release/installers`.
 Run the following command:
 
 ```sh
-$ ./scripts/build/darwin.sh all
+$ ./scripts/build/darwin.sh installer-dmg
+$ ./scripts/build/darwin.sh installer-zip
 ```
 
 ### GNU/Linux

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -50,7 +50,7 @@ the application might not run successfully.
 ### OS X
 
 ```sh
-./scripts/build/darwin.sh install
+./scripts/build/darwin.sh develop-electron
 ```
 
 ### GNU/Linux

--- a/scripts/darwin/installer-dmg.sh
+++ b/scripts/darwin/installer-dmg.sh
@@ -103,11 +103,6 @@ pushd "$VOLUME_DIRECTORY"
 ln -s /Applications
 popd
 
-# Symlink MacOS/Etcher to MacOS/Electron since for some reason, the Electron
-# binary tries to be ran in some systems.
-# See https://github.com/Microsoft/vscode/issues/92
-cp -p "$VOLUME_APPLICATION/Contents/MacOS/Etcher" "$VOLUME_APPLICATION/Contents/MacOS/Electron"
-
 # Set the DMG icon image
 # Writing this hexadecimal buffer to the com.apple.FinderInfo
 # extended attribute does the trick.

--- a/scripts/linux/package.sh
+++ b/scripts/linux/package.sh
@@ -25,16 +25,6 @@ if [[ "$OS" != "Linux" ]]; then
   exit 1
 fi
 
-if ! command -v asar 2>/dev/null 1>&2; then
-  echo "Dependency missing: asar" 1>&2
-  exit 1
-fi
-
-if ! command -v wget 2>/dev/null 1>&2; then
-  echo "Dependency missing: wget" 1>&2
-  exit 1
-fi
-
 function usage() {
   echo "Usage: $0"
   echo ""
@@ -92,11 +82,7 @@ mv $ARGV_OUTPUT/electron $ARGV_OUTPUT/$(echo "$ARGV_APPLICATION_NAME" | tr '[:up
 cp $ARGV_LICENSE $ARGV_OUTPUT/LICENSE
 echo "$ARGV_VERSION" > $ARGV_OUTPUT/version
 rm $ARGV_OUTPUT/resources/default_app.asar
-mkdir -p $ARGV_OUTPUT/resources/app
 
-for file in $(echo $ARGV_FILES | sed "s/,/ /g"); do
-  cp -rf "$file" $ARGV_OUTPUT/resources/app
-done
-
-asar pack $ARGV_OUTPUT/resources/app $ARGV_OUTPUT/resources/app.asar --unpack *.node
-rm -rf $ARGV_OUTPUT/resources/app
+./scripts/unix/create-asar.sh \
+  -f "$ARGV_FILES" \
+  -o "$ARGV_OUTPUT/resources/app.asar"

--- a/scripts/unix/create-asar.sh
+++ b/scripts/unix/create-asar.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+if ! command -v asar 2>/dev/null 1>&2; then
+  echo "Dependency missing: asar" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -f <files (comma separated)>"
+  echo "    -o <output>"
+  exit 0
+}
+
+ARGV_FILES=""
+ARGV_OUTPUT=""
+
+while getopts ":f:o:" option; do
+  case $option in
+    f) ARGV_FILES=$OPTARG ;;
+    o) ARGV_OUTPUT=$OPTARG ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_FILES" ] || [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+TEMPORAL_DIRECTORY="$ARGV_OUTPUT.tmp"
+rm -rf "$TEMPORAL_DIRECTORY"
+mkdir -p "$TEMPORAL_DIRECTORY"
+
+for file in $(echo "$ARGV_FILES" | sed "s/,/ /g"); do
+  cp -rf "$file" "$TEMPORAL_DIRECTORY"
+done
+
+mkdir -p $(dirname "$ARGV_OUTPUT")
+asar pack "$TEMPORAL_DIRECTORY" "$ARGV_OUTPUT" --unpack *.node
+rm -rf "$TEMPORAL_DIRECTORY"


### PR DESCRIPTION
The `darwin.sh` script now accepts the following commands:

- `develop-electron`
- `installer-dmg`
- `installer-zip`

In order to accomplish this, `./scripts/darwin/package.sh` is no longer
relying on `electron-packager`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>