### PR TITLE
test(GUI): fix non-running test in DrivesModel test suite

### DIFF
--- a/tests/gui/models/drives.spec.js
+++ b/tests/gui/models/drives.spec.js
@@ -210,7 +210,7 @@ describe('Browser: DrivesModel', function() {
               {
                 device: '/dev/sdb',
                 name: 'Foo',
-                size: 999999999,
+                size: 2000000000,
                 mountpoint: '/mnt/foo',
                 system: false,
                 protected: true


### PR DESCRIPTION
We have a test to ensure a drive is not auto-selected when its
protected, however the real functionality of this test was not being
tested given that the size the fake drive had was not enough to hold the
image.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>