### PR TITLE
docs: C++ are not auto-selected by Visual Studio anymore 

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -23,6 +23,9 @@ Prerequisites
 - [Rimraf](https://github.com/isaacs/rimraf)
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
 - [Visual Studio Community 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48146) (free) (other editions, like Professional and Enterprise, should work too)
+  - Visual Studio 2015 doesn't install C++ by default. You have to rerun the
+    setup, select Modify and then check `Visual C++ -> Common Tools for Visual
+    C++ 2015` (see http://stackoverflow.com/a/31955339)
 - [MinGW](http://www.mingw.org)
 
 The following MinGW packages are required:


### PR DESCRIPTION
Its not possible to build Etcher without it. For some reason, the Visual
Studio Community 2015 installer is not ticking it by default anymore..

See: https://github.com/resin-io/etcher/pull/1110
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>