### PR TITLE
chore: simplify .travis.yml dependencies installation across OSes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,15 +44,10 @@ install:
   - gem install scss_lint
   - npm install -g bower
   - npm install -g electron-installer-debian
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      make electron-develop;
-    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install afsctool;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      make electron-develop;
-    fi
+  - make electron-develop
 
 before_script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
After our recent changes, the command to install dependencies for both
OS X and GNU/Linux has been unified as `make electron-develop`, so there
is no longer a need to have multiple conditionals for each OS in
`.travis.yml`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>