### PR TITLE
chore: define `S3_BUCKET` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ APPLICATION_COPYRIGHT = $(shell jq -r '.copyright' package.json)
 APPLICATION_CATEGORY = public.app-category.developer-tools
 APPLICATION_BUNDLE_ID = io.resin.etcher
 APPLICATION_FILES = lib,assets
+S3_BUCKET = resin-production-downloads
 
 # Add the current commit to the version if release type is "snapshot"
 RELEASE_TYPE ?= snapshot


### PR DESCRIPTION
We use that variable in the Makefile but we're not defining it, which
means that maintainers publishing Etcher need to remember to pass that
as an option.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>