### PR TITLE
upgrade: `drivelist` to v5.0.9

### DIFF
--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -7,6 +7,10 @@
     <link rel="stylesheet" type="text/css" href="css/desktop.css">
     <link rel="stylesheet" type="text/css" href="css/angular.css">
 
+    <!-- Enable debug information from all modules that use `debug` -->
+    <!-- See https://github.com/visionmedia/debug#browser-support -->
+    <script>window.localStorage.debug = '*';</script>
+
     <script>
       window._trackJs = {
         token: '032448bc3d9e4cffb1e9b43d29d6c142',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -250,6 +250,11 @@
       "from": "cross-spawn-async@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz"
     },
+    "debug": {
+      "version": "2.6.0",
+      "from": "debug@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz"
+    },
     "decamelize": {
       "version": "1.2.0",
       "from": "decamelize@>=1.1.1 <2.0.0",
@@ -266,9 +271,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.8",
-      "from": "drivelist@5.0.8",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.8.tgz",
+      "version": "5.0.9",
+      "from": "drivelist@5.0.9",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.9.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -1222,6 +1227,11 @@
       "version": "1.3.0",
       "from": "moment-duration-format@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
+    },
+    "ms": {
+      "version": "0.7.2",
+      "from": "ms@0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.8",
+    "drivelist": "^5.0.9",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
This version doesn't throw an error if there is `stderr` output from the
scripts but the scripts exit with code zero.

Instead, the module prints the `stderr` output to a `debug` channel, so
we enable debug information by setting a `localStorage` value in order
to see what's going on.

Fixes: https://github.com/resin-io/etcher/issues/1034
Change-Type: patch
Changelog-Entry: Ignore `stderr` output from drive detection scripts if they exit with code zero.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>