### PR TITLE
upgrade: `drivelist` to v5.0.11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -271,9 +271,8 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.10",
-      "from": "drivelist@5.0.10",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.10.tgz",
+      "version": "5.0.11",
+      "from": "drivelist@5.0.11",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.10",
+    "drivelist": "^5.0.11",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
Change-Type: patch
Changelog-Entry: Omit empty SD Card readers in the drive selector on Windows.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>