### PR TITLE
upgrade: `drivelist` to v5.0.13

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -271,8 +271,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.11",
-      "from": "drivelist@5.0.11",
+      "version": "5.0.13",
+      "from": "drivelist@5.0.13",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.13.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.11",
+    "drivelist": "^5.0.13",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
This version fixes an `EACCES` issue when spawning the platform scripts
in OS X and GNU/Linux, which caused because previous versions were
published to NPM from Windows, and Windows seems to mess up the file
permissions (the execution bit in this particular case).

I'm not adding a changelog entry given this issue happen on `master` and
didn't affect any release.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>