### PR TITLE
chore: don't install `electron-installer-debian` in OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       pip install codespell;
       gem install scss_lint;
-      npm install -g bower electron-installer-debian;
-      npm install -g electron-installer-debian;
+      npm install -g bower;
       brew install afsctool;
       brew install jq;
     fi


### PR DESCRIPTION
The `electron-installer-debian` is not needed for OS X builds. On top of
that, it seems that we're installing it twice.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>