### PR TITLE
chore: create re-usable check-dependency.sh script

### DIFF
--- a/scripts/build/dependencies-bower.sh
+++ b/scripts/build/dependencies-bower.sh
@@ -19,14 +19,7 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep bower
+./scripts/build/check-dependency.sh bower
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -19,15 +19,8 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep npm
-check_dep python
+./scripts/build/check-dependency.sh npm
+./scripts/build/check-dependency.sh python
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/download-tool.sh
+++ b/scripts/build/download-tool.sh
@@ -19,22 +19,11 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
+./scripts/build/check-dependency.sh wget
 
-check_dep wget
-
-if command -v sha256sum 2>/dev/null 1>&2; then
-  SHA256SUM=sha256sum
-elif command -v shasum 2>/dev/null 1>&2; then
-  SHA256SUM="shasum -a 256"
-else
-  echo "Dependency missing: sha256sum or shasum" 1>&2
-  exit 1
+SHA256SUM=$(./scripts/build/check-dependency.sh sha256sum shasum)
+if [ "$SHA256SUM" == "shasum" ]; then
+  SHA256SUM="$SHA256SUM -a 256"
 fi
 
 function usage() {

--- a/scripts/build/electron-configure-package-darwin.sh
+++ b/scripts/build/electron-configure-package-darwin.sh
@@ -19,21 +19,14 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Darwin" ]]; then
   echo "This script is only meant to be run in OS X" 1>&2
   exit 1
 fi
 
-check_dep /usr/libexec/PlistBuddy
-check_dep unzip
+./scripts/build/check-dependency.sh /usr/libexec/PlistBuddy
+./scripts/build/check-dependency.sh unzip
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-configure-package-linux.sh
+++ b/scripts/build/electron-configure-package-linux.sh
@@ -25,14 +25,7 @@ if [[ "$OS" != "Linux" ]]; then
   exit 1
 fi
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep unzip
+./scripts/build/check-dependency.sh unzip
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-create-asar.sh
+++ b/scripts/build/electron-create-asar.sh
@@ -19,14 +19,7 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep asar
+./scripts/build/check-dependency.sh asar
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-create-readonly-dmg-darwin.sh
+++ b/scripts/build/electron-create-readonly-dmg-darwin.sh
@@ -19,20 +19,13 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Darwin" ]]; then
   echo "This script is only meant to be run in OS X" 1>&2
   exit 1
 fi
 
-check_dep hdiutil
+./scripts/build/check-dependency.sh hdiutil
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-create-readwrite-dmg-darwin.sh
+++ b/scripts/build/electron-create-readwrite-dmg-darwin.sh
@@ -19,24 +19,17 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Darwin" ]]; then
   echo "This script is only meant to be run in OS X" 1>&2
   exit 1
 fi
 
-check_dep hdiutil
-check_dep xattr
-check_dep tiffutil
-check_dep osascript
-check_dep afsctool
+./scripts/build/check-dependency.sh hdiutil
+./scripts/build/check-dependency.sh xattr
+./scripts/build/check-dependency.sh tiffutil
+./scripts/build/check-dependency.sh osascript
+./scripts/build/check-dependency.sh afsctool
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-download-package.sh
+++ b/scripts/build/electron-download-package.sh
@@ -19,14 +19,7 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep wget
+./scripts/build/check-dependency.sh wget
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-installer-app-zip-darwin.sh
+++ b/scripts/build/electron-installer-app-zip-darwin.sh
@@ -19,20 +19,13 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep zip
-
 OS=$(uname)
 if [[ "$OS" != "Darwin" ]]; then
   echo "This script is only meant to be run in OS X" 1>&2
   exit 1
 fi
+
+./scripts/build/check-dependency.sh zip
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-installer-appimage-linux.sh
+++ b/scripts/build/electron-installer-appimage-linux.sh
@@ -20,21 +20,13 @@ set -u
 set -e
 set -x
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Linux" ]]; then
   echo "This script is only meant to be run in GNU/Linux" 1>&2
   exit 1
 fi
 
-check_dep upx
-check_dep wget
+./scripts/build/check-dependency.sh upx
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-installer-debian-linux.sh
+++ b/scripts/build/electron-installer-debian-linux.sh
@@ -19,20 +19,13 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Linux" ]]; then
   echo "This script is only meant to be run in GNU/Linux" 1>&2
   exit 1
 fi
 
-check_dep electron-installer-debian
+./scripts/build/check-dependency.sh electron-installer-debian
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-sign-app-darwin.sh
+++ b/scripts/build/electron-sign-app-darwin.sh
@@ -19,21 +19,14 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Darwin" ]]; then
   echo "This script is only meant to be run in OS X" 1>&2
   exit 1
 fi
 
-check_dep codesign
-check_dep spctl
+./scripts/build/check-dependency.sh codesign
+./scripts/build/check-dependency.sh spctl
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-sign-dmg-darwin.sh
+++ b/scripts/build/electron-sign-dmg-darwin.sh
@@ -19,20 +19,13 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname)
 if [[ "$OS" != "Darwin" ]]; then
   echo "This script is only meant to be run in OS X" 1>&2
   exit 1
 fi
 
-check_dep hdiutil
+./scripts/build/check-dependency.sh hdiutil
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/electron-sign-exe-win32.sh
+++ b/scripts/build/electron-sign-exe-win32.sh
@@ -19,20 +19,13 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
 OS=$(uname -o 2>/dev/null || true)
 if [[ "$OS" != "Msys" ]]; then
   echo "This script is only meant to be run in Windows" 1>&2
   exit 1
 fi
 
-check_dep signtool
+./scripts/build/check-dependency.sh signtool
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/build/package-cli.sh
+++ b/scripts/build/package-cli.sh
@@ -19,15 +19,8 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep browserify
-check_dep rsync
+./scripts/build/check-dependency.sh browserify
+./scripts/build/check-dependency.sh rsync
 
 function usage() {
   echo "Usage: $0"

--- a/scripts/publish/bintray-debian.sh
+++ b/scripts/publish/bintray-debian.sh
@@ -20,14 +20,7 @@
 set -u
 set -e
 
-function check_dep() {
-  if ! command -v $1 2>/dev/null 1>&2; then
-    echo "Dependency missing: $1" 1>&2
-    exit 1
-  fi
-}
-
-check_dep curl
+./scripts/build/check-dependency.sh curl
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <debfile>" 1>&2


### PR DESCRIPTION
We have a little snippet to check if a dependency is installed on the
system that we're literally copy-pasting in every single script in the
build system script collection.

For re-usability purposes, this snippet has been extracted to a
`check-dependency.sh` that is called by every script that needs it.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>