### PR TITLE
upgrade: `drivelist` to v5.0.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -266,9 +266,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.5",
-      "from": "drivelist@5.0.5",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.5.tgz",
+      "version": "5.0.6",
+      "from": "drivelist@5.0.6",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.6.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.5",
+    "drivelist": "^5.0.6",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-stream": "^5.1.0",
     "etcher-image-write": "^9.0.0",


### PR DESCRIPTION
- https://github.com/resin-io-modules/drivelist/issues/130

Change-Type: patch
Changelog-Entry: Fix "This key is already associated with an element of this collection" error when multiple partitions point to the same drive letter on Windows.
Fixes: https://github.com/resin-io/etcher/issues/1004
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>