### PR TITLE
feat(gui): add referers to etcher.io links

### DIFF
--- a/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
+++ b/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
@@ -12,7 +12,7 @@
 <div class="modal-footer">
   <div class="modal-menu">
     <button class="button button-primary"
-      os-open-external="https://etcher.io">DOWNLOAD</button>
+      os-open-external="https://etcher.io?ref=etcher_update">DOWNLOAD</button>
     <button class="button button-default"
       ng-click="modal.closeModal()">SKIP</button>
   </div>

--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -38,7 +38,7 @@
       <svg-icon path="../../../assets/etcher.svg"
         width="83px"
         height="13px"
-        os-open-external="https://etcher.io"></svg-icon>
+        os-open-external="https://etcher.io?ref=etcher_footer"></svg-icon>
 
       <span class="caption">
         IS <span class="caption" os-open-external="https://github.com/resin-io/etcher">AN OPEN SOURCE PROJECT</span> BY


### PR DESCRIPTION
We add referers to the two etcher.io links in the interface—one for the
update link, and one for the footer logo link.

Closes: https://github.com/resin-io/etcher/issues/987
Changelog-Entry: Add referers to the etcher.io links