### PR TITLE
chore: ensure `npm run sass` was ran and the results committed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,10 @@ install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       npm test;
+      ./scripts/ci/ensure-staged-sass.sh;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "xvfb-run --server-args=$XVFB_ARGS npm test";
+      ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "xvfb-run --server-args=$XVFB_ARGS npm test && ./scripts/ci/ensure-staged-sass.sh";
     fi
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ build: off
 test_script:
   - node --version
   - npm --version
+  - bash .\scripts\ci\ensure-staged-sass.sh
   - cmd: npm test
 
 notifications:

--- a/scripts/ci/ensure-staged-sass.sh
+++ b/scripts/ci/ensure-staged-sass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -u
+
+npm run sass
+
+# From http://stackoverflow.com/a/9393642/1641422
+if [[ -n $(git status -s) ]]; then
+  echo "There are unstaged sass changes. Please commit the result of:" 1>&2
+  echo ""
+  echo "    npm run sass" 1>&2
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
We recently encountered a UI regression caused by forgetting to commit
the generated CSS files.

The solution is to make the CI servers run `npm run sass` and check if
there are unstaged files afterwards. If so, the tests halt.

In order to avoid duplication between Travis CI and Appveyor CI, this
logic has been encoded into a bash script at `scripts/ci`.

See: https://github.com/resin-io/etcher/pull/1120
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>