### PR TITLE
chore: add a `package` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,10 @@ TARGETS = \
 	info \
 	clean \
 	distclean \
+	package \
 	electron-develop
+
+package: $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH)
 
 ifeq ($(TARGET_PLATFORM),darwin)
 electron-installer-app-zip: $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH).zip


### PR DESCRIPTION
This target would easily allow us to create a package for the
application without being wrapped into an installer, which is
particularly useful to provide custom builds, or test asar related
issues, for example.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>