### PR TITLE
fix(GUI): open DevTools in `detach` mode

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -65,7 +65,7 @@ electron.app.on('ready', () => {
   mainWindow.on('focus', () => {
     electron.globalShortcut.register('CmdOrCtrl+Alt+I', () => {
       mainWindow.webContents.openDevTools({
-        mode: 'undocked'
+        mode: 'detach'
       });
     });
   });


### PR DESCRIPTION
We were previously using the `undocked` mode, which would open DevTools
in a seaprate window, however the user was still allows to pick a new
mode, causing DevTools to be shown inside the main application and
completely ruining the UI.

The `detach` mode in the other hand, completely prevents user from
putting DevTools in the main application, therefore allowing no way to
make the UI look broken.

See: http://electron.atom.io/docs/api/web-contents/
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>