### PR TITLE
fix: make the image selection window a modal (#932)

### DIFF
--- a/lib/gui/os/dialog/services/dialog.js
+++ b/lib/gui/os/dialog/services/dialog.js
@@ -40,7 +40,8 @@ module.exports = function($q, SupportedFormatsModel) {
    */
   this.selectImage = () => {
     return $q((resolve, reject) => {
-      electron.remote.dialog.showOpenDialog({
+      const currentWindow = electron.remote.getCurrentWindow();
+      electron.remote.dialog.showOpenDialog(currentWindow, {
 
         // This variable is set when running in GNU/Linux from
         // inside an AppImage, and represents the working directory


### PR DESCRIPTION
The image selection dialog is attached to the parent window so it is a modal.