### PR TITLE
docs: add msys-zip as a required Windows dependency

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -29,6 +29,7 @@ The following MinGW packages are required:
 
 - `msys-make`
 - `msys-unzip`
+- `msys-zip`
 - `msys-wget`
 - `msys-bash`
 - `msys-coreutils`


### PR DESCRIPTION
We need this dependency to create ZIP packages on Windows.