### PR TITLE
chore: fix `electron-sign-app-darwin.sh` reference

### DIFF
--- a/scripts/build/electron-sign-dmg-darwin.sh
+++ b/scripts/build/electron-sign-dmg-darwin.sh
@@ -69,7 +69,7 @@ hdiutil attach "$ARGV_APPLICATION_DMG" -readwrite -noverify
 # Wait for a bit to ensure the image is mounted
 sleep 2
 
-./scripts/darwin/electron-sign-app.sh -a "$VOLUME_APPLICATION" -i "$ARGV_IDENTITY"
+./scripts/build/electron-sign-app-darwin.sh -a "$VOLUME_APPLICATION" -i "$ARGV_IDENTITY"
 
 # Unmount temporary DMG image.
 hdiutil detach "$VOLUME_DIRECTORY"


### PR DESCRIPTION
`electron-sign-dmg-darwin.sh` was incorrectly referring to
`scripts/build/electron-sign-app-darwin.sh` as
`scripts/darwin/electron-sign-app.sh`, causing the DMG builds to fail in
OS X.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>