### PR TITLE
doc: recommend `make electron-develop` to clean dependency tree

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,7 +37,7 @@ dependency.
 
 Use the following steps to ensure everything goes flawlessly:
 
-- Delete your `node_modules/` to ensure you don't have extraneous dependencies
+- Run `make electron-develop` to ensure you don't have extraneous dependencies
   you might have brought during development, or you are running older
   dependencies because you come from another branch or reference.
 


### PR DESCRIPTION
Because of NPM shrinkwrap, we recommend having a clean dependency tree
in `CONTRIBUTING.md` before upgrading a dependency. We currently
recommend maually wiping out `node_modules`, but since the
`electron-develop` make target already does that, is more user friendly
to recommend that instead.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>