### PR TITLE
feat(gui): add changelog link to update notifier

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -6240,6 +6240,8 @@ body {
   padding: 0;
   max-height: 250px;
   overflow: auto; }
+  .modal-body a {
+    color: #5793db; }
   .modal-body .list-group {
     padding: 0 20px; }
   .modal-body .list-group-item {

--- a/lib/gui/components/modal/styles/_modal.scss
+++ b/lib/gui/components/modal/styles/_modal.scss
@@ -44,6 +44,10 @@
   max-height: 250px;
   overflow: auto;
 
+  a {
+    color: $palette-theme-primary-background;
+  }
+
   .list-group {
     padding: 0 20px;
   }

--- a/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
+++ b/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
@@ -6,6 +6,9 @@
 <div class="modal-body">
   <div class="modal-text">
     <p>A new version of Etcher is available for download</p>
+    <a os-open-external="https://github.com/resin-io/etcher/blob/master/CHANGELOG.md#readme">
+      See what's new
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
We add a blue clickable link to the Github changelog in the update dialog
below the modal body text.

Closes: https://github.com/resin-io/etcher/issues/905
Change-Type: patch
Changelog-Entry: Add a changelog link to the update notifier modal.