### PR TITLE
chore: don't use symbolic links on Windows builds

### DIFF
--- a/scripts/build/dependencies-bower.sh
+++ b/scripts/build/dependencies-bower.sh
@@ -49,7 +49,7 @@ if [ "$ARGV_PRODUCTION" == "true" ]; then
 fi
 
 if [ -n "$ARGV_PREFIX" ]; then
-  ln -s "$PWD/bower.json" "$ARGV_PREFIX/bower.json"
+  cp "$PWD/bower.json" "$ARGV_PREFIX/bower.json"
   pushd "$ARGV_PREFIX"
   bower install $INSTALL_OPTS
   popd

--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -99,10 +99,10 @@ if [ "$ARGV_PRODUCTION" == "true" ]; then
 fi
 
 if [ -n "$ARGV_PREFIX" ]; then
-  ln -s "$PWD/package.json" "$ARGV_PREFIX/package.json"
+  cp "$PWD/package.json" "$ARGV_PREFIX/package.json"
 
   if [ -f "$PWD/npm-shrinkwrap.json" ]; then
-    ln -s "$PWD/npm-shrinkwrap.json" "$ARGV_PREFIX/npm-shrinkwrap.json"
+    cp "$PWD/npm-shrinkwrap.json" "$ARGV_PREFIX/npm-shrinkwrap.json"
   fi
 
   pushd "$ARGV_PREFIX"


### PR DESCRIPTION
Cygwin can't resolve them correctly, causing cryptic errors during
build.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>