### PR TITLE
chore: fix various code-signing Windows issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,8 @@ ifeq ($(TARGET_PLATFORM),win32)
 		-o $@
 ifdef CODE_SIGN_CERTIFICATE
 ifdef CODE_SIGN_CERTIFICATE_PASSWORD
-	./scripts/build/electron-sign-exe.sh -f $@/$(APPLICATION_NAME).exe \
-		-d "$(APPLICATION_NAME) - $(APPLICATION_VERSION)"
+	./scripts/build/electron-sign-exe-win32.sh -f $@/$(APPLICATION_NAME).exe \
+		-d "$(APPLICATION_NAME) - $(APPLICATION_VERSION)" \
 		-c $(CODE_SIGN_CERTIFICATE) \
 		-p $(CODE_SIGN_CERTIFICATE_PASSWORD)
 endif
@@ -316,8 +316,8 @@ $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-win32-$(TAR
 	./scripts/build/electron-installer-nsis-win32.sh -n $(APPLICATION_NAME) -a $< -t $(BUILD_TEMPORARY_DIRECTORY) -o $@
 ifdef CODE_SIGN_CERTIFICATE
 ifdef CODE_SIGN_CERTIFICATE_PASSWORD
-	./scripts/build/electron-sign-exe.sh -f $@ \
-		-d "$(APPLICATION_NAME) - $(APPLICATION_VERSION)"
+	./scripts/build/electron-sign-exe-win32.sh -f $@ \
+		-d "$(APPLICATION_NAME) - $(APPLICATION_VERSION)" \
 		-c $(CODE_SIGN_CERTIFICATE) \
 		-p $(CODE_SIGN_CERTIFICATE_PASSWORD)
 endif

--- a/scripts/build/electron-sign-exe-win32.sh
+++ b/scripts/build/electron-sign-exe-win32.sh
@@ -65,10 +65,10 @@ fi
 TIMESTAMP_SERVER=http://timestamp.comodoca.com
 
 signtool sign \
-  /t "$TIMESTAMP_SERVER" \
-  /d "$ARGV_SIGNATURE_DESCRIPTION" \
-  /f "$ARGV_CERTIFICATE_FILE" \
-  /p "$ARGV_CERTIFICATE_PASSWORD" \
+  -t "$TIMESTAMP_SERVER" \
+  -d "$ARGV_SIGNATURE_DESCRIPTION" \
+  -f "$ARGV_CERTIFICATE_FILE" \
+  -p "$ARGV_CERTIFICATE_PASSWORD" \
   "$ARGV_FILE"
 
-signtool verify /pa /v "$ARGV_FILE"
+signtool verify -pa -v "$ARGV_FILE"


### PR DESCRIPTION
- Add missing backslash that caused the command to not be interpreted
  completely

- Update `electron-sign-exe.exe` to `electron-sign-exe-win32.exe` in
  Makefile

- Use hyphen options instead of Windows slash style, which confuses bash

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>