### PR TITLE
upgrade: `drivelist` to v5.0.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1136,14 +1136,14 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "drivelist": {
-      "version": "5.0.4",
-      "from": "drivelist@5.0.4",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.4.tgz",
+      "version": "5.0.5",
+      "from": "drivelist@5.0.5",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.5.tgz",
       "dependencies": {
         "lodash": {
-          "version": "4.17.2",
+          "version": "4.17.4",
           "from": "lodash@>=4.16.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.4",
+    "drivelist": "^5.0.5",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^5.1.0",
     "etcher-image-write": "^9.0.0",


### PR DESCRIPTION
- https://github.com/resin-io-modules/drivelist/pull/129

Change-Type: patch
Changelog-Entry: Fix system drives detected as removable drives on Mac Mini.
See: https://github.com/resin-io/etcher/issues/983
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>