### PR TITLE
chore: split `dependencies.sh` into bower and npm scripts

### DIFF
--- a/scripts/build/darwin.sh
+++ b/scripts/build/darwin.sh
@@ -47,7 +47,7 @@ APPLICATION_COPYRIGHT=`node -e "console.log(require('./package.json').copyright)
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
 
 if [ "$COMMAND" == "cli" ]; then
-  ./scripts/unix/dependencies.sh -r x64 -v 6.2.2 -t node -f -p
+  ./scripts/unix/dependencies-npm.sh -r x64 -v 6.2.2 -t node -f -p
   ./scripts/unix/package-cli.sh \
     -n etcher \
     -e bin/etcher \
@@ -58,10 +58,11 @@ if [ "$COMMAND" == "cli" ]; then
 fi
 
 if [ "$COMMAND" == "develop-electron" ]; then
-  ./scripts/unix/dependencies.sh \
+  ./scripts/unix/dependencies-npm.sh \
     -r x64 \
     -v "$ELECTRON_VERSION" \
     -t electron
+  ./scripts/unix/dependencies-bower.sh
   exit 0
 fi
 
@@ -71,11 +72,14 @@ if [ "$COMMAND" == "installer-dmg" ]; then
     -f "lib,build,assets" \
     -o "etcher-release/app"
 
-  ./scripts/unix/dependencies.sh -p \
+  ./scripts/unix/dependencies-npm.sh -p \
     -r x64 \
     -v "$ELECTRON_VERSION" \
     -x "etcher-release/app" \
     -t electron
+
+  ./scripts/unix/dependencies-bower.sh -p \
+    -x "etcher-release/app"
 
   ./scripts/unix/create-asar.sh \
     -d "etcher-release/app" \
@@ -115,11 +119,14 @@ if [ "$COMMAND" == "installer-zip" ]; then
     -f "lib,build,assets" \
     -o "etcher-release/app"
 
-  ./scripts/unix/dependencies.sh -p \
+  ./scripts/unix/dependencies-npm.sh -p \
     -r x64 \
     -v "$ELECTRON_VERSION" \
     -x "etcher-release/app" \
     -t electron
+
+  ./scripts/unix/dependencies-bower.sh -p \
+    -x "etcher-release/app"
 
   ./scripts/unix/create-asar.sh \
     -d "etcher-release/app" \

--- a/scripts/build/linux.sh
+++ b/scripts/build/linux.sh
@@ -55,15 +55,16 @@ APPLICATION_DESCRIPTION=`node -e "console.log(require('./package.json').descript
 APPLICATION_VERSION=`node -e "console.log(require('./package.json').version)"`
 
 if [ "$COMMAND" == "develop-electron" ]; then
-  ./scripts/unix/dependencies.sh \
+  ./scripts/unix/dependencies-npm.sh \
     -r "$ARCH" \
     -v "$ELECTRON_VERSION" \
     -t electron
+  ./scripts/unix/dependencies-bower.sh
   exit 0
 fi
 
 if [ "$COMMAND" == "develop-cli" ]; then
-  ./scripts/unix/dependencies.sh \
+  ./scripts/unix/dependencies-npm.sh \
     -r "$ARCH" \
     -v "$NODE_VERSION" \
     -t node
@@ -71,7 +72,7 @@ if [ "$COMMAND" == "develop-cli" ]; then
 fi
 
 if [ "$COMMAND" == "installer-cli" ]; then
-  ./scripts/unix/dependencies.sh -f -p \
+  ./scripts/unix/dependencies-npm.sh -f -p \
     -r "$ARCH" \
     -v "$NODE_VERSION" \
     -t node
@@ -91,11 +92,14 @@ if [ "$COMMAND" == "installer-debian" ]; then
     -f "lib,build,assets" \
     -o "etcher-release/app"
 
-  ./scripts/unix/dependencies.sh -p \
+  ./scripts/unix/dependencies-npm.sh -p \
     -r "$ARCH" \
     -v "$ELECTRON_VERSION" \
     -x "etcher-release/app" \
     -t electron
+
+  ./scripts/unix/dependencies-bower.sh -p \
+    -x "etcher-release/app"
 
   ./scripts/unix/create-asar.sh \
     -d "etcher-release/app" \
@@ -131,11 +135,14 @@ if [ "$COMMAND" == "installer-appimage" ]; then
     -f "lib,build,assets" \
     -o "etcher-release/app"
 
-  ./scripts/unix/dependencies.sh -p \
+  ./scripts/unix/dependencies-npm.sh -p \
     -r "$ARCH" \
     -v "$ELECTRON_VERSION" \
     -x "etcher-release/app" \
     -t electron
+
+  ./scripts/unix/dependencies-bower.sh -p \
+    -x "etcher-release/app"
 
   ./scripts/unix/create-asar.sh \
     -d "etcher-release/app" \

--- a/scripts/unix/dependencies-bower.sh
+++ b/scripts/unix/dependencies-bower.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+function check_dep() {
+  if ! command -v $1 2>/dev/null 1>&2; then
+    echo "Dependency missing: $1" 1>&2
+    exit 1
+  fi
+}
+
+check_dep bower
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -x <install prefix>"
+  echo "    -p production install"
+  exit 0
+}
+
+ARGV_PREFIX=""
+ARGV_PRODUCTION=false
+
+while getopts ":x:p" option; do
+  case $option in
+    x) ARGV_PREFIX=$OPTARG ;;
+    p) ARGV_PRODUCTION=true ;;
+    *) usage ;;
+  esac
+done
+
+INSTALL_OPTS="--allow-root"
+
+if [ "$ARGV_PRODUCTION" == "true" ]; then
+  INSTALL_OPTS="$INSTALL_OPTS --production"
+fi
+
+if [ -n "$ARGV_PREFIX" ]; then
+  pushd "$ARGV_PREFIX"
+  bower install $INSTALL_OPTS
+  popd
+else
+  bower install $INSTALL_OPTS
+fi
+

--- a/scripts/unix/dependencies-npm.sh
+++ b/scripts/unix/dependencies-npm.sh
@@ -27,7 +27,6 @@ function check_dep() {
 }
 
 check_dep npm
-check_dep bower
 check_dep python
 
 function usage() {
@@ -87,35 +86,23 @@ else
   export npm_config_arch=$ARGV_ARCHITECTURE
 fi
 
-NPM_INSTALL_OPTS="--build-from-source"
+INSTALL_OPTS="--build-from-source"
 
 if [ "$ARGV_FORCE" == "true" ]; then
-  NPM_INSTALL_OPTS="$NPM_INSTALL_OPTS --force"
+  INSTALL_OPTS="$INSTALL_OPTS --force"
 fi
 
 if [ "$ARGV_PRODUCTION" == "true" ]; then
-  NPM_INSTALL_OPTS="$NPM_INSTALL_OPTS --production"
+  INSTALL_OPTS="$INSTALL_OPTS --production"
 fi
 
 if [ -n "$ARGV_PREFIX" ]; then
-  NPM_INSTALL_OPTS="$NPM_INSTALL_OPTS --prefix=$ARGV_PREFIX"
+  INSTALL_OPTS="$INSTALL_OPTS --prefix=$ARGV_PREFIX"
 fi
 
-npm install $NPM_INSTALL_OPTS
+npm install $INSTALL_OPTS
 
 # Using `--prefix` might cause npm to create an empty `etc` directory
 if [ -n "$ARGV_PREFIX" ] && [ ! "$(ls -A "$ARGV_PREFIX/etc")" ]; then
   rm -rf "$ARGV_PREFIX/etc"
-fi
-
-if [ "$ARGV_TARGET_PLATFORM" == "electron" ]; then
-  BOWER_INSTALL_OPTS="--production --allow-root"
-
-  if [ -n "$ARGV_PREFIX" ]; then
-    pushd "$ARGV_PREFIX"
-    bower install $BOWER_INSTALL_OPTS
-    popd
-  fi
-
-  bower install $BOWER_INSTALL_OPTS
 fi


### PR DESCRIPTION
The purpose of this change is to stay true to the Makefile approach,
where each rule is meant to create a single directory/file.

Currently, `unix/dependencies.sh` resulted in `bower_components` and
`node_modules`. Splitting this rule also means that we don't have to
install bower dependencies where we don't need them (e.g: the CLI).

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>