### PR TITLE
fix(GUI): improve validation error message

### DIFF
--- a/lib/gui/components/flash-error-modal/templates/flash-error-modal.tpl.html
+++ b/lib/gui/components/flash-error-modal/templates/flash-error-modal.tpl.html
@@ -8,7 +8,9 @@
 </div>
 
 <div class="modal-body">
-  <div class="modal-text">{{ ::modal.data.message }}</div>
+  <div class="modal-text">
+    <p>{{ ::modal.data.message }}</p>
+  </div>
 </div>
 
 <div class="modal-footer">

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -71,8 +71,9 @@ module.exports = {
     genericFlashError: _.template('Oops, seems something went wrong.'),
 
     validation: _.template([
-      'Your removable drive may be corrupted.',
-      'Try inserting a different one and try again.'
+      'The write has been completed successfully but Etcher detected potential',
+      'corruption issues when reading the image back from the drive.',
+      '\n\nPlease consider writing the image to a different drive.'
     ].join(' ')),
 
     invalidImage: _.template('<%= image.path %> is not a supported image type.'),


### PR DESCRIPTION
The current validation message is obscure and tends to lead users to
believe there is a problem with Etcher.

Fixes: https://github.com/resin-io/etcher/issues/735
Change-Type: patch
Changelog-Entry: Improve validation error message.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>