### PR TITLE
fix(GUI): expand button in modal menu if its the only one

### DIFF
--- a/lib/gui/components/modal/styles/_modal.scss
+++ b/lib/gui/components/modal/styles/_modal.scss
@@ -104,8 +104,8 @@
 .modal-menu {
   display: flex;
 
-  > .button {
-    flex-basis: 50%;
+  > * {
+    flex-basis: auto;
   }
 }
 

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6276,8 +6276,8 @@ body {
 
 .modal-menu {
   display: flex; }
-  .modal-menu > .button, .modal-menu > .progress-button {
-    flex-basis: 50%; }
+  .modal-menu > * {
+    flex-basis: auto; }
 
 .modal-open {
   padding-right: 0 !important; }


### PR DESCRIPTION
The `.modal-menu` class holds buttons that are shown at the bottom of
the modal. If there are two buttons, the class will show them side by
side with equal sizes, however if there is only one button, it will be
incorrectly resized to 50% of the available space.

![screenshot 2017-01-12 19 30 04](https://cloud.githubusercontent.com/assets/2192773/21912637/99db45e0-d8fd-11e6-97d1-aa544dd6c7fc.png)

Change-Type: patch
Changelog-Entry: Fix alignment of single call to action buttons inside modals.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>