### PR TITLE
fix: allow undefined drives and images in DriveConstraintsModel

### DIFF
--- a/lib/shared/drive-constraints.js
+++ b/lib/shared/drive-constraints.js
@@ -16,6 +16,8 @@
 
 'use strict';
 
+const _ = require('lodash');
+
 /**
  * @summary Check if a drive is locked
  * @function
@@ -38,7 +40,7 @@
  * }
  */
 exports.isDriveLocked = (drive) => {
-  return Boolean(drive.protected || false);
+  return Boolean(_.get(drive, 'protected', false));
 };
 
 /**
@@ -60,7 +62,7 @@ exports.isDriveLocked = (drive) => {
  * }
  */
 exports.isSystemDrive = (drive) => {
-  return Boolean(drive.system || false);
+  return Boolean(_.get(drive, 'system', false));
 };
 
 /**
@@ -85,7 +87,7 @@ exports.isSystemDrive = (drive) => {
  * }
  */
 exports.isDriveLargeEnough = (drive, image) => {
-  return drive.size >= (image.size || 0);
+  return _.get(drive, 'size', 0) >= _.get(image, 'size', 0);
 };
 
 /**
@@ -145,5 +147,5 @@ exports.isDriveValid = (drive, image) => {
  * }
  */
 exports.isDriveSizeRecommended = (drive, image) => {
-  return drive.size >= (image.recommendedDriveSize || 0);
+  return _.get(drive, 'size', 0) >= _.get(image, 'recommendedDriveSize', 0);
 };

--- a/tests/shared/drive-constraints.spec.js
+++ b/tests/shared/drive-constraints.spec.js
@@ -39,6 +39,12 @@ describe('Shared: DriveConstraints', function() {
       m.chai.expect(result).to.be.false;
     });
 
+    it('should return false if the drive is undefined', function() {
+      const result = constraints.isDriveLocked(undefined);
+
+      m.chai.expect(result).to.be.false;
+    });
+
   });
 
   describe('.isSystemDrive()', function() {
@@ -74,6 +80,12 @@ describe('Shared: DriveConstraints', function() {
         protected: true,
         system: false
       });
+
+      m.chai.expect(result).to.be.false;
+    });
+
+    it('should return false if the drive is undefined', function() {
+      const result = constraints.isSystemDrive(undefined);
 
       m.chai.expect(result).to.be.false;
     });
@@ -122,6 +134,31 @@ describe('Shared: DriveConstraints', function() {
       });
 
       m.chai.expect(result).to.be.false;
+    });
+
+    it('should return false if the drive is undefined', function() {
+      const result = constraints.isDriveLargeEnough(undefined, {
+        path: 'rpi.img',
+        size: 1000000000
+      });
+
+      m.chai.expect(result).to.be.false;
+    });
+
+    it('should return true if the image is undefined', function() {
+      const result = constraints.isDriveLargeEnough({
+        device: '/dev/disk1',
+        name: 'USB Drive',
+        size: 1000000000,
+        protected: false
+      }, undefined);
+
+      m.chai.expect(result).to.be.true;
+    });
+
+    it('should return false if the drive and image are undefined', function() {
+      const result = constraints.isDriveLargeEnough(undefined, undefined);
+      m.chai.expect(result).to.be.true;
     });
 
   });
@@ -184,6 +221,32 @@ describe('Shared: DriveConstraints', function() {
         size: 1000000000
       });
 
+      m.chai.expect(result).to.be.true;
+    });
+
+    it('should return false if the drive is undefined', function() {
+      const result = constraints.isDriveSizeRecommended(undefined, {
+        path: 'rpi.img',
+        size: 1000000000,
+        recommendedDriveSize: 1000000000
+      });
+
+      m.chai.expect(result).to.be.false;
+    });
+
+    it('should return true if the image is undefined', function() {
+      const result = constraints.isDriveSizeRecommended({
+        device: '/dev/disk1',
+        name: 'USB Drive',
+        size: 2000000000,
+        protected: false
+      }, undefined);
+
+      m.chai.expect(result).to.be.true;
+    });
+
+    it('should return false if the drive and image are undefined', function() {
+      const result = constraints.isDriveSizeRecommended(undefined, undefined);
       m.chai.expect(result).to.be.true;
     });
 


### PR DESCRIPTION
Currently the `DriveConstraintsModel` errors when given an `undefined`
drive, or image; this commit changes that behaviour. Comes with tests.

Changelog-Entry: Don't throw errors when drives and/or images are undefined in
the DriveConstraintsModel.