### PR TITLE
fix(GUI): emit an analytics event on ENOSPC

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -79,6 +79,7 @@ module.exports = function(
         AnalyticsService.logEvent('Validation error');
       } else if (error.code === 'ENOSPC') {
         FlashErrorModalService.show(messages.error.notEnoughSpaceInDrive());
+        AnalyticsService.logEvent('Out of space');
       } else {
         FlashErrorModalService.show(messages.error.genericFlashError());
         ErrorService.reportException(error);


### PR DESCRIPTION
There exists a change the user will run out of space on his drive when
flashing an image format for which we can't guarantee its uncompressed
size (e.g: gzip and bzip2).

When that happens, we show a friendly error message explaining what
happened, however we should also be emitting an analytics event.

Change-Type: patch
Changelog-Entry: Emit an analytics event on `ENOSPC`.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>