### PR TITLE
fix(GUI): don't ignore any `robot` message from the CLI

### DIFF
--- a/lib/shared/child-writer/writer-proxy.js
+++ b/lib/shared/child-writer/writer-proxy.js
@@ -175,9 +175,9 @@ return isElevated().then((elevated) => {
           // causing several progress lines to come up at once as single message.
           // Trying to parse multiple JSON objects separated by new lines will
           // of course make the parser confused, causing errors later on.
-          // As a solution, we only consider the last message.
-          const object = _.last(utils.splitObjectLines(data.toString()));
-          ipc.of[process.env.IPC_SERVER_ID].emit('message', object);
+          _.each(utils.splitObjectLines(data.toString()), (object) => {
+            ipc.of[process.env.IPC_SERVER_ID].emit('message', object);
+          });
 
         };
 


### PR DESCRIPTION
We recently sent a PR to handle multiple buffered IPC messages being
reported as a single message, confusing `JSON.parse()` in
`lib/shared/child-writer/index.js`, by only sending the last message,
and ignoring the rest, under the assumption that the loss of some state
messages is not critical for the application and the writing process to
work property.

As @lurch pointed out, however, a buffer set of messages might contain
an error object somewhere, and by ignoring all but the last message, we
ignore any error that happened in the way.

See: https://github.com/resin-io/etcher/issues/898
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>