### PR TITLE
chore: start codespell dictionary file in the root of the project

### DIFF
--- a/dictionary
+++ b/dictionary
@@ -1,0 +1,1 @@
+boolen->boolean

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jslint": "eslint lib tests scripts bin versionist.conf.js",
     "scsslint": "scss-lint lib/gui/scss",
     "htmllint": "node scripts/html-lint.js",
-    "codespell": "codespell.py lib tests",
+    "codespell": "codespell.py --dictionary=- --dictionary=dictionary lib tests",
     "lint": "npm run jslint && npm run scsslint && npm run codespell && npm run htmllint",
     "changelog": "versionist",
     "start": "electron lib/start.js",


### PR DESCRIPTION
codespell works by having a dictionary of pairs of malformed words and
their correct equivalents. This means that codespell will not catch most
issues out of the box, but we can train it based on the common spelling
issues we encounter along the way.

The plan is to add a pair to `dictionary` every time we encounter a typo
during a code review, and we ensure that error will not happen again
anymore.

See: https://github.com/resin-io/etcher/pull/1084
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>