### PR TITLE
upgrade: `drivelist` to v5.0.10

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -271,9 +271,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.9",
-      "from": "drivelist@5.0.9",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.9.tgz",
+      "version": "5.0.10",
+      "from": "drivelist@5.0.10",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.10.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.9",
+    "drivelist": "^5.0.10",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
This version contains a fix to omit drive letters assigned to partitions
without a valid file system (read "valid for Windows"), causing our
unmounting routine to fail in these cases.

Change-Type: patch
Changelog-Entry: Fix "Error: Command Failed" error when unmounting on Windows.
Fixes: https://github.com/resin-io/etcher/issues/1019
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>