### PR TITLE
chore: install dependencies directly in package

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -66,22 +66,36 @@ if [ "$COMMAND" == "develop-electron" ]; then
 fi
 
 if [ "$COMMAND" == "installer-dmg" ]; then
+  ./scripts/unix/create-electron-app.sh \
+    -s . \
+    -f "lib,build,assets" \
+    -o "etcher-release/app"
+
   ./scripts/unix/dependencies.sh -p \
     -r x64 \
     -v "$ELECTRON_VERSION" \
+    -x "etcher-release/app" \
     -t electron
 
-  ./scripts/darwin/package.sh \
-    -n $APPLICATION_NAME \
+  ./scripts/unix/create-asar.sh \
+    -d "etcher-release/app" \
+    -o "etcher-release/app.asar"
+
+  ./scripts/unix/download-electron.sh \
     -r x64 \
+    -v "$ELECTRON_VERSION" \
+    -s darwin \
+    -o etcher-release/$APPLICATION_NAME-darwin-x64
+
+  ./scripts/darwin/configure-electron.sh \
+    -d etcher-release/$APPLICATION_NAME-darwin-x64 \
+    -n $APPLICATION_NAME \
     -v $APPLICATION_VERSION \
     -b io.resin.etcher \
     -c "$APPLICATION_COPYRIGHT" \
     -t public.app-category.developer-tools \
-    -f "package.json,lib,node_modules,bower_components,build,assets" \
-    -i assets/icon.icns \
-    -e $ELECTRON_VERSION \
-    -o etcher-release/$APPLICATION_NAME-darwin-x64
+    -a "etcher-release/app.asar" \
+    -i assets/icon.icns
 
   ./scripts/darwin/installer-dmg.sh \
     -n $APPLICATION_NAME \
@@ -96,22 +110,36 @@ if [ "$COMMAND" == "installer-dmg" ]; then
 fi
 
 if [ "$COMMAND" == "installer-zip" ]; then
+  ./scripts/unix/create-electron-app.sh \
+    -s . \
+    -f "lib,build,assets" \
+    -o "etcher-release/app"
+
   ./scripts/unix/dependencies.sh -p \
     -r x64 \
     -v "$ELECTRON_VERSION" \
+    -x "etcher-release/app" \
     -t electron
 
-  ./scripts/darwin/package.sh \
-    -n $APPLICATION_NAME \
+  ./scripts/unix/create-asar.sh \
+    -d "etcher-release/app" \
+    -o "etcher-release/app.asar"
+
+  ./scripts/unix/download-electron.sh \
     -r x64 \
+    -v "$ELECTRON_VERSION" \
+    -s darwin \
+    -o etcher-release/$APPLICATION_NAME-darwin-x64
+
+  ./scripts/darwin/configure-electron.sh \
+    -d etcher-release/$APPLICATION_NAME-darwin-x64 \
+    -n $APPLICATION_NAME \
     -v $APPLICATION_VERSION \
     -b io.resin.etcher \
     -c "$APPLICATION_COPYRIGHT" \
     -t public.app-category.developer-tools \
-    -f "package.json,lib,node_modules,bower_components,build,assets" \
-    -i assets/icon.icns \
-    -e $ELECTRON_VERSION \
-    -o etcher-release/$APPLICATION_NAME-darwin-x64
+    -a "etcher-release/app.asar" \
+    -i assets/icon.icns
 
   ./scripts/darwin/sign.sh \
     -a etcher-release/$APPLICATION_NAME-darwin-x64/$APPLICATION_NAME.app \

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -86,19 +86,33 @@ if [ "$COMMAND" == "installer-cli" ]; then
 fi
 
 if [ "$COMMAND" == "installer-debian" ]; then
+  ./scripts/unix/create-electron-app.sh \
+    -s . \
+    -f "lib,build,assets" \
+    -o "etcher-release/app"
+
   ./scripts/unix/dependencies.sh -p \
     -r "$ARCH" \
     -v "$ELECTRON_VERSION" \
+    -x "etcher-release/app" \
     -t electron
 
-  ./scripts/linux/package.sh \
-    -n "$APPLICATION_NAME" \
+  ./scripts/unix/create-asar.sh \
+    -d "etcher-release/app" \
+    -o "etcher-release/app.asar"
+
+  ./scripts/unix/download-electron.sh \
     -r "$ARCH" \
+    -v "$ELECTRON_VERSION" \
+    -s linux \
+    -o "etcher-release/$APPLICATION_NAME-linux-$ARCH"
+
+  ./scripts/linux/configure-electron.sh \
+    -d etcher-release/$APPLICATION_NAME-linux-$ARCH \
+    -n "$APPLICATION_NAME" \
     -v "$APPLICATION_VERSION" \
     -l LICENSE \
-    -f "package.json,lib,node_modules,bower_components,build,assets" \
-    -e "$ELECTRON_VERSION" \
-    -o etcher-release/$APPLICATION_NAME-linux-$ARCH
+    -a "etcher-release/app.asar"
 
   ./scripts/linux/installer-deb.sh \
     -p etcher-release/$APPLICATION_NAME-linux-$ARCH \
@@ -112,19 +126,33 @@ fi
 if [ "$COMMAND" == "installer-appimage" ]; then
   check_dep zip
 
+  ./scripts/unix/create-electron-app.sh \
+    -s . \
+    -f "lib,build,assets" \
+    -o "etcher-release/app"
+
   ./scripts/unix/dependencies.sh -p \
     -r "$ARCH" \
     -v "$ELECTRON_VERSION" \
+    -x "etcher-release/app" \
     -t electron
 
-  ./scripts/linux/package.sh \
-    -n "$APPLICATION_NAME" \
+  ./scripts/unix/create-asar.sh \
+    -d "etcher-release/app" \
+    -o "etcher-release/app.asar"
+
+  ./scripts/unix/download-electron.sh \
     -r "$ARCH" \
+    -v "$ELECTRON_VERSION" \
+    -s linux \
+    -o "etcher-release/$APPLICATION_NAME-linux-$ARCH"
+
+  ./scripts/linux/configure-electron.sh \
+    -d etcher-release/$APPLICATION_NAME-linux-$ARCH \
+    -n "$APPLICATION_NAME" \
     -v "$APPLICATION_VERSION" \
     -l LICENSE \
-    -f "package.json,lib,node_modules,bower_components,build,assets" \
-    -e "$ELECTRON_VERSION" \
-    -o etcher-release/$APPLICATION_NAME-linux-$ARCH
+    -a "etcher-release/app.asar"
 
   ./scripts/linux/installer-appimage.sh \
     -n "$APPLICATION_NAME" \

--- a/scripts/darwin/configure-electron.sh
+++ b/scripts/darwin/configure-electron.sh
@@ -39,73 +39,59 @@ function usage() {
   echo ""
   echo "Options"
   echo ""
+  echo "    -d <electron directory>"
   echo "    -n <application name>"
-  echo "    -r <application architecture>"
   echo "    -v <application version>"
   echo "    -b <application bundle id>"
   echo "    -c <application copyright>"
   echo "    -t <application category>"
-  echo "    -f <application files (comma separated)>"
+  echo "    -a <application asar (.asar)>"
   echo "    -i <application icon (.icns)>"
-  echo "    -e <electron version>"
-  echo "    -o <output>"
   exit 0
 }
 
+ARGV_ELECTRON_DIRECTORY=""
 ARGV_APPLICATION_NAME=""
-ARGV_ARCHITECTURE=""
 ARGV_VERSION=""
 ARGV_BUNDLE_ID=""
 ARGV_COPYRIGHT=""
 ARGV_CATEGORY=""
-ARGV_FILES=""
+ARGV_ASAR=""
 ARGV_ICON=""
-ARGV_ELECTRON_VERSION=""
-ARGV_OUTPUT=""
 
-while getopts ":n:r:v:b:c:t:f:i:e:o:" option; do
+while getopts ":d:n:v:b:c:t:a:i:" option; do
   case $option in
+    d) ARGV_ELECTRON_DIRECTORY="$OPTARG" ;;
     n) ARGV_APPLICATION_NAME="$OPTARG" ;;
-    r) ARGV_ARCHITECTURE="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;
     b) ARGV_BUNDLE_ID="$OPTARG" ;;
     c) ARGV_COPYRIGHT="$OPTARG" ;;
     t) ARGV_CATEGORY="$OPTARG" ;;
-    f) ARGV_FILES="$OPTARG" ;;
+    a) ARGV_ASAR="$OPTARG" ;;
     i) ARGV_ICON="$OPTARG" ;;
-    e) ARGV_ELECTRON_VERSION="$OPTARG" ;;
-    o) ARGV_OUTPUT="$OPTARG" ;;
     *) usage ;;
   esac
 done
 
-if [ -z "$ARGV_APPLICATION_NAME" ] \
-  || [ -z "$ARGV_ARCHITECTURE" ] \
+if [ -z "$ARGV_ELECTRON_DIRECTORY" ] \
+  || [ -z "$ARGV_APPLICATION_NAME" ] \
   || [ -z "$ARGV_VERSION" ] \
   || [ -z "$ARGV_BUNDLE_ID" ] \
   || [ -z "$ARGV_COPYRIGHT" ] \
   || [ -z "$ARGV_CATEGORY" ] \
-  || [ -z "$ARGV_FILES" ] \
-  || [ -z "$ARGV_ICON" ] \
-  || [ -z "$ARGV_ELECTRON_VERSION" ] \
-  || [ -z "$ARGV_OUTPUT" ]
+  || [ -z "$ARGV_ASAR" ] \
+  || [ -z "$ARGV_ICON" ]
 then
   usage
 fi
 
-./scripts/unix/download-electron.sh \
-  -r "$ARGV_ARCHITECTURE" \
-  -v "$ARGV_ELECTRON_VERSION" \
-  -s darwin \
-  -o "$ARGV_OUTPUT"
-
-APPLICATION_OUTPUT="$ARGV_OUTPUT/$ARGV_APPLICATION_NAME.app"
-mv "$ARGV_OUTPUT/Electron.app" "$APPLICATION_OUTPUT"
+APPLICATION_OUTPUT="$ARGV_ELECTRON_DIRECTORY/$ARGV_APPLICATION_NAME.app"
+mv "$ARGV_ELECTRON_DIRECTORY/Electron.app" "$APPLICATION_OUTPUT"
 rm "$APPLICATION_OUTPUT/Contents/Resources/default_app.asar"
 
 # Don't include these for now
-rm -f "$ARGV_OUTPUT"/LICENSE*
-rm -f "$ARGV_OUTPUT/version"
+rm -f "$ARGV_ELECTRON_DIRECTORY"/LICENSE*
+rm -f "$ARGV_ELECTRON_DIRECTORY/version"
 
 function plist_set() {
   local plist_file=$1
@@ -153,6 +139,8 @@ for id in EH NP; do
     "$APPLICATION_OUTPUT/Contents/Frameworks/$ARGV_APPLICATION_NAME Helper $id.app"
 done
 
-./scripts/unix/create-asar.sh \
-  -f "$ARGV_FILES" \
-  -o "$APPLICATION_OUTPUT/Contents/Resources/app.asar"
+cp "$ARGV_ASAR" "$APPLICATION_OUTPUT/Contents/Resources/app.asar"
+
+if [ -d "$ARGV_ASAR.unpacked" ]; then
+  cp -rf "$ARGV_ASAR.unpacked" "$APPLICATION_OUTPUT/Contents/Resources/app.asar.unpacked"
+fi

--- a/scripts/linux/configure-electron.sh
+++ b/scripts/linux/configure-electron.sh
@@ -37,59 +37,47 @@ function usage() {
   echo ""
   echo "Options"
   echo ""
+  echo "    -d <electron directory>"
   echo "    -n <application name>"
-  echo "    -r <application architecture>"
   echo "    -v <application version>"
   echo "    -l <application license file>"
-  echo "    -f <application files (comma separated)>"
-  echo "    -e <electron version>"
-  echo "    -o <output>"
+  echo "    -a <application asar (.asar)>"
   exit 0
 }
 
+ARGV_ELECTRON_DIRECTORY=""
 ARGV_APPLICATION_NAME=""
-ARGV_ARCHITECTURE=""
 ARGV_VERSION=""
 ARGV_LICENSE=""
-ARGV_FILES=""
-ARGV_ELECTRON_VERSION=""
-ARGV_OUTPUT=""
+ARGV_ASAR=""
 
-while getopts ":n:r:v:l:f:e:o:" option; do
+while getopts ":d:n:v:l:a:" option; do
   case $option in
+    d) ARGV_ELECTRON_DIRECTORY="$OPTARG" ;;
     n) ARGV_APPLICATION_NAME="$OPTARG" ;;
-    r) ARGV_ARCHITECTURE="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;
     l) ARGV_LICENSE="$OPTARG" ;;
-    f) ARGV_FILES="$OPTARG" ;;
-    e) ARGV_ELECTRON_VERSION="$OPTARG" ;;
-    o) ARGV_OUTPUT="$OPTARG" ;;
+    a) ARGV_ASAR="$OPTARG" ;;
     *) usage ;;
   esac
 done
 
-if [ -z "$ARGV_APPLICATION_NAME" ] \
-  || [ -z "$ARGV_ARCHITECTURE" ] \
+if [ -z "$ARGV_ELECTRON_DIRECTORY" ] \
+  || [ -z "$ARGV_APPLICATION_NAME" ] \
   || [ -z "$ARGV_VERSION" ] \
   || [ -z "$ARGV_LICENSE" ] \
-  || [ -z "$ARGV_FILES" ] \
-  || [ -z "$ARGV_ELECTRON_VERSION" ] \
-  || [ -z "$ARGV_OUTPUT" ]
+  || [ -z "$ARGV_ASAR" ]
 then
   usage
 fi
 
-./scripts/unix/download-electron.sh \
-  -r "$ARGV_ARCHITECTURE" \
-  -v "$ARGV_ELECTRON_VERSION" \
-  -s linux \
-  -o "$ARGV_OUTPUT"
+mv $ARGV_ELECTRON_DIRECTORY/electron $ARGV_ELECTRON_DIRECTORY/$(echo "$ARGV_APPLICATION_NAME" | tr '[:upper:]' '[:lower:]')
+cp $ARGV_LICENSE $ARGV_ELECTRON_DIRECTORY/LICENSE
+echo "$ARGV_VERSION" > $ARGV_ELECTRON_DIRECTORY/version
+rm $ARGV_ELECTRON_DIRECTORY/resources/default_app.asar
 
-mv $ARGV_OUTPUT/electron $ARGV_OUTPUT/$(echo "$ARGV_APPLICATION_NAME" | tr '[:upper:]' '[:lower:]')
-cp $ARGV_LICENSE $ARGV_OUTPUT/LICENSE
-echo "$ARGV_VERSION" > $ARGV_OUTPUT/version
-rm $ARGV_OUTPUT/resources/default_app.asar
+cp "$ARGV_ASAR" "$ARGV_ELECTRON_DIRECTORY/resources/app.asar"
 
-./scripts/unix/create-asar.sh \
-  -f "$ARGV_FILES" \
-  -o "$ARGV_OUTPUT/resources/app.asar"
+if [ -d "$ARGV_ASAR.unpacked" ]; then
+  cp -rf "$ARGV_ASAR.unpacked" "$ARGV_ELECTRON_DIRECTORY/resources/app.asar.unpacked"
+fi


### PR DESCRIPTION
Previously, the build scripts would override the top level
`node_modules` and `bower_components`. After this commit, the
dependencies are installed directly in the Electron package.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>