### PR TITLE
feat(gui): red confirm button for system drives

### DIFF
--- a/build/css/main.css
+++ b/build/css/main.css
@@ -1255,7 +1255,7 @@ mark,
 .text-right {
   text-align: right; }
 
-.text-center {
+.text-center, .modal-footer-label {
   text-align: center; }
 
 .text-justify {
@@ -6037,8 +6037,9 @@ body {
  * limitations under the License.
  */
 .label {
-  font-size: 9px;
-  font-weight: normal; }
+  font-size: 10px;
+  font-weight: bold;
+  padding: 2px 5px; }
 
 .label-big {
   font-size: 11px;
@@ -6231,7 +6232,7 @@ body {
   flex-grow: 0; }
 
 .modal-title {
-  font-size: inherit;
+  font-size: 12px;
   flex-grow: 1; }
 
 .modal-body {
@@ -6261,10 +6262,12 @@ body {
     .modal-body .list-group-item[disabled] .list-group-item-heading {
       color: #b3b3b3; }
   .modal-body .list-group-item-heading {
-    font-size: 13px; }
+    font-size: 14px;
+    font-weight: bold; }
   .modal-body .list-group-item-text {
     line-height: 1;
-    font-size: 11px;
+    font-size: 13px;
+    font-weight: bold;
     color: #b3b3b3; }
 
 .modal-text {
@@ -6408,8 +6411,13 @@ body {
  * limitations under the License.
  */
 .modal-drive-selector-modal .modal-content {
-  width: 300px;
+  width: 400px;
   height: 320px; }
+
+.modal-drive-selector-modal .button, .modal-drive-selector-modal .progress-button,
+.modal-drive-selector-modal .label,
+.modal-drive-selector-modal .modal-title {
+  font-weight: bold; }
 
 .modal-drive-selector-modal .list-group-item[disabled] {
   cursor: not-allowed; }
@@ -6420,6 +6428,13 @@ body {
 .component-drive-selector-body .list-group-item-heading,
 .component-drive-selector-body .list-group-item-text {
   word-break: break-all; }
+
+.component-drive-selector-body .list-group-item-text,
+.component-drive-selector-body .list-group-item-footer {
+  display: inline-block; }
+
+.component-drive-selector-body .list-group-item-footer {
+  margin-top: 0; }
 
 /*
  * Copyright 2016 resin.io

--- a/lib/gui/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/components/drive-selector/controllers/drive-selector.js
@@ -18,7 +18,7 @@
 
 const _ = require('lodash');
 
-module.exports = function($q, $uibModalInstance, DrivesModel, SelectionStateModel, WarningModalService) {
+module.exports = function($q, $uibModalInstance, DrivesModel, ManifestBindService, SelectionStateModel, WarningModalService) {
 
   /**
    * @summary The drive selector state
@@ -140,6 +140,36 @@ module.exports = function($q, $uibModalInstance, DrivesModel, SelectionStateMode
         this.closeModal();
       }
     });
+  };
+
+  this.getButtonStatus = () => {
+    const isDisabled = !this.state.hasDrive() || this.state.getDrive().protected;
+
+    if (isDisabled) {
+      return 'disabled';
+    }
+
+    const isDangerous = this.state.hasDrive() && this.state.isSystemDrive(this.state.getDrive());
+
+    if (isDangerous) {
+      return 'danger';
+    }
+
+    return 'primary';
+  };
+
+  this.getFooterMessage = () => {
+    if (this.getButtonStatus() === 'danger'
+      && this.state.isSystemDrive(this.state.getDrive())) {
+      return ManifestBindService.get('displayName') + ' has identified this as a system drive!';
+
+    }
+
+    return undefined;
+  };
+
+  this.hasFooterMessage = () => {
+    return Boolean(this.getFooterMessage());
   };
 
 };

--- a/lib/gui/components/drive-selector/drive-selector.js
+++ b/lib/gui/components/drive-selector/drive-selector.js
@@ -27,7 +27,8 @@ const DriveSelector = angular.module(MODULE_NAME, [
   require('../warning-modal/warning-modal'),
   require('../../models/drives'),
   require('../../models/selection-state'),
-  require('../../utils/byte-size/byte-size')
+  require('../../utils/byte-size/byte-size'),
+  require('../../utils/manifest-bind/manifest-bind')
 ]);
 
 DriveSelector.controller('DriveSelectorController', require('./controllers/drive-selector'));

--- a/lib/gui/components/drive-selector/styles/_drive-selector.scss
+++ b/lib/gui/components/drive-selector/styles/_drive-selector.scss
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-.modal-drive-selector-modal .modal-content {
-  width: 300px;
-  height: 320px;
-}
+.modal-drive-selector-modal {
+  .modal-content {
+    width: 400px;
+    height: 320px;
+  }
 
-.modal-drive-selector-modal .list-group-item[disabled] {
-  cursor: not-allowed;
+  .button,
+  .label,
+  .modal-title {
+    font-weight: bold;
+  }
+
+  .list-group-item[disabled] {
+    cursor: not-allowed;
+  }
 }
 
 .component-drive-selector-body {
@@ -33,5 +41,18 @@
   .list-group-item-text {
     word-break: break-all;
   }
+
+  .list-group-item-text,
+  .list-group-item-footer {
+    display: inline-block;
+  }
+
+  .list-group-item-footer {
+    margin-top: 0;
+  }
+}
+
+.modal-footer-label {
+  @extend .text-center;
 }
 

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -27,17 +27,14 @@
 
             <span class="label label-danger"
               ng-hide="modal.state.isDriveLargeEnough(drive)">
-                <i class="glyphicon glyphicon-resize-small"></i>
                 TOO SMALL FOR IMAGE</span>
 
             <span class="label label-danger"
               ng-show="modal.state.isDriveLocked(drive) && modal.state.isDriveLargeEnough(drive)">
-                <i class="glyphicon glyphicon-lock"></i>
                 LOCKED</span>
 
             <span class="label label-danger"
               ng-show="modal.state.isSystemDrive(drive)">
-                <i class="glyphicon glyphicon-hdd"></i>
                 SYSTEM DRIVE</span>
 
           </footer>
@@ -50,7 +47,17 @@
 </div>
 
 <div class="modal-footer">
-  <button class="button button-primary button-block"
+  <p class="modal-footer-label"
+    ng-show="modal.getButtonStatus() === 'danger'">
+      {{ modal.getFooterMessage() }}
+  </p>
+  <button class="button button-block"
+    ng-class="{ 'label-danger': modal.getButtonStatus() === 'danger',
+                'button-primary': modal.getButtonStatus() === 'primary' }"
     ng-click="modal.closeModal()"
-    ng-disabled="!modal.state.hasDrive()">CONTINUE</button>
+    ng-disabled="!modal.state.hasDrive()">
+      <i class="glyphicon glyphicon-alert"
+        ng-show="modal.getButtonStatus() === 'danger'"></i>
+      Continue
+  </button>
 </div>

--- a/lib/gui/components/modal/styles/_modal.scss
+++ b/lib/gui/components/modal/styles/_modal.scss
@@ -33,7 +33,7 @@
 }
 
 .modal-title {
-  font-size: inherit;
+  font-size: 12px;
   flex-grow: 1;
 }
 
@@ -79,12 +79,14 @@
   }
 
   .list-group-item-heading {
-    font-size: 13px;
+    font-size: 14px;
+    font-weight: bold;
   }
 
   .list-group-item-text {
     line-height: 1;
-    font-size: 11px;
+    font-size: 13px;
+    font-weight: bold;
     color: $palette-theme-light-soft-foreground;
   }
 }

--- a/lib/gui/scss/components/_label.scss
+++ b/lib/gui/scss/components/_label.scss
@@ -15,8 +15,9 @@
  */
 
 .label {
-  font-size: 9px;
-  font-weight: normal;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 2px 5px;
 }
 
 .label-big {

--- a/tests/gui/components/drive-selector.spec.js
+++ b/tests/gui/components/drive-selector.spec.js
@@ -1,0 +1,224 @@
+'use strict';
+
+const _ = require('lodash');
+const m = require('mochainon');
+const angular = require('angular');
+require('angular-mocks');
+
+describe('Browser: DriveSelector', function() {
+
+  beforeEach(angular.mock.module(
+    require('../../../lib/gui/components/drive-selector/drive-selector')
+  ));
+
+  describe('DriveSelectorController', function() {
+
+    const defaultDrive = {
+      device: '/dev/disk2',
+      name: 'My Drive',
+      size: 123456789,
+      protected: false,
+      system: false
+    };
+
+    let currentDrive;
+
+    let $controller;
+    let $q;
+    let $rootScope;
+
+    const importSelectionStateModel = () => {
+      beforeEach(angular.mock.module({
+        SelectionStateModel: {
+          getDrive: () => {
+            return currentDrive;
+          },
+          hasDrive: () => {
+            return Boolean(currentDrive);
+          },
+          isSystemDrive: () => {
+            return Boolean(currentDrive.system);
+          }
+        }
+      }));
+    };
+
+    const injectDependencies = () => {
+      beforeEach(angular.mock.inject(function(_$controller_, _$q_, _$rootScope_) {
+        $controller = _$controller_;
+        $q = _$q_;
+        $rootScope = _$rootScope_;
+      }));
+    };
+
+    // Note '$rootScope' won't be instantiated until inside an 'it',
+    // therefore only call this function there or in a deeper scope.
+    const makeDriveSelectorController = () => {
+      const scope = $rootScope.$new();
+
+      return $controller('DriveSelectorController', {
+        $scope: scope,
+
+        // Inject stub for $uibModalInstance; this is necessary because
+        // none is provided by UI Bootstrap.
+        $uibModalInstance: {
+          result: $q.resolve(),
+          opened: $q.resolve(),
+          closed: $q.resolve(),
+          rendered: $q.resolve(),
+          close: _.constant($q.resolve()),
+          dismiss: _.constant($q.reject())
+        }
+      });
+    };
+
+    describe('.getButtonStatus()', function() {
+
+      importSelectionStateModel();
+      injectDependencies();
+
+      describe('given there is no selected drive', function() {
+
+        it('should return "disabled"', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = undefined;
+
+          const result = DriveSelectorController.getButtonStatus();
+
+          m.chai.expect(result).to.equal('disabled');
+
+        });
+      });
+
+      describe('given there is a protected drive', function() {
+
+        it('should return "disabled"', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = _.merge(defaultDrive, {
+            protected: true
+          });
+
+          const result = DriveSelectorController.getButtonStatus();
+
+          m.chai.expect(result).to.equal('disabled');
+
+        });
+      });
+
+      describe('given there is a system drive', function() {
+
+        it('should return "danger"', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = _.merge(defaultDrive, {
+            protected: false,
+            system: true
+          });
+
+          const result = DriveSelectorController.getButtonStatus();
+
+          m.chai.expect(result).to.equal('danger');
+
+        });
+      });
+
+      describe('given there is a removable drive', function() {
+
+        it('should return "primary"', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = _.merge(defaultDrive, {
+            protected: false,
+            system: false
+          });
+
+          const result = DriveSelectorController.getButtonStatus();
+          m.chai.expect(result).to.equal('primary');
+
+        });
+      });
+    });
+
+    describe('.getFooterMessage()', function() {
+
+      importSelectionStateModel();
+      injectDependencies();
+
+      describe('given there is no drive', function() {
+
+        it('should be undefined', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = undefined;
+
+          const result = DriveSelectorController.getFooterMessage();
+
+          m.chai.expect(result).to.be.undefined;
+
+        });
+      });
+
+      describe('given there is a system drive', function() {
+
+        it('should not be undefined', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = _.merge(defaultDrive, {
+            protected: false,
+            system: true
+          });
+
+          const result = DriveSelectorController.getFooterMessage();
+
+          m.chai.expect(result).to.not.be.undefined;
+
+        });
+      });
+    });
+
+    describe('.hasFooterMessage()', function() {
+
+      importSelectionStateModel();
+      injectDependencies();
+
+      describe('given there is no drive', function() {
+
+        it('should be false', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = undefined;
+
+          const result = DriveSelectorController.hasFooterMessage();
+
+          m.chai.expect(result).to.be.false;
+        });
+      });
+
+      describe('given there is a system drive', function() {
+
+        it('should be true', function() {
+
+          const DriveSelectorController = makeDriveSelectorController();
+
+          currentDrive = _.merge(defaultDrive, {
+            protected: false,
+            system: true
+          });
+
+          const result = DriveSelectorController.hasFooterMessage();
+
+          m.chai.expect(result).to.be.true;
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Make the drive-list confirmation button a cautionary red upon selection of
a system drive, and show a descriptive warning label. Also, make the drive
list wider for the label and changes to come.

See: #888
Changelog-Entry: Drive selection cautions user with red confirm button.