### PR TITLE
refactor: move all byte-size conversion logic to lib/shared/units.js 

### DIFF
--- a/lib/gui/models/flash-state.js
+++ b/lib/gui/models/flash-state.js
@@ -25,6 +25,7 @@ const _ = require('lodash');
 const Store = require('./store');
 const MODULE_NAME = 'Etcher.Models.FlashState';
 const FlashState = angular.module(MODULE_NAME, []);
+const units = require('../../shared/units');
 
 FlashState.service('FlashStateModel', function() {
 
@@ -132,8 +133,8 @@ FlashState.service('FlashStateModel', function() {
         speed: _.attempt(() => {
           if (_.isNumber(state.speed) && !_.isNaN(state.speed)) {
 
-            // Transform bytes to megabytes preserving only two decimal places
-            return Math.floor(state.speed / 1e+6 * 100) / 100;
+            // Preserve only two decimal places
+            return Math.floor(units.bytesToMegabytes(state.speed) * 100) / 100;
 
           }
         })

--- a/lib/shared/units.js
+++ b/lib/shared/units.js
@@ -16,21 +16,32 @@
 
 'use strict';
 
-const units = require('../../../../shared/units');
+/**
+ * @summary Convert bytes to gigabytes
+ * @function
+ * @public
+ *
+ * @param {Number} bytes - bytes
+ * @returns {Number} gigabytes
+ *
+ * @example
+ * const result = units.bytesToGigabytes(7801405440);
+ */
+exports.bytesToGigabytes = (bytes) => {
+  return bytes / 1e+9;
+};
 
-module.exports = () => {
-
-  /**
-   * @summary Convert bytes to gigabytes
-   * @function
-   * @public
-   *
-   * @param {Number} bytes - bytes
-   * @returns {Number} gigabytes
-   *
-   * @example
-   * {{ 7801405440 | gigabytes }}
-   */
-  return units.bytesToGigabytes;
-
+/**
+ * @summary Convert bytes to megabytes
+ * @function
+ * @public
+ *
+ * @param {Number} bytes - bytes
+ * @returns {Number} megabytes
+ *
+ * @example
+ * const result = units.bytesToMegabytes(7801405440);
+ */
+exports.bytesToMegabytes = (bytes) => {
+  return bytes / 1e+6;
 };

--- a/tests/gui/utils/byte-size.spec.js
+++ b/tests/gui/utils/byte-size.spec.js
@@ -3,6 +3,7 @@
 const m = require('mochainon');
 const angular = require('angular');
 require('angular-mocks');
+const units = require('../../../lib/shared/units');
 
 describe('Browser: ByteSize', function() {
 
@@ -18,9 +19,8 @@ describe('Browser: ByteSize', function() {
       gigabyteFilter = _gigabyteFilter_;
     }));
 
-    it('should convert bytes to gigabytes', function() {
-      m.chai.expect(gigabyteFilter(7801405440)).to.equal(7.80140544);
-      m.chai.expect(gigabyteFilter(100000000)).to.equal(0.1);
+    it('should expose lib/shared/units.js bytesToGigabytes()', function() {
+      m.chai.expect(gigabyteFilter).to.equal(units.bytesToGigabytes);
     });
 
   });

--- a/tests/shared/units.spec.js
+++ b/tests/shared/units.spec.js
@@ -16,21 +16,23 @@
 
 'use strict';
 
-const units = require('../../../../shared/units');
+const m = require('mochainon');
+const units = require('../../lib/shared/units');
 
-module.exports = () => {
+describe('Shared: Units', function() {
 
-  /**
-   * @summary Convert bytes to gigabytes
-   * @function
-   * @public
-   *
-   * @param {Number} bytes - bytes
-   * @returns {Number} gigabytes
-   *
-   * @example
-   * {{ 7801405440 | gigabytes }}
-   */
-  return units.bytesToGigabytes;
+  describe('.bytesToGigabytes()', function() {
 
-};
+    it('should convert bytes to gigabytes', function() {
+      m.chai.expect(units.bytesToGigabytes(7801405440)).to.equal(7.80140544);
+      m.chai.expect(units.bytesToGigabytes(100000000)).to.equal(0.1);
+    });
+
+    it('should convert bytes to megabytes', function() {
+      m.chai.expect(units.bytesToMegabytes(1.2e+7)).to.equal(12);
+      m.chai.expect(units.bytesToMegabytes(332000)).to.equal(0.332);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This commit extracts the byte-related conversions from the `byte-size`
AngularJS module and the `FlashStateModel` to a re-usable generic
CommonJS module at `lib/shared/units.js`, than can also be used by the
CLI.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>