### PR TITLE
chore: don't include *.dll files inside the asar archive 

### DIFF
--- a/scripts/unix/electron-create-asar.sh
+++ b/scripts/unix/electron-create-asar.sh
@@ -54,4 +54,9 @@ if [ -z "$ARGV_DIRECTORY" ] || [ -z "$ARGV_OUTPUT" ]; then
 fi
 
 mkdir -p $(dirname "$ARGV_OUTPUT")
-asar pack "$ARGV_DIRECTORY" "$ARGV_OUTPUT" --unpack *.node
+
+# Omit `*.dll` and `*.node` files from the
+# asar package, otherwise `process.dlopen` and
+# `module.require` can't load them correctly.
+asar pack "$ARGV_DIRECTORY" "$ARGV_OUTPUT" \
+  --unpack "{*.dll,*.node}"


### PR DESCRIPTION
This change is needed to make `electron-create-asar.sh` output valid
asar packages on Windows (Msys).

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>