### PR TITLE
chore: update `angular-ui-router` in `npm-shrinkwrap.json`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,9 +13,9 @@
       "resolved": "https://registry.npmjs.org/angular-if-state/-/angular-if-state-1.0.0.tgz",
       "dependencies": {
         "angular-ui-router": {
-          "version": "0.4.2",
-          "from": "angular-ui-router@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.2.tgz"
+          "version": "0.3.2",
+          "from": "angular-ui-router@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.3.2.tgz"
         }
       }
     },


### PR DESCRIPTION
Looks like this dependency was not updated correctly on the shrinkwrap
file. Probably happened in the linked pull request, where the shrinkwrap
file was hand edited at some point (see PR discussion).

See: https://github.com/resin-io/etcher/pull/1083
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>