### PR TITLE
refactor(GUI): remove component-drive-selector-body outdated class

### DIFF
--- a/lib/gui/components/drive-selector/styles/_drive-selector.scss
+++ b/lib/gui/components/drive-selector/styles/_drive-selector.scss
@@ -23,7 +23,7 @@
   cursor: not-allowed;
 }
 
-.component-drive-selector-body {
+.modal-drive-selector-modal {
 
   .list-group-item-footer {
     margin-top: 8px;

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -3,7 +3,7 @@
   <button class="close" ng-click="modal.closeModal()">&times;</button>
 </div>
 
-<div class="component-drive-selector-body modal-body">
+<div class="modal-body">
   <ul class="list-group">
     <li class="list-group-item" ng-repeat="drive in modal.drives.getDrives() track by drive.device"
       ng-disabled="!modal.constraints.isDriveValid(drive, modal.state.getImage())"

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6416,11 +6416,11 @@ body {
 .modal-drive-selector-modal .list-group-item[disabled] {
   cursor: not-allowed; }
 
-.component-drive-selector-body .list-group-item-footer {
+.modal-drive-selector-modal .list-group-item-footer {
   margin-top: 8px; }
 
-.component-drive-selector-body .list-group-item-heading,
-.component-drive-selector-body .list-group-item-text {
+.modal-drive-selector-modal .list-group-item-heading,
+.modal-drive-selector-modal .list-group-item-text {
   word-break: break-all; }
 
 /*


### PR DESCRIPTION
The rules inside this class should be moved to
`.modal-drive-selector-modal`.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>