### PR TITLE
chore: reuse npm/bower dependencies across builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,21 +88,22 @@ APPLICATION_VERSION_DEBIAN = $(shell echo $(APPLICATION_VERSION) | tr "-" "~")
 # Rules
 # ---------------------------------------------------------------------
 
-release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app:
+release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies/node_modules: package.json npm-shrinkwrap.json
+	./scripts/unix/dependencies-npm.sh -p -r "$(TARGET_ARCH)" -v "$(ELECTRON_VERSION)" -x $(dir $@) -t electron
+
+release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies/bower_components: bower.json
+	./scripts/unix/dependencies-bower.sh -p -x $(dir $@)
+
+release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app: \
+	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies/node_modules \
+	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies/bower_components
 	./scripts/unix/electron-create-resources-app.sh -s . -f "$(APPLICATION_FILES)" -o $@
-
-release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app/node_modules:\
-	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app
-	./scripts/unix/dependencies-npm.sh -p -r "$(TARGET_ARCH)" -v "$(ELECTRON_VERSION)" -x $< -t electron
-
-release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app/bower_components:\
-	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app
-	./scripts/unix/dependencies-bower.sh -p -x $<
+	for prerequisite in $^; do \
+		cp -rf $$prerequisite $@; \
+	done
 
 release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app.asar: \
-	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app \
-	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app/node_modules \
-	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app/bower_components
+	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app
 	./scripts/unix/electron-create-asar.sh -d $< -o $@
 
 release/$(APPLICATION_NAME)-$(TARGET_PLATFORM)-$(TARGET_ARCH): \

--- a/scripts/unix/dependencies-bower.sh
+++ b/scripts/unix/dependencies-bower.sh
@@ -56,8 +56,10 @@ if [ "$ARGV_PRODUCTION" == "true" ]; then
 fi
 
 if [ -n "$ARGV_PREFIX" ]; then
+  cp "$PWD/bower.json" "$ARGV_PREFIX"
   pushd "$ARGV_PREFIX"
   bower install $INSTALL_OPTS
+  rm bower.json
   popd
 else
   bower install $INSTALL_OPTS

--- a/scripts/unix/dependencies-npm.sh
+++ b/scripts/unix/dependencies-npm.sh
@@ -97,12 +97,24 @@ if [ "$ARGV_PRODUCTION" == "true" ]; then
 fi
 
 if [ -n "$ARGV_PREFIX" ]; then
+  mkdir -p "$ARGV_PREFIX"
   INSTALL_OPTS="$INSTALL_OPTS --prefix=$ARGV_PREFIX"
+  cp "$PWD/package.json" "$ARGV_PREFIX"
+
+  if [ -f "$PWD/npm-shrinkwrap.json" ]; then
+    cp "$PWD/npm-shrinkwrap.json" "$ARGV_PREFIX"
+  fi
 fi
 
 npm install $INSTALL_OPTS
 
-# Using `--prefix` might cause npm to create an empty `etc` directory
-if [ -n "$ARGV_PREFIX" ] && [ ! "$(ls -A "$ARGV_PREFIX/etc")" ]; then
-  rm -rf "$ARGV_PREFIX/etc"
+if [ -n "$ARGV_PREFIX" ]; then
+  rm -f "$ARGV_PREFIX/package.json"
+  rm -f "$ARGV_PREFIX/npm-shrinkwrap.json"
+
+  # Using `--prefix` might cause npm to create an empty `etc` directory
+  if [ ! "$(ls -A "$ARGV_PREFIX/etc")" ]; then
+    rm -rf "$ARGV_PREFIX/etc"
+  fi
+
 fi

--- a/scripts/unix/electron-create-resources-app.sh
+++ b/scripts/unix/electron-create-resources-app.sh
@@ -51,17 +51,7 @@ fi
 
 mkdir -p "$ARGV_OUTPUT"
 
-function copy_file_if_it_exists() {
-  local file=$1
-
-  if [ -f "$ARGV_SOURCE_DIRECTORY/$file" ]; then
-    cp "$ARGV_SOURCE_DIRECTORY/$file" "$ARGV_OUTPUT"
-  fi
-}
-
-copy_file_if_it_exists "package.json"
-copy_file_if_it_exists "npm-shrinkwrap.json"
-copy_file_if_it_exists "bower.json"
+cp "$ARGV_SOURCE_DIRECTORY/package.json" "$ARGV_OUTPUT"
 
 for file in $(echo "$ARGV_FILES" | sed "s/,/ /g"); do
   cp -rf "$file" "$ARGV_OUTPUT"


### PR DESCRIPTION
Currently, we create a "resources app" and install dependencies on it.
This means that to create another "resources app", the whole dependency
installation process needs to be repeated.

As a solution, we cache dependencies at
`release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies/` and
copy them to the resources apps as we need them.

This has the additional benefit that the resources app depends on the
dependencies rather than the other way around (dependencies depend on
the resources app), which didn't feel right.

In order to accomodate to these changes, the dependencies scripts are
now in charge of taking their corresponding manifests with them when the
prefix option is passed, given that neither `npm` nor `bower` allow to
customise the output location.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>