### PR TITLE
fix(GUI): update notifier transformRequest error at startup

### DIFF
--- a/lib/gui/components/update-notifier/services/update-notifier.js
+++ b/lib/gui/components/update-notifier/services/update-notifier.js
@@ -23,6 +23,14 @@ const etcherLatestVersion = require('etcher-latest-version');
 module.exports = function($http, $q, ModalService, UPDATE_NOTIFIER_SLEEP_TIME, ManifestBindService, SettingsModel) {
 
   /**
+   * @summary The current application version
+   * @constant
+   * @private
+   * @type {String}
+   */
+  const CURRENT_VERSION = ManifestBindService.get('version');
+
+  /**
    * @summary Get the latest available Etcher version
    * @function
    * @private
@@ -48,6 +56,14 @@ module.exports = function($http, $q, ModalService, UPDATE_NOTIFIER_SLEEP_TIME, M
         });
       }, (error, latestVersion) => {
         if (error) {
+
+          // The error status equals -1 if the request couldn't
+          // be made successfully, for example, because of a
+          // timeout on an unstable network connection.
+          if (error.status === -1) {
+            return resolve(CURRENT_VERSION);
+          }
+
           return reject(error);
         }
 
@@ -75,7 +91,7 @@ module.exports = function($http, $q, ModalService, UPDATE_NOTIFIER_SLEEP_TIME, M
    */
   this.isLatestVersion = () => {
     return this.getLatestVersion().then((version) => {
-      return semver.gte(ManifestBindService.get('version'), version);
+      return semver.gte(CURRENT_VERSION, version);
     });
   };
 


### PR DESCRIPTION
Etcher checks what is the latest version by making an HTTP request to S3
in order to see if it should present the update notifier modal at
startup.

If the user is not connected to the internet, or is on an unstable
connection, the request might fail completely or timeout, leading to a
weird error message being presented to the user:

```json
{
  "data": null,
  "status": -1,
  "config": {
    "method": "GET",
    "transformRequest": [null],
    "transformResponse": [null],
    "url": "https://resin-production-downloads.s3.amazonaws.com",
    "headers": {
      "Accept": "application/json, text/plain, */*"
    }
  },
  "statusText": ""
}
```

To solve the error, we tweak `UpdateNotifierService.getLatestVersion()`
to resolve the current version if there was a problem making the request
(e.g: the response didn't come through at all), which after some
experimentation, we can check by comparing the `status` property with
`-1`.

This error happens in all operating systems, and currently is trending
on TrackJS.

Change-Type: patch
Changelog-Entry: Fix `transformRequest` error at startup when not connected to the internet, or when on an unstable connection.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>