### PR TITLE
chore: don't upgrade npm to latest on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm install -g npm bower rimraf asar
+  - npm install -g bower rimraf asar
   - choco install nsis -version 2.51
   - choco install upx
   - choco install jq


### PR DESCRIPTION
Running `npm install -g npm` causes npm to be upgraded to v4, which
seems to have the following bug when running `npm install`:

```
npm ERR! Callback called more than once.
```

Not upgrading npm on our Appveyor builds causes npm to stay at v3, and
the problem dissapears.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>