### PR TITLE
upgrade: `drivelist` to v5.0.8

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -266,9 +266,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.6",
-      "from": "drivelist@5.0.6",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.6.tgz",
+      "version": "5.0.8",
+      "from": "drivelist@5.0.8",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.8.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -512,15 +512,15 @@
       "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
-    "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-    },
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "js-message": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.6",
+    "drivelist": "^5.0.8",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
Change-Type: patch
Changelog-Entry: Fix 'MySQL' is not recognised as an internal or external command error on Windows.
See: https://github.com/resin-io-modules/drivelist/issues/133
Fixes: https://github.com/resin-io/etcher/issues/1025
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>