### PR TITLE
upgrade: `drivelist` to v5.0.14

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -271,9 +271,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.13",
-      "from": "drivelist@5.0.13",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.13.tgz",
+      "version": "5.0.14",
+      "from": "drivelist@5.0.14",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.14.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.13",
+    "drivelist": "^5.0.14",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
See: https://github.com/resin-io-modules/drivelist/pull/146
Change-Type: patch
Changelog-Entry: Don't ignore errors coming from the Windows drive detection script.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>