### PR TITLE
upgrade: `etcher-image-write` to v9.0.0

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -64,32 +64,40 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
 
     return unmount.unmountDrive(drive);
   }).then(() => {
-    return Bluebird.props({
-      image: imageStream.getFromFilePath(imagePath),
-      driveFileDescriptor: fs.openAsync(drive.raw, 'rs+')
-    });
-  }).then((results) => {
-    return imageWrite.write({
-      fd: results.driveFileDescriptor,
-      device: drive.raw,
-      size: drive.size
-    }, results.image, {
-      check: options.validateWriteOnSuccess,
-      transform: results.image.transform,
-      bmap: results.image.bmap,
-      bytesToZeroOutFromTheBeginning: results.image.bytesToZeroOutFromTheBeginning
-    });
-  }).then((writer) => {
-    return new Bluebird((resolve, reject) => {
-      writer.on('progress', onProgress);
-      writer.on('error', reject);
-      writer.on('done', resolve);
-    });
-  }).tap(() => {
-    if (!options.unmountOnSuccess) {
-      return;
-    }
+    return fs.openAsync(drive.raw, 'rs+');
+  }).then((driveFileDescriptor) => {
+    return imageStream.getFromFilePath(imagePath).then((image) => {
+      return imageWrite.write({
+        fd: driveFileDescriptor,
+        device: drive.raw,
+        size: drive.size
+      }, image, {
+        check: options.validateWriteOnSuccess,
+        transform: image.transform,
+        bmap: image.bmap,
+        bytesToZeroOutFromTheBeginning: image.bytesToZeroOutFromTheBeginning
+      });
+    }).then((writer) => {
+      return new Bluebird((resolve, reject) => {
+        writer.on('progress', onProgress);
+        writer.on('error', reject);
+        writer.on('done', resolve);
+      });
+    }).tap(() => {
 
-    return unmount.unmountDrive(drive);
+      // Make sure the device stream file descriptor is closed
+      // before returning control the the caller. Not closing
+      // the file descriptor (and waiting for it) results in
+      // `EBUSY` errors when attempting to unmount the drive
+      // right afterwards in some Windows 7 systems.
+      return fs.closeAsync(driveFileDescriptor).then(() => {
+
+        if (!options.unmountOnSuccess) {
+          return;
+        }
+
+        return unmount.unmountDrive(drive);
+      });
+    });
   });
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -296,11 +296,6 @@
       "from": "asn1.js@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.2.tgz"
     },
-    "assert": {
-      "version": "1.3.0",
-      "from": "assert@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
-    },
     "assert-plus": {
       "version": "0.1.5",
       "from": "assert-plus@>=0.1.5 <0.2.0",
@@ -1408,9 +1403,9 @@
       }
     },
     "etcher-image-write": {
-      "version": "8.1.5",
-      "from": "etcher-image-write@8.1.5",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-8.1.5.tgz",
+      "version": "9.0.0",
+      "from": "etcher-image-write@9.0.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.0.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "drivelist": "^5.0.4",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^5.1.0",
-    "etcher-image-write": "^8.1.5",
+    "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",
     "file-tail": "^0.3.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This version includes support for retrying up to ten times when EIO
errors are encountered during reading.

See: https://github.com/resin-io-modules/etcher-image-write/pull/70
Fixes: https://github.com/resin-io/etcher/issues/981
Change-Type: patch
Changelog-Entry: Fix sporadic "EIO: i/o error, read" errors during validation.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>