### PR TITLE
style(GUI): fix small chain indentation issue

### DIFF
--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -108,8 +108,8 @@ return isElevated().then((elevated) => {
         });
 
         return commandPrefix
-        .concat([ process.env.APPIMAGE ])
-        .concat(translatedArguments);
+          .concat([ process.env.APPIMAGE ])
+          .concat(translatedArguments);
       }
 
       return commandPrefix.concat(process.argv);


### PR DESCRIPTION
I couldn't find an ESLint rule that would protect us from this in the
future.

See: https://github.com/resin-io/etcher/pull/1148#discussion_r103525165
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>