### PR TITLE
feat(gui): sort file picker extensions alphabetically

### DIFF
--- a/lib/gui/os/dialog/services/dialog.js
+++ b/lib/gui/os/dialog/services/dialog.js
@@ -57,7 +57,7 @@ module.exports = function($q, SupportedFormatsModel) {
         filters: [
           {
             name: 'OS Images',
-            extensions: SupportedFormatsModel.getAllExtensions()
+            extensions: _.sortBy(SupportedFormatsModel.getAllExtensions())
           }
         ]
       }, (files) => {


### PR DESCRIPTION
We sort the supported file extensions listed in the file picker
in alphabetical order.

See: https://github.com/resin-io/etcher/issues/984
Changelog-Entry: Sort supported extensions alphabetically in the
file-picker.