### PR TITLE
chore: exit with error code 1 on build script usage section

### DIFF
--- a/scripts/darwin/configure-electron.sh
+++ b/scripts/darwin/configure-electron.sh
@@ -47,7 +47,7 @@ function usage() {
   echo "    -t <application category>"
   echo "    -a <application asar (.asar)>"
   echo "    -i <application icon (.icns)>"
-  exit 0
+  exit 1
 }
 
 ARGV_ELECTRON_DIRECTORY=""

--- a/scripts/darwin/installer-dmg.sh
+++ b/scripts/darwin/installer-dmg.sh
@@ -50,7 +50,7 @@ function usage() {
   echo "    -i <application icon (.icns)>"
   echo "    -b <application background (.png)>"
   echo "    -o <output>"
-  exit 0
+  exit 1
 }
 
 ARGV_APPLICATION_NAME=""

--- a/scripts/darwin/installer-zip.sh
+++ b/scripts/darwin/installer-zip.sh
@@ -41,7 +41,7 @@ function usage() {
   echo ""
   echo "    -a <application (.app)>"
   echo "    -o <output>"
-  exit 0
+  exit 1
 }
 
 ARGV_APPLICATION=""

--- a/scripts/darwin/sign.sh
+++ b/scripts/darwin/sign.sh
@@ -42,7 +42,7 @@ function usage() {
   echo ""
   echo "    -a <application (.app)>"
   echo "    -i <identity>"
-  exit 0
+  exit 1
 }
 
 ARGV_APPLICATION=""

--- a/scripts/linux/configure-electron.sh
+++ b/scripts/linux/configure-electron.sh
@@ -42,7 +42,7 @@ function usage() {
   echo "    -v <application version>"
   echo "    -l <application license file>"
   echo "    -a <application asar (.asar)>"
-  exit 0
+  exit 1
 }
 
 ARGV_ELECTRON_DIRECTORY=""

--- a/scripts/linux/installer-appimage.sh
+++ b/scripts/linux/installer-appimage.sh
@@ -47,7 +47,7 @@ function usage() {
   echo "    -b <application binary name>"
   echo "    -i <application icon (.png)>"
   echo "    -o <output>"
-  exit 0
+  exit 1
 }
 
 ARGV_APPLICATION_NAME=""

--- a/scripts/linux/installer-deb.sh
+++ b/scripts/linux/installer-deb.sh
@@ -43,7 +43,7 @@ function usage() {
   echo "    -r <application architecture>"
   echo "    -c <debian configuration (.json)>"
   echo "    -o <output directory>"
-  exit 0
+  exit 1
 }
 
 ARGV_DIRECTORY=""

--- a/scripts/unix/create-asar.sh
+++ b/scripts/unix/create-asar.sh
@@ -35,7 +35,7 @@ function usage() {
   echo ""
   echo "    -d <directory>"
   echo "    -o <output>"
-  exit 0
+  exit 1
 }
 
 ARGV_DIRECTORY=""

--- a/scripts/unix/create-electron-app.sh
+++ b/scripts/unix/create-electron-app.sh
@@ -27,7 +27,7 @@ function usage() {
   echo "    -s <source directory>"
   echo "    -f <extra files (comma separated)>"
   echo "    -o <output>"
-  exit 0
+  exit 1
 }
 
 ARGV_SOURCE_DIRECTORY=""

--- a/scripts/unix/dependencies-npm.sh
+++ b/scripts/unix/dependencies-npm.sh
@@ -40,7 +40,7 @@ function usage() {
   echo "    -x <install prefix>"
   echo "    -f force install"
   echo "    -p production install"
-  exit 0
+  exit 1
 }
 
 ARGV_ARCHITECTURE=""

--- a/scripts/unix/download-electron.sh
+++ b/scripts/unix/download-electron.sh
@@ -38,7 +38,7 @@ function usage() {
   echo "    -v <electron version>"
   echo "    -s <electron operating system>"
   echo "    -o <output directory>"
-  exit 0
+  exit 1
 }
 
 ARGV_ARCHITECTURE=""

--- a/scripts/unix/package-cli.sh
+++ b/scripts/unix/package-cli.sh
@@ -40,7 +40,7 @@ function usage() {
   echo "    -r <architecture>"
   echo "    -s <operating system (linux|darwin)>"
   echo "    -o <output directory>"
-  exit 0
+  exit 1
 }
 
 ARGV_APPLICATION_NAME=""


### PR DESCRIPTION
We're currently exitting with error code 0 when displaying the usage
information on build scripts, which means that if the user forgets or
mistypes an option argument, the script will carry on its way.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>