### PR TITLE
chore: use `rmdir` to delete empty npm `etc/` directory

### DIFF
--- a/scripts/unix/dependencies-npm.sh
+++ b/scripts/unix/dependencies-npm.sh
@@ -114,7 +114,7 @@ if [ -n "$ARGV_PREFIX" ]; then
 
   # Using `--prefix` might cause npm to create an empty `etc` directory
   if [ ! "$(ls -A "$ARGV_PREFIX/etc")" ]; then
-    rm -rf "$ARGV_PREFIX/etc"
+    rmdir "$ARGV_PREFIX/etc"
   fi
 
 fi


### PR DESCRIPTION
NPM might create an empty `etc/` directory when calling it with the
`--prefix` option and we have a check to see if this directory indeed
exists and its empty in order to proceed and delete it.

We currently use `rm -rf` for it, even though `rmdir` is sufficient.

See: https://github.com/resin-io/etcher/pull/923#discussion_r90570968
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>