### PR TITLE
chore: add missing `:` after options in publish scripts 

### DIFF
--- a/scripts/publish/aws-s3.sh
+++ b/scripts/publish/aws-s3.sh
@@ -39,7 +39,7 @@ ARGV_BUCKET=""
 ARGV_VERSION=""
 ARGV_PRODUCT_NAME=""
 
-while getopts ":f:b:v:p" option; do
+while getopts ":f:b:v:p:" option; do
   case $option in
     f) ARGV_FILE="$OPTARG" ;;
     b) ARGV_BUCKET="$OPTARG" ;;

--- a/scripts/publish/bintray-debian.sh
+++ b/scripts/publish/bintray-debian.sh
@@ -41,7 +41,7 @@ ARGV_ARCHITECTURE=""
 ARGV_COMPONENT_NAME=""
 ARGV_RELEASE_TYPE=""
 
-while getopts ":f:v:r:c:t" option; do
+while getopts ":f:v:r:c:t:" option; do
   case $option in
     f) ARGV_FILE="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;


### PR DESCRIPTION
Not including the colon means that the option parsing mechanism is not
expecting an argument for the `-t` and the `-p` option (for
`bintray-debian.sh` and `aws-s3.sh` respectively), and thus `$OPTARG`
will be undefined.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>