### PR TITLE
chore: move electron package caching responsibility to GNU Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,23 +104,32 @@ release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app.asar: \
 	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app
 	./scripts/unix/electron-create-asar.sh -d $< -o $@
 
+release/electron-$(ELECTRON_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH).zip:
+	./scripts/unix/electron-download-package.sh \
+		-r "$(TARGET_ARCH)" \
+		-v "$(ELECTRON_VERSION)" \
+		-s "$(TARGET_PLATFORM)" \
+		-o $@
+
 release/$(APPLICATION_NAME)-$(TARGET_PLATFORM)-$(TARGET_ARCH): \
-	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app.asar
-	./scripts/unix/electron-download-package.sh -r "$(TARGET_ARCH)" -v "$(ELECTRON_VERSION)" -s "$(TARGET_PLATFORM)" -o $@
+	release/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-app.asar \
+	release/electron-$(ELECTRON_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH).zip
 ifeq ($(TARGET_PLATFORM),darwin)
-	./scripts/darwin/electron-configure-package-darwin.sh -d $@ -a $< \
+	./scripts/darwin/electron-configure-package-darwin.sh -p $(word 2,$^) -a $< \
 		-n "$(APPLICATION_NAME)" \
 		-v "$(APPLICATION_VERSION)" \
 		-b "$(APPLICATION_BUNDLE_ID)" \
 		-c "$(APPLICATION_COPYRIGHT)" \
 		-t "$(APPLICATION_CATEGORY)" \
-		-i assets/icon.icns
+		-i assets/icon.icns \
+		-o $@
 endif
 ifeq ($(TARGET_PLATFORM),linux)
-	./scripts/linux/electron-configure-package-linux.sh -d $@ -a $< \
+	./scripts/linux/electron-configure-package-linux.sh -p $(word 2,$^) -a $< \
 		-n "$(APPLICATION_NAME)" \
 		-v "$(APPLICATION_VERSION)" \
-		-l LICENSE
+		-l LICENSE \
+		-o $@
 endif
 
 release/out/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-darwin-$(TARGET_ARCH).zip: \

--- a/scripts/darwin/electron-configure-package-darwin.sh
+++ b/scripts/darwin/electron-configure-package-darwin.sh
@@ -33,13 +33,14 @@ if [[ "$OS" != "Darwin" ]]; then
 fi
 
 check_dep /usr/libexec/PlistBuddy
+check_dep unzip
 
 function usage() {
   echo "Usage: $0"
   echo ""
   echo "Options"
   echo ""
-  echo "    -d <electron directory>"
+  echo "    -p <electron package>"
   echo "    -n <application name>"
   echo "    -v <application version>"
   echo "    -b <application bundle id>"
@@ -47,10 +48,11 @@ function usage() {
   echo "    -t <application category>"
   echo "    -a <application asar (.asar)>"
   echo "    -i <application icon (.icns)>"
+  echo "    -o <output directory>"
   exit 1
 }
 
-ARGV_ELECTRON_DIRECTORY=""
+ARGV_ELECTRON_PACKAGE=""
 ARGV_APPLICATION_NAME=""
 ARGV_VERSION=""
 ARGV_BUNDLE_ID=""
@@ -58,10 +60,11 @@ ARGV_COPYRIGHT=""
 ARGV_CATEGORY=""
 ARGV_ASAR=""
 ARGV_ICON=""
+ARGV_OUTPUT=""
 
-while getopts ":d:n:v:b:c:t:a:i:" option; do
+while getopts ":p:n:v:b:c:t:a:i:o:" option; do
   case $option in
-    d) ARGV_ELECTRON_DIRECTORY="$OPTARG" ;;
+    p) ARGV_ELECTRON_PACKAGE="$OPTARG" ;;
     n) ARGV_APPLICATION_NAME="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;
     b) ARGV_BUNDLE_ID="$OPTARG" ;;
@@ -69,29 +72,34 @@ while getopts ":d:n:v:b:c:t:a:i:" option; do
     t) ARGV_CATEGORY="$OPTARG" ;;
     a) ARGV_ASAR="$OPTARG" ;;
     i) ARGV_ICON="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
     *) usage ;;
   esac
 done
 
-if [ -z "$ARGV_ELECTRON_DIRECTORY" ] \
+if [ -z "$ARGV_ELECTRON_PACKAGE" ] \
   || [ -z "$ARGV_APPLICATION_NAME" ] \
   || [ -z "$ARGV_VERSION" ] \
   || [ -z "$ARGV_BUNDLE_ID" ] \
   || [ -z "$ARGV_COPYRIGHT" ] \
   || [ -z "$ARGV_CATEGORY" ] \
   || [ -z "$ARGV_ASAR" ] \
-  || [ -z "$ARGV_ICON" ]
+  || [ -z "$ARGV_ICON" ] \
+  || [ -z "$ARGV_OUTPUT" ]
 then
   usage
 fi
 
-APPLICATION_OUTPUT="$ARGV_ELECTRON_DIRECTORY/$ARGV_APPLICATION_NAME.app"
-mv "$ARGV_ELECTRON_DIRECTORY/Electron.app" "$APPLICATION_OUTPUT"
-rm "$APPLICATION_OUTPUT/Contents/Resources/default_app.asar"
+mkdir -p $(dirname "$ARGV_OUTPUT")
+unzip "$ARGV_ELECTRON_PACKAGE" -d "$ARGV_OUTPUT"
+
+APPLICATION_OUTPUT="$ARGV_OUTPUT/$ARGV_APPLICATION_NAME.app"
+mv "$ARGV_OUTPUT/Electron.app" "$APPLICATION_OUTPUT"
+rm -f "$APPLICATION_OUTPUT/Contents/Resources/default_app.asar"
 
 # Don't include these for now
-rm -f "$ARGV_ELECTRON_DIRECTORY"/LICENSE*
-rm -f "$ARGV_ELECTRON_DIRECTORY/version"
+rm -f "$ARGV_OUTPUT"/LICENSE*
+rm -f "$ARGV_OUTPUT/version"
 
 function plist_set() {
   local plist_file=$1

--- a/scripts/linux/electron-configure-package-linux.sh
+++ b/scripts/linux/electron-configure-package-linux.sh
@@ -19,6 +19,12 @@
 set -u
 set -e
 
+OS=$(uname)
+if [[ "$OS" != "Linux" ]]; then
+  echo "This script is only meant to be run in GNU/Linux" 1>&2
+  exit 1
+fi
+
 function check_dep() {
   if ! command -v $1 2>/dev/null 1>&2; then
     echo "Dependency missing: $1" 1>&2
@@ -26,58 +32,61 @@ function check_dep() {
   fi
 }
 
-OS=$(uname)
-if [[ "$OS" != "Linux" ]]; then
-  echo "This script is only meant to be run in GNU/Linux" 1>&2
-  exit 1
-fi
+check_dep unzip
 
 function usage() {
   echo "Usage: $0"
   echo ""
   echo "Options"
   echo ""
-  echo "    -d <electron directory>"
+  echo "    -p <electron package>"
   echo "    -n <application name>"
   echo "    -v <application version>"
   echo "    -l <application license file>"
   echo "    -a <application asar (.asar)>"
+  echo "    -o <output directory>"
   exit 1
 }
 
-ARGV_ELECTRON_DIRECTORY=""
+ARGV_ELECTRON_PACKAGE=""
 ARGV_APPLICATION_NAME=""
 ARGV_VERSION=""
 ARGV_LICENSE=""
 ARGV_ASAR=""
+ARGV_OUTPUT=""
 
-while getopts ":d:n:v:l:a:" option; do
+while getopts ":p:n:v:l:a:o:" option; do
   case $option in
-    d) ARGV_ELECTRON_DIRECTORY="$OPTARG" ;;
+    p) ARGV_ELECTRON_PACKAGE="$OPTARG" ;;
     n) ARGV_APPLICATION_NAME="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;
     l) ARGV_LICENSE="$OPTARG" ;;
     a) ARGV_ASAR="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
     *) usage ;;
   esac
 done
 
-if [ -z "$ARGV_ELECTRON_DIRECTORY" ] \
+if [ -z "$ARGV_ELECTRON_PACKAGE" ] \
   || [ -z "$ARGV_APPLICATION_NAME" ] \
   || [ -z "$ARGV_VERSION" ] \
   || [ -z "$ARGV_LICENSE" ] \
-  || [ -z "$ARGV_ASAR" ]
+  || [ -z "$ARGV_ASAR" ] \
+  || [ -z "$ARGV_OUTPUT" ]
 then
   usage
 fi
 
-mv $ARGV_ELECTRON_DIRECTORY/electron $ARGV_ELECTRON_DIRECTORY/$(echo "$ARGV_APPLICATION_NAME" | tr '[:upper:]' '[:lower:]')
-cp $ARGV_LICENSE $ARGV_ELECTRON_DIRECTORY/LICENSE
-echo "$ARGV_VERSION" > $ARGV_ELECTRON_DIRECTORY/version
-rm $ARGV_ELECTRON_DIRECTORY/resources/default_app.asar
+mkdir -p $(dirname "$ARGV_OUTPUT")
+unzip "$ARGV_ELECTRON_PACKAGE" -d "$ARGV_OUTPUT"
 
-cp "$ARGV_ASAR" "$ARGV_ELECTRON_DIRECTORY/resources/app.asar"
+mv $ARGV_OUTPUT/electron $ARGV_OUTPUT/$(echo "$ARGV_APPLICATION_NAME" | tr '[:upper:]' '[:lower:]')
+cp $ARGV_LICENSE $ARGV_OUTPUT/LICENSE
+echo "$ARGV_VERSION" > $ARGV_OUTPUT/version
+rm $ARGV_OUTPUT/resources/default_app.asar
+
+cp "$ARGV_ASAR" "$ARGV_OUTPUT/resources/app.asar"
 
 if [ -d "$ARGV_ASAR.unpacked" ]; then
-  cp -rf "$ARGV_ASAR.unpacked" "$ARGV_ELECTRON_DIRECTORY/resources/app.asar.unpacked"
+  cp -rf "$ARGV_ASAR.unpacked" "$ARGV_OUTPUT/resources/app.asar.unpacked"
 fi

--- a/scripts/unix/electron-download-package.sh
+++ b/scripts/unix/electron-download-package.sh
@@ -27,7 +27,6 @@ function check_dep() {
 }
 
 check_dep wget
-check_dep unzip
 
 function usage() {
   echo "Usage: $0"
@@ -64,10 +63,6 @@ then
   usage
 fi
 
-OUTPUT_DIRNAME=$(dirname "$ARGV_OUTPUT")
-rm -rf "$ARGV_OUTPUT"
-mkdir -p "$OUTPUT_DIRNAME"
-
 ELECTRON_ARCHITECTURE=$ARGV_ARCHITECTURE
 if [ "$ELECTRON_ARCHITECTURE" == "x86" ]; then
   ELECTRON_ARCHITECTURE="ia32"
@@ -76,9 +71,5 @@ fi
 ELECTRON_GITHUB_REPOSITORY=https://github.com/electron/electron
 ELECTRON_FILENAME="electron-v$ARGV_ELECTRON_VERSION-$ARGV_OPERATING_SYSTEM-$ELECTRON_ARCHITECTURE.zip"
 
-pushd "$OUTPUT_DIRNAME"
-wget "$ELECTRON_GITHUB_REPOSITORY/releases/download/v$ARGV_ELECTRON_VERSION/$ELECTRON_FILENAME"
-popd
-
-unzip "$OUTPUT_DIRNAME/$ELECTRON_FILENAME" -d "$ARGV_OUTPUT"
-rm "$OUTPUT_DIRNAME/$ELECTRON_FILENAME"
+mkdir -p $(dirname $ARGV_OUTPUT)
+wget "$ELECTRON_GITHUB_REPOSITORY/releases/download/v$ARGV_ELECTRON_VERSION/$ELECTRON_FILENAME" -O "$ARGV_OUTPUT"


### PR DESCRIPTION
Currently, `scripts/unix/electron-download-package.sh` contains its own
logic to determine if the package was already downloaded.

This commit takes the electron package uncompressing task to the
configure scripts, and reduce `electron-download-package.sh` to a script
that simply downloads the zip to a certain location, since this change
allows us to have a separate Make rule to download the Electron zip (and
thus have Make take care of caching).

After this change, the `electron-configure-package-*.sh` scripts are no
longer routines that modify a certain directory, but scripts that take
the zip as an input and actually create the package directory, which
aligns better with Make's design.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>