### PR TITLE
chore: don't print Makefile comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,14 +365,14 @@ endif
 .PHONY: $(TARGETS)
 
 electron-develop:
-	# Since we use an `npm-shrinkwrap.json` file, if you pull changes
-	# that update a dependency and try to `npm install` directly, npm
-	# will complain that your `node_modules` tree is not equal to what
-	# is defined by the `npm-shrinkwrap.json` file, and will thus
-	# refuse to do anything but install from scratch.
-	# The `node_modules` directory also needs to be wiped out if you're
-	# changing between target architectures, since compiled add-ons
-	# will not work otherwise.
+# Since we use an `npm-shrinkwrap.json` file, if you pull changes
+# that update a dependency and try to `npm install` directly, npm
+# will complain that your `node_modules` tree is not equal to what
+# is defined by the `npm-shrinkwrap.json` file, and will thus
+# refuse to do anything but install from scratch.
+# The `node_modules` directory also needs to be wiped out if you're
+# changing between target architectures, since compiled add-ons
+# will not work otherwise.
 	rm -rf node_modules
 	./scripts/build/dependencies-npm.sh \
 		-r "$(TARGET_ARCH)" \


### PR DESCRIPTION
We have a big comment block in the `electron-develop` target which gets
printed everytime the target gets executed.

After some research, turns out GNU Make will ignore the comments if they
are not indented.

See: http://stackoverflow.com/a/18363477/1641422
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>