### PR TITLE
feat(gui): label system drives in drive-list widget

### DIFF
--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -35,6 +35,11 @@
                 <i class="glyphicon glyphicon-lock"></i>
                 LOCKED</span>
 
+            <span class="label label-danger"
+              ng-show="modal.state.isSystemDrive(drive)">
+                <i class="glyphicon glyphicon-hdd"></i>
+                SYSTEM DRIVE</span>
+
           </footer>
         </div>
         <span class="tick tick--success"

--- a/lib/gui/models/selection-state.js
+++ b/lib/gui/models/selection-state.js
@@ -169,6 +169,28 @@ SelectionStateModel.service('SelectionStateModel', function(DrivesModel) {
   };
 
   /**
+   * @summary Check if a drive is a system drive
+   * @function
+   * @public
+   * @param {Object} drive - drive
+   * @returns {Boolean} whether the drive is a system drive
+   *
+   * @example
+   * if (SelectionStateModel.isSystemDrive({
+   *   device: '/dev/disk2',
+   *   name: 'My Drive',
+   *   size: 123456789,
+   *   protected: true,
+   *   system: true
+   * })) {
+   *   console.log('This drive is a system drive!');
+   * }
+   */
+  this.isSystemDrive = (drive) => {
+    return Boolean(drive.system);
+  };
+
+  /**
    * @summary Toggle set drive
    * @function
    * @public

--- a/tests/gui/models/selection-state.spec.js
+++ b/tests/gui/models/selection-state.spec.js
@@ -137,6 +137,33 @@ describe('Browser: SelectionState', function() {
 
     });
 
+    describe('.isSystemDrive()', function() {
+
+      it('should return true if the drive is a system drive', function() {
+        const result = SelectionStateModel.isSystemDrive({
+          device: '/dev/disk2',
+          name: 'USB Drive',
+          size: 999999999,
+          protected: true,
+          system: true
+        });
+
+        m.chai.expect(result).to.be.true;
+      });
+
+      it('should return false if the drive is a removable drive', function() {
+        const result = SelectionStateModel.isSystemDrive({
+          device: '/dev/disk2',
+          name: 'USB Drive',
+          size: 999999999,
+          protected: true,
+          system: false
+        });
+
+        m.chai.expect(result).to.be.false;
+      });
+    });
+
     describe('given a drive', function() {
 
       beforeEach(function() {


### PR DESCRIPTION
System drives in the drive-list widget now have a red warning label
beneath. Also new is the `isSystemDrive()` method under
`SelectionStateModel` and its unit-tests.

See: https://github.com/resin-io/etcher/issues/888
Changelog-Entry: Label system drives in the drive-list widget