### PR TITLE
chore: speed up `make` startup time by using `jq`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - clang
       - dpkg
       - fakeroot
+      - jq
 
 before_install:
   - rm -rf ~/.nvm
@@ -46,6 +47,7 @@ install:
   - npm install -g electron-installer-debian
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew install afsctool;
+      brew install jq;
     fi
   - make electron-develop
 

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 # Application configuration
 # ---------------------------------------------------------------------
 
-ELECTRON_VERSION = $(shell node -e "console.log(require('./package.json').devDependencies['electron-prebuilt'])")
-APPLICATION_NAME = $(shell node -e "console.log(require('./package.json').displayName)")
-APPLICATION_DESCRIPTION=$(shell node -e "console.log(require('./package.json').description)")
-APPLICATION_VERSION = $(shell node -e "console.log(require('./package.json').version)")
-APPLICATION_COPYRIGHT = $(shell node -e "console.log(require('./package.json').copyright)")
+ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron-prebuilt"]' package.json)
+APPLICATION_NAME = $(shell jq -r '.displayName' package.json)
+APPLICATION_DESCRIPTION=$(shell jq -r '.description' package.json)
+APPLICATION_VERSION = $(shell jq -r '.version' package.json)
+APPLICATION_COPYRIGHT = $(shell jq -r '.copyright' package.json)
 APPLICATION_CATEGORY = public.app-category.developer-tools
 APPLICATION_BUNDLE_ID = io.resin.etcher
 APPLICATION_FILES = lib,build,assets

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -14,6 +14,7 @@ Prerequisites
 - [UPX](http://upx.sourceforge.net)
 - [Python](https://www.python.org)
 - [SCSS Lint](https://github.com/brigade/scss-lint/)
+- [jq](https://stedolan.github.io/jq/)
 
 ### Windows
 


### PR DESCRIPTION
By changing the `Makefile` to use `jq` instead of `node` for getting settings
from `package.json`, the time to do `make help` drops from over 1.5 seconds to
under 0.05 seconds!