### PR TITLE
fix: don't lock `installer-cli` architecture to x64 in build scripts

### DIFF
--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -72,7 +72,7 @@ if [ "$COMMAND" == "installer-cli" ]; then
   ./scripts/unix/package-cli.sh \
     -n etcher \
     -e bin/etcher \
-    -r x64 \
+    -r "$ARCH" \
     -s linux \
     -o etcher-release/etcher-cli-linux-$ARCH
   exit 0


### PR DESCRIPTION
We were accidentally hardcoding the installer generation to `x64`.

See: https://github.com/resin-io/etcher/pull/896#discussion_r89999295
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>