### PR TITLE
chore: upgrade Etcher build system to use Visual Studio 2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 init:
   - git config --global core.autocrlf input
 
-image: Visual Studio 2013
+image: Visual Studio 2015
 
 cache:
   - C:\Users\appveyor\.node-gyp

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -20,7 +20,7 @@ Prerequisites
 - [Rimraf](https://github.com/isaacs/rimraf)
 - [Asar](https://github.com/electron/asar)
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
-- [Visual Studio Community 2013](https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx)
+- [Visual Studio Community 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48146) (free) (other editions, like Professional and Enterprise, should work too)
 - [7z](http://www.7-zip.org) (command line version)
 - [MinGW](http://www.mingw.org)
 
@@ -69,7 +69,7 @@ make electron-develop
 
 ### Windows
 
-**Run the following command from the _Developer Command Prompt for VS2013_**,
+**Run the following command from the _Developer Command Prompt for VS2015_**,
 to ensure all Visual Studio command utilities are available in the `%PATH%`:
 
 ```sh

--- a/scripts/unix/dependencies-npm.sh
+++ b/scripts/unix/dependencies-npm.sh
@@ -74,11 +74,7 @@ then
 fi
 
 if [ "$ARGV_TARGET_OPERATING_SYSTEM" == "win32" ]; then
-
-  # We require Visual Studio 2013 specifically since newer versions
-  # lack command line build tools such as `lib.exe` and `cl.exe`.
-  export GYP_MSVS_VERSION=2013
-
+  export GYP_MSVS_VERSION=2015
 fi
 
 if [ "$ARGV_TARGET_PLATFORM" == "electron" ]; then


### PR DESCRIPTION
This version was not working the last time we checked, but it looks like
there were some advancements in node-gyp in the previous months, and all
dependencies have upgraded to it already.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>