### PR TITLE
chore: use `pushd`/`popd` instead of `--prefix` on `dependencies-npm.sh`

### DIFF
--- a/scripts/unix/dependencies-npm.sh
+++ b/scripts/unix/dependencies-npm.sh
@@ -98,23 +98,18 @@ fi
 
 if [ -n "$ARGV_PREFIX" ]; then
   mkdir -p "$ARGV_PREFIX"
-  INSTALL_OPTS="$INSTALL_OPTS --prefix=$ARGV_PREFIX"
   ln -s "$PWD/package.json" "$ARGV_PREFIX/package.json"
 
   if [ -f "$PWD/npm-shrinkwrap.json" ]; then
     ln -s "$PWD/npm-shrinkwrap.json" "$ARGV_PREFIX/npm-shrinkwrap.json"
   fi
-fi
 
-npm install $INSTALL_OPTS
+  pushd "$ARGV_PREFIX"
+  npm install $INSTALL_OPTS
+  popd
 
-if [ -n "$ARGV_PREFIX" ]; then
   rm -f "$ARGV_PREFIX/package.json"
   rm -f "$ARGV_PREFIX/npm-shrinkwrap.json"
-
-  # Using `--prefix` might cause npm to create an empty `etc` directory
-  if [ ! "$(ls -A "$ARGV_PREFIX/etc")" ]; then
-    rmdir "$ARGV_PREFIX/etc"
-  fi
-
+else
+  npm install $INSTALL_OPTS
 fi


### PR DESCRIPTION
We currently use the `--prefix` option in `dependencies-npm.sh` to
install dependencies in another directory, however that function causes
ENOSELF to be thrown on Windows under Msys. As a solution, we take the
same `pushd`/`popd` approach as we do in `dependencies-bower.sh`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>