### PR TITLE
chore: add `distclean` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ TARGETS = \
 	help \
 	info \
 	clean \
+	distclean \
 	electron-develop
 
 ifeq ($(TARGET_PLATFORM),darwin)
@@ -304,5 +305,9 @@ info:
 
 clean:
 	rm -rf $(BUILD_DIRECTORY)
+
+distclean: clean
+	rm -rf node_modules
+	rm -rf bower_components
 
 .DEFAULT_GOAL = help


### PR DESCRIPTION
This new target also deletes the `node_modules` and `bower_components`
directories, taking the project directory to a totally pristine state.