### PR TITLE
chore: support generating armv7l .deb packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,9 @@ else
 		ifneq ($(filter %86,$(shell uname -p)),)
 			HOST_ARCH = x86
 		endif
+		ifeq ($(shell uname -m),armv7l)
+			HOST_ARCH = armv7l
+		endif
 	endif
 	ifeq ($(shell uname -s),Darwin)
 		HOST_PLATFORM = darwin
@@ -134,12 +137,7 @@ endif
 # Extra variables
 # ---------------------------------------------------------------------
 
-ifeq ($(TARGET_ARCH),x86)
-	TARGET_ARCH_DEBIAN = i386
-endif
-ifeq ($(TARGET_ARCH),x64)
-	TARGET_ARCH_DEBIAN = amd64
-endif
+TARGET_ARCH_DEBIAN = $(shell ./scripts/build/architecture-convert.sh -r $(TARGET_ARCH) -t debian)
 
 ifeq ($(RELEASE_TYPE),production)
 	PRODUCT_NAME = etcher
@@ -388,7 +386,7 @@ publish-bintray-debian: $(PUBLISH_BINTRAY_DEBIAN)
 	$(foreach publishable,$^,$(call execute-command,./scripts/publish/bintray-debian.sh \
 		-f $(publishable) \
 		-v $(APPLICATION_VERSION_DEBIAN) \
-		-r $(TARGET_ARCH_DEBIAN) \
+		-r $(TARGET_ARCH) \
 		-c $(APPLICATION_NAME_LOWERCASE) \
 		-t $(RELEASE_TYPE)))
 

--- a/scripts/build/architecture-convert.sh
+++ b/scripts/build/architecture-convert.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -e
+set -u
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -r <architecture>"
+  echo "    -t <type (debian|node)>"
+  exit 1
+}
+
+ARGV_ARCHITECTURE=""
+ARGV_TYPE=""
+
+while getopts ":r:t:" option; do
+  case $option in
+    r) ARGV_ARCHITECTURE=$OPTARG ;;
+    t) ARGV_TYPE=$OPTARG ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_ARCHITECTURE" ] || [ -z "$ARGV_TYPE" ]; then
+  usage
+fi
+
+RESULT=""
+
+if [ "$ARGV_TYPE" == "node" ]; then
+  if [ "$ARGV_ARCHITECTURE" == "x86" ]; then
+    RESULT=ia32
+  elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
+    RESULT=x64
+  elif [ "$ARGV_ARCHITECTURE" == "armv7l" ]; then
+    RESULT=arm
+  fi
+elif [ "$ARGV_TYPE" == "debian" ]; then
+  if [ "$ARGV_ARCHITECTURE" == "x86" ]; then
+    RESULT=i386
+  elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
+    RESULT=amd64
+  elif [ "$ARGV_ARCHITECTURE" == "armv7l" ]; then
+    RESULT=armhf
+  fi
+else
+  echo "Unsupported architecture type: $ARGV_TYPE" 1>&2
+  exit 1
+fi
+
+if [ -z "$RESULT" ]; then
+  echo "Unsupported architecture: $ARGV_ARCHITECTURE" 1>&2
+  exit 1
+fi
+
+echo "$RESULT"

--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -82,11 +82,8 @@ fi
 export npm_config_target=$ARGV_TARGET_VERSION
 export npm_config_build_from_source=true
 
-if [ "$ARGV_ARCHITECTURE" == "x86" ]; then
-  export npm_config_arch=ia32
-else
-  export npm_config_arch=$ARGV_ARCHITECTURE
-fi
+ELECTRON_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t node)
+export npm_config_arch=$ELECTRON_ARCHITECTURE
 
 INSTALL_OPTS=""
 

--- a/scripts/build/electron-download-package.sh
+++ b/scripts/build/electron-download-package.sh
@@ -26,7 +26,7 @@ function usage() {
   echo ""
   echo "Options"
   echo ""
-  echo "    -r <electron architecture>"
+  echo "    -r <architecture>"
   echo "    -v <electron version>"
   echo "    -s <electron operating system>"
   echo "    -o <output directory>"
@@ -56,11 +56,7 @@ then
   usage
 fi
 
-ELECTRON_ARCHITECTURE=$ARGV_ARCHITECTURE
-if [ "$ELECTRON_ARCHITECTURE" == "x86" ]; then
-  ELECTRON_ARCHITECTURE="ia32"
-fi
-
+ELECTRON_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t node)
 ELECTRON_GITHUB_REPOSITORY=https://github.com/electron/electron
 ELECTRON_DOWNLOADS_BASEURL="$ELECTRON_GITHUB_REPOSITORY/releases/download/v$ARGV_ELECTRON_VERSION"
 ELECTRON_FILENAME="electron-v$ARGV_ELECTRON_VERSION-$ARGV_OPERATING_SYSTEM-$ELECTRON_ARCHITECTURE.zip"

--- a/scripts/build/electron-installer-debian-linux.sh
+++ b/scripts/build/electron-installer-debian-linux.sh
@@ -33,7 +33,7 @@ function usage() {
   echo "Options"
   echo ""
   echo "    -p <application directory>"
-  echo "    -r <application architecture>"
+  echo "    -r <architecture>"
   echo "    -c <debian configuration (.json)>"
   echo "    -o <output directory>"
   exit 1
@@ -62,19 +62,12 @@ then
   usage
 fi
 
-if [ "$ARGV_ARCHITECTURE" == "x86" ]; then
-  DEBARCH=i386
-elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
-  DEBARCH=amd64
-else
-  echo "Unsupported architecture: $ARGV_ARCHITECTURE" 1>&2
-  exit 1
-fi
+DEBIAN_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t debian)
 
 cp scripts/build/debian/etcher-electron.sh "$ARGV_DIRECTORY"
 electron-installer-debian \
   --src "$ARGV_DIRECTORY" \
   --dest "$ARGV_OUTPUT" \
   --config "$ARGV_DEBIAN_CONFIGURATION" \
-  --arch "$DEBARCH"
+  --arch "$DEBIAN_ARCHITECTURE"
 rm "$ARGV_DIRECTORY/etcher-electron.sh"

--- a/scripts/publish/bintray-debian.sh
+++ b/scripts/publish/bintray-debian.sh
@@ -82,12 +82,13 @@ fi
 
 PACKAGE_FILE_NAME=$(basename $ARGV_FILE)
 PACKAGE_NAME=${PACKAGE_FILE_NAME%.*}
+PACKAGE_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t debian)
 
 curl --upload-file $ARGV_FILE \
   --user $BINTRAY_USER:$BINTRAY_API_KEY \
   --header "X-Bintray-Debian-Distribution: $PACKAGE_DISTRIBUTION" \
   --header "X-Bintray-Debian-Component: $ARGV_COMPONENT_NAME" \
-  --header "X-Bintray-Debian-Architecture: $ARGV_ARCHITECTURE" \
+  --header "X-Bintray-Debian-Architecture: $PACKAGE_ARCHITECTURE" \
   --header "X-Bintray-Publish: 1" \
   https://api.bintray.com/content/resin-io/debian/$ARGV_COMPONENT_NAME/$ARGV_VERSION/$PACKAGE_FILE_NAME
 


### PR DESCRIPTION
This is the architecture of the Raspberry Pi 3. The following changes
were necessary:

- Detect the architecture using `uname -m`
- Set the Debian equivalent architecture to `armhf`
- Handle the new architecture correctly on `dependencies-npm.sh` and
  `electron-download-package.sh`, referring to it as simply `arm` (which
  is what `node-gyp` expects)

Steps to test this PR:

- `make electron-installer-debian` from a Raspberry Pi 3

This PR also includes `architecture-convert.sh`, which is a script to
find an architecture equivalence for Node and Debian.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>