### PR TITLE
chore: get rid of commitizen

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ you from accidentally writing to your hard-drives, ensures every byte of data
 was written correctly and much more.
 
 [![dependencies](https://david-dm.org/resin-io/etcher.svg)](https://david-dm.org/resin-io/etcher.svg)
-[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![Build Status](https://travis-ci.org/resin-io/etcher.svg?branch=master)](https://travis-ci.org/resin-io/etcher)
 [![Build status](https://ci.appveyor.com/api/projects/status/e745k1gt39nik0t7/branch/master?svg=true)](https://ci.appveyor.com/project/resin-io/etcher/branch/master)
 [![Gitter](https://badges.gitter.im/resin-io/etcher.svg)](https://gitter.im/resin-io/etcher?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,13 +76,6 @@ request.*
 Sending a pull request
 ----------------------
 
-We make use of [commitizen] to ensure certain commit conventions, since they
-will be used to auto-generate the CHANGELOG. The project already includes all
-necessary configuration, so you only have to install the commitizen cli tool
-(`npm install -g commitizen`) and commit by executing `git cz`, which will
-drive you through an interactive wizard to make sure your commit is perfectly
-crafted according to our guidelines.
-
 When sending a pull request, consider the following guidelines:
 
 - Write a concise commit message explaining your changes.
@@ -118,5 +111,4 @@ Don't hesitate to get in touch if you have any questions or need any help!
 [ARCHITECTURE]: https://github.com/resin-io/etcher/blob/master/docs/ARCHITECTURE.md
 [RUNNING-LOCALLY]: https://github.com/resin-io/etcher/blob/master/docs/RUNNING-LOCALLY.md
 [EditorConfig]: http://editorconfig.org
-[commitizen]: https://commitizen.github.io/cz-cli/#making-your-repo-commitizen-friendly
 [shrinkwrap]: https://docs.npmjs.com/cli/shrinkwrap

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   "devDependencies": {
     "angular-mocks": "^1.4.7",
     "browserify": "^13.0.1",
-    "cz-conventional-changelog": "^1.1.6",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^3.1.1",
     "electron-packager": "^7.0.1",
@@ -116,10 +115,5 @@
     "node-sass": "^3.8.0",
     "tmp": "0.0.31",
     "versionist": "^2.1.0"
-  },
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
   }
 }


### PR DESCRIPTION
No one on the team is using this and the adaptor we're using proved to
be suboptimal. We might consider this again once we develop a good
Commitizen adapter integrated more closely with Versionist.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>