### PR TITLE
style(GUI): move update notifier checkbox inside modal body

### DIFF
--- a/lib/gui/components/update-notifier/styles/_update-notifier.scss
+++ b/lib/gui/components/update-notifier/styles/_update-notifier.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.modal-update-notifier .modal-footer .checkbox {
+.modal-update-notifier .checkbox {
   color: $palette-theme-light-soft-foreground;
   font-size: 11px;
   margin-bottom: 0;

--- a/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
+++ b/lib/gui/components/update-notifier/templates/update-notifier-modal.tpl.html
@@ -5,17 +5,8 @@
 
 <div class="modal-body">
   <p>Etcher {{ ::modal.options.version }} is available for download</p>
-</div>
 
-<div class="modal-footer">
-  <div class="modal-menu">
-    <button class="button button-primary"
-      os-open-external="https://etcher.io?ref=etcher_update">Download</button>
-    <button class="button button-default"
-      ng-click="modal.closeModal()">Skip</button>
-  </div>
-
-  <div class="checkbox text-right">
+  <div class="checkbox">
     <label>
       <input type="checkbox"
         ng-model="modal.sleepUpdateCheck"
@@ -25,3 +16,11 @@
   </div>
 </div>
 
+<div class="modal-footer">
+  <div class="modal-menu">
+    <button class="button button-primary button-block"
+      os-open-external="https://etcher.io?ref=etcher_update">Download</button>
+    <button class="button button-default button-block"
+      ng-click="modal.closeModal()">Skip</button>
+  </div>
+</div>

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6289,7 +6289,7 @@ body {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.modal-update-notifier .modal-footer .checkbox {
+.modal-update-notifier .checkbox {
   color: #b3b3b3;
   font-size: 11px;
   margin-bottom: 0; }


### PR DESCRIPTION
This is a small step towards unifying all the modal skeletons that we
use through the application.

By moving the checkbox to the modal body we can declare the footer and
the header once in a single place.

![screenshot 2017-01-31 15 58 56](https://cloud.githubusercontent.com/assets/2192773/22482257/88a38b0e-e7ce-11e6-95ea-cd9c7a9bbf55.png)

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>