### PR TITLE
chore: persist temporary artifacts during AppImage builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,22 +213,33 @@ ifdef CODE_SIGN_IDENTITY
 endif
 	./scripts/build/electron-create-readonly-dmg-darwin.sh -d $< -o $@
 
-$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-linux-$(TARGET_ARCH).zip: \
+$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-linux-$(TARGET_ARCH).AppDir: \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-linux-$(TARGET_ARCH) \
-	| $(BUILD_OUTPUT_DIRECTORY) $(BUILD_TEMPORARY_DIRECTORY)
-	TMPDIR=$(BUILD_TEMPORARY_DIRECTORY) ./scripts/build/electron-installer-appimage-linux.sh -p $< -o $@ \
+	| $(BUILD_DIRECTORY)
+	./scripts/build/electron-create-appdir.sh -p $< -o $@ \
 		-n "$(APPLICATION_NAME)" \
 		-d "$(APPLICATION_DESCRIPTION)" \
 		-r "$(TARGET_ARCH)" \
 		-b "$(APPLICATION_NAME_LOWERCASE)" \
 		-i assets/icon.png
 
+$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-linux-$(TARGET_ARCH).AppImage: \
+	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-linux-$(TARGET_ARCH).AppDir \
+	| $(BUILD_DIRECTORY) $(BUILD_TEMPORARY_DIRECTORY)
+	./scripts/build/electron-create-appimage-linux.sh -d $< -o $@ \
+		-r "$(TARGET_ARCH)" \
+		-w "$(BUILD_TEMPORARY_DIRECTORY)"
+
+$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-linux-$(TARGET_ARCH).zip: \
+	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-linux-$(TARGET_ARCH).AppImage \
+	| $(BUILD_OUTPUT_DIRECTORY)
+	./scripts/build/electron-installer-appimage-zip.sh -i $< -o $@
+
 $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-electron_$(APPLICATION_VERSION_DEBIAN)_$(TARGET_ARCH_DEBIAN).deb: \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-linux-$(TARGET_ARCH) \
 	| $(BUILD_OUTPUT_DIRECTORY)
-	./scripts/build/electron-installer-debian-linux.sh -p $< -r "$(TARGET_ARCH)" \
-		-c scripts/build/debian/config.json \
-		-o $(dir $@)
+	./scripts/build/electron-installer-debian-linux.sh -p $< -r "$(TARGET_ARCH)" -o $| \
+		-c scripts/build/debian/config.json
 
 # ---------------------------------------------------------------------
 # Phony targets

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -31,6 +31,7 @@ The following MinGW packages are required:
 - `msys-unzip`
 - `msys-wget`
 - `msys-bash`
+- `msys-coreutils`
 
 ### OS X
 

--- a/scripts/build/electron-create-appimage-linux.sh
+++ b/scripts/build/electron-create-appimage-linux.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+OS=$(uname)
+if [[ "$OS" != "Linux" ]]; then
+  echo "This script is only meant to be run in GNU/Linux" 1>&2
+  exit 1
+fi
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -d <appdir>"
+  echo "    -r <application architecture>"
+  echo "    -w <download directory>"
+  echo "    -o <output>"
+  exit 1
+}
+
+ARGV_APPDIR=""
+ARGV_ARCHITECTURE=""
+ARGV_DOWNLOAD_DIRECTORY=""
+ARGV_OUTPUT=""
+
+while getopts ":d:r:w:o:" option; do
+  case $option in
+    d) ARGV_APPDIR="$OPTARG" ;;
+    r) ARGV_ARCHITECTURE="$OPTARG" ;;
+    w) ARGV_DOWNLOAD_DIRECTORY="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_APPDIR" ] \
+  || [ -z "$ARGV_ARCHITECTURE" ] \
+  || [ -z "$ARGV_DOWNLOAD_DIRECTORY" ] \
+  || [ -z "$ARGV_OUTPUT" ]
+then
+  usage
+fi
+
+if [ "$ARGV_ARCHITECTURE" == "x64"  ]; then
+  APPIMAGES_ARCHITECTURE="x86_64"
+  APPIMAGEASSISTANT_CHECKSUM=e792fa6ba1dd81de6438844fde39aa12d6b6d15238154ec46baf01da1c92d59f
+elif [ "$ARGV_ARCHITECTURE" == "x86"  ]; then
+  APPIMAGES_ARCHITECTURE="i686"
+  APPIMAGEASSISTANT_CHECKSUM=0faade0c009e703c221650e414f3b4ea8d03abbd8b9f1f065aef46156ee15dd0
+else
+  echo "Invalid architecture: $ARGV_ARCHITECTURE" 1>&2
+  exit 1
+fi
+
+APPIMAGES_TAG=6
+APPIMAGES_GITHUB_RELEASE_BASE_URL=https://github.com/probonopd/AppImageKit/releases/download/$APPIMAGES_TAG
+APPIMAGEASSISTANT_PATH=$ARGV_DOWNLOAD_DIRECTORY/AppImageAssistant-$ARGV_ARCHITECTURE.AppImage
+mkdir -p "$ARGV_DOWNLOAD_DIRECTORY"
+./scripts/build/download-tool.sh -x \
+  -u "$APPIMAGES_GITHUB_RELEASE_BASE_URL/AppImageAssistant_$APPIMAGES_TAG-$APPIMAGES_ARCHITECTURE.AppImage" \
+  -c "$APPIMAGEASSISTANT_CHECKSUM" \
+  -o "$APPIMAGEASSISTANT_PATH"
+
+# Generate AppImage
+mkdir -p "$(dirname "$ARGV_OUTPUT")"
+$APPIMAGEASSISTANT_PATH "$ARGV_APPDIR" "$ARGV_OUTPUT"

--- a/scripts/build/electron-installer-appimage-zip.sh
+++ b/scripts/build/electron-installer-appimage-zip.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+./scripts/build/check-dependency.sh zip
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -i <appimage>"
+  echo "    -o <output>"
+  exit 1
+}
+
+ARGV_APPIMAGE=""
+ARGV_OUTPUT=""
+
+while getopts ":i:o:" option; do
+  case $option in
+    i) ARGV_APPIMAGE="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_APPIMAGE" ] || [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+# Package AppImage inside a Zip to preserve the execution permissions
+CWD=$(pwd)
+mkdir -p "$(dirname $ARGV_OUTPUT)"
+pushd "$(dirname $ARGV_APPIMAGE)"
+zip "$CWD/$ARGV_OUTPUT" "$(basename $ARGV_APPIMAGE)"
+popd


### PR DESCRIPTION
Currently, `electron-installer-appimage.sh` deletes temporary stuff it
needs as it goes (like the AppDir, AppImageAssistant, or even the
AppImage after creating a ZIP). Since this is not very Make-friendly,
the script has been split into the following smaller scripts that
perform a single task:

- `electron-create-appimage-linux.sh`
- `electron-create-appdir.sh`

Utilising them in different Makefile rules effectively results in Make
persisting the "temporary artifacts".

See: https://github.com/resin-io/etcher/pull/913#discussion_r90801230
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>