### PR TITLE
chore: add missing `:` after `p` option in aws-s3.sh

### DIFF
--- a/scripts/publish/aws-s3.sh
+++ b/scripts/publish/aws-s3.sh
@@ -39,7 +39,7 @@ ARGV_BUCKET=""
 ARGV_VERSION=""
 ARGV_PRODUCT_NAME=""
 
-while getopts ":f:b:v:p" option; do
+while getopts ":f:b:v:p:" option; do
   case $option in
     f) ARGV_FILE="$OPTARG" ;;
     b) ARGV_BUCKET="$OPTARG" ;;


### PR DESCRIPTION
Not including the colon means that the option parsing mechanism is not
expecting an argument for the `-p` option, and thus `$OPTARG` will be
undefined.

See: https://github.com/resin-io/etcher/pull/1134
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>