### PR TITLE
chore: build x64 and x86 jobs for GNU/Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,18 @@ language: cpp
 sudo: false
 
 env:
-  - NODE_VERSION="6.1.0" RUBY_VERSION="2.3.1"
+  global:
+    - NODE_VERSION="6.1.0"
+    - RUBY_VERSION="2.3.1"
+  matrix:
+    - TARGET_ARCH=x64
+    - TARGET_ARCH=x86
+
+matrix:
+  exclude:
+    - os: osx
+      env: TARGET_ARCH=x86
+
 os:
   - linux
   - osx
@@ -20,7 +31,16 @@ addons:
     packages:
       - upx-ucl
       - gcc-4.8
+      - gcc-4.8-multilib
       - g++-4.8
+      - g++-4.8-multilib
+      - linux-libc-dev:i386
+      - libgtk2.0-0:i386
+      - libxtst6:i386
+      - libnss3:i386
+      - libxss1:i386
+      - libgconf-2-4:i386
+      - libasound2:i386
       - clang
       - dpkg
       - fakeroot
@@ -49,6 +69,7 @@ install:
       brew install afsctool;
       brew install jq;
     fi
+  - make info
   - make electron-develop
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,18 @@ endif
 #
 TARGET_ARCH ?= $(HOST_ARCH)
 
+# Support x86 builds from x64 in GNU/Linux
+# See https://github.com/addaleax/lzma-native/issues/27
+ifeq ($(TARGET_PLATFORM),linux)
+	ifneq ($(HOST_ARCH),$(TARGET_ARCH))
+		ifeq ($(TARGET_ARCH),x86)
+			export CFLAGS += -m32
+		else
+$(error Can't build $(TARGET_ARCH) binaries on a $(HOST_ARCH) host)
+		endif
+	endif
+endif
+
 # ---------------------------------------------------------------------
 # Code signing
 # ---------------------------------------------------------------------
@@ -285,6 +297,9 @@ electron-develop:
 	# will complain that your `node_modules` tree is not equal to what
 	# is defined by the `npm-shrinkwrap.json` file, and will thus
 	# refuse to do anything but install from scratch.
+	# The `node_modules` directory also needs to be wiped out if you're
+	# changing between target architectures, since compiled add-ons
+	# will not work otherwise.
 	rm -rf node_modules
 	./scripts/build/dependencies-npm.sh \
 		-r "$(TARGET_ARCH)" \


### PR DESCRIPTION
This change makes Travis CI spawn 3 jobs:

- GNU/Linux with TARGET_ARCH=x64
- GNU/Linux with TARGET_ARCH=x86
- macOS with TARGET_ARCH=x64

We add `make info` before starting the build for convenience.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>