### PR TITLE
chore: cache chocolatey installs as recommended by Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,20 +9,20 @@ image: Visual Studio 2013
 cache:
   - C:\Users\appveyor\.node-gyp
   - '%AppData%\npm-cache'
-  - '%CHOCOLATEY_CACHE%'
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+  - C:\Users\appveyor\AppData\Local\Temp\chocolatey -> appveyor.yml
 
 # what combinations to test
 environment:
   global:
     ELECTRON_NO_ATTACH_CONSOLE: true
-    CHOCOLATEY_CACHE: '%AppData%\chocolatey-cache'
   matrix:
     - nodejs_version: 6.1.0
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm install -g npm bower rimraf asar
-  - choco config set cacheLocation %CHOCOLATEY_CACHE%
   - choco install nsis -version 2.51
   - choco install upx
   - choco install 7zip.commandline


### PR DESCRIPTION
We tried to save the Chocolatey cache in a previous PR, but it looks
like its not working properly. This PR implements the "correct" way to
cache Chocolatey installs, as recommended in Appveyor forums.

The arrows mean that the cache is invalidated if the file in the right
side (`appveyor.yml`) in this case, is changed.

See: http://help.appveyor.com/discussions/suggestions/592-speeding-up-chocolatey-downloads-and-installs
See: https://github.com/resin-io/etcher/commit/e603cb0838b005f1c8430bbce4c98b431d9c1ba9
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>