### PR TITLE
fix(gui): break and wrap bootstrap overflowing tooltip text

### DIFF
--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -5976,6 +5976,9 @@ body {
 [uib-tooltip] {
   cursor: default; }
 
+.tooltip {
+  word-wrap: break-word; }
+
 /*
  * Copyright 2016 resin.io
  *

--- a/lib/gui/scss/modules/_bootstrap.scss
+++ b/lib/gui/scss/modules/_bootstrap.scss
@@ -35,3 +35,8 @@ body {
 [uib-tooltip] {
   cursor: default;
 }
+
+.tooltip {
+  word-wrap: break-word;
+}
+


### PR DESCRIPTION
Instead of letting Bootstrap tooltip text overflow, allow breaks to occur in
words.

Closes: https://github.com/resin-io/etcher/issues/1032
Changelog-Entry: Fix overflowing tooltip text by allowing breaks in words.