### PR TITLE
chore: fix error functions in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,16 +66,16 @@ else
 endif
 
 ifndef HOST_PLATFORM
-	$(error We couldn\'t detect your host platform)
+$(error We couldn\'t detect your host platform)
 endif
 ifndef HOST_ARCH
-	$(error We couldn\'t detect your host architecture)
+$(error We couldn\'t detect your host architecture)
 endif
 
 TARGET_PLATFORM = $(HOST_PLATFORM)
 
 ifneq ($(TARGET_PLATFORM),$(HOST_PLATFORM))
-	$(error We don\'t support cross-platform builds yet)
+$(error We don\'t support cross-platform builds yet)
 endif
 
 # Default to host architecture. You can override by doing:


### PR DESCRIPTION
`$(error ...)` (and `$(warning ...)`) functions in a Makefile can't be indented - if they are make displays a `*** commands commence before first target. Stop.` error.