### PR TITLE
chore: move `bower.json` removal after popd in `dependencies-bower.sh`

### DIFF
--- a/scripts/unix/dependencies-bower.sh
+++ b/scripts/unix/dependencies-bower.sh
@@ -59,8 +59,8 @@ if [ -n "$ARGV_PREFIX" ]; then
   cp "$PWD/bower.json" "$ARGV_PREFIX"
   pushd "$ARGV_PREFIX"
   bower install $INSTALL_OPTS
-  rm bower.json
   popd
+  rm "$ARGV_PREFIX/bower.json"
 else
   bower install $INSTALL_OPTS
 fi


### PR DESCRIPTION
The reason for this change is to make things more explicit.

See: https://github.com/resin-io/etcher/pull/923#discussion_r90571316
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>