### PR TITLE
docs: update Visual Studio Community 2013 link in RUNNING-LOCALLY.md

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -20,7 +20,7 @@ Prerequisites
 - [Rimraf](https://github.com/isaacs/rimraf)
 - [Asar](https://github.com/electron/asar)
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
-- [Visual Studio Community 2013](https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx)
+- [Visual Studio Community 2013](https://www.microsoft.com/en-us/download/details.aspx?id=48129) (free)
 - [7z](http://www.7-zip.org) (command line version)
 
 ### OS X


### PR DESCRIPTION
For some reason, the link we had before now redirects to the Visual
Studio 2015 landing page.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>