### PR TITLE
fix(GUI): don't auto select system drives in unsafe mode

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -101,7 +101,12 @@ const storeReducer = (state, action) => {
 
         if (_.every([
           constraints.isDriveValid(drive, image),
-          constraints.isDriveSizeRecommended(drive, image)
+          constraints.isDriveSizeRecommended(drive, image),
+
+          // We don't want to auto-select system drives,
+          // even when "unsafe mode" is enabled
+          !constraints.isSystemDrive(drive)
+
         ])) {
           return storeReducer(newState, {
             type: ACTIONS.SELECT_DRIVE,

--- a/tests/gui/models/drives.spec.js
+++ b/tests/gui/models/drives.spec.js
@@ -248,6 +248,23 @@ describe('Browser: DrivesModel', function() {
             m.chai.expect(SelectionStateModel.hasDrive()).to.be.false;
           });
 
+          it('should not auto-select a single system drive', function() {
+            m.chai.expect(SelectionStateModel.hasDrive()).to.be.false;
+
+            DrivesModel.setDrives([
+              {
+                device: '/dev/sdb',
+                name: 'Foo',
+                size: 2000000000,
+                mountpoint: '/mnt/foo',
+                system: true,
+                protected: false
+              }
+            ]);
+
+            m.chai.expect(SelectionStateModel.hasDrive()).to.be.false;
+          });
+
         });
 
       });


### PR DESCRIPTION
Currently Etcher will auto-select a system drive if its the only
available one when the "unsafe mode" is enabled, which doesn't feel
right.

Change-Type: patch
Changelog-Entry: Don't auto select system drives in unsafe mode.
See: https://github.com/resin-io/etcher/pull/1061
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>