### PR TITLE
chore: make use of the "spec" mocha reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git@github.com:resin-io/etcher.git"
   },
   "scripts": {
-    "test": "npm run lint && electron-mocha --recursive --renderer tests/gui -R min && electron-mocha --recursive tests/cli tests/shared -R min",
+    "test": "npm run lint && electron-mocha --recursive --renderer tests/gui -R spec && electron-mocha --recursive tests/cli tests/shared -R spec",
     "sass": "node-sass ./lib/gui/scss/main.scss > ./lib/gui/css/main.css",
     "jslint": "eslint lib tests scripts bin versionist.conf.js",
     "scsslint": "scss-lint lib/gui/scss",


### PR DESCRIPTION
The "min" mocha reporter clears the screen after each run, causing any
error/warning from the renderer process tests to be visually overwritten
by the main process tests.

Therefore, we now make use of the "spec" mocha reporter.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>