### PR TITLE
chore: fix JSDoc warnings

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -26,7 +26,7 @@ const packageJSON = require('../../package.json');
 
 /**
  * @summary Parsed CLI options and arguments
- * @type Object
+ * @type {Object}
  * @public
  */
 module.exports = yargs

--- a/lib/cli/unmount.js
+++ b/lib/cli/unmount.js
@@ -24,7 +24,6 @@ const os = require('os');
 /**
  * @summary Unmount command templates
  * @namespace COMMAND_TEMPLATES
- * @private
  *
  * We make sure that the commands declared here exit
  * successfully even if the drive is not mounted.
@@ -34,12 +33,14 @@ const COMMAND_TEMPLATES = {
   /**
    * @property {String} darwin
    * @memberof COMMAND_TEMPLATES
+   * @private
    */
   darwin: '/usr/sbin/diskutil unmountDisk force <%= device %>',
 
   /**
    * @property {String} linux
    * @memberof COMMAND_TEMPLATES
+   * @private
    *
    * @description
    * If trying to unmount the raw device in Linux, we get:

--- a/lib/gui/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/components/drive-selector/controllers/drive-selector.js
@@ -29,22 +29,22 @@ module.exports = function(
 
   /**
    * @summary The drive selector state
-   * @property
-   * @type Object
+   * @type {Object}
+   * @public
    */
   this.state = SelectionStateModel;
 
   /**
    * @summary Static methods to check a drive's properties
-   * @property
-   * @type Object
+   * @type {Object}
+   * @public
    */
   this.constraints = DriveConstraintsModel;
 
   /**
    * @summary The drives model
-   * @property
-   * @type Object
+   * @type {Object}
+   * @public
    *
    * @description
    * We expose the whole service instead of the `.drives`

--- a/lib/gui/components/tooltip-modal/controllers/tooltip-modal.js
+++ b/lib/gui/components/tooltip-modal/controllers/tooltip-modal.js
@@ -20,7 +20,7 @@ module.exports = function($uibModalInstance, tooltipData) {
 
   /**
    * @summary Tooltip data
-   * @property
+   * @type {Object}
    * @public
    */
   this.data = tooltipData;

--- a/lib/gui/components/update-notifier/controllers/update-notifier.js
+++ b/lib/gui/components/update-notifier/controllers/update-notifier.js
@@ -27,14 +27,14 @@ module.exports = function($uibModalInstance, SettingsModel, options) {
 
   /**
    * @summary Settings model
-   * @type Object
+   * @type {Object}
    * @public
    */
   this.settings = SettingsModel;
 
   /**
    * @summary Modal options
-   * @type Object
+   * @type {Object}
    * @public
    */
   this.options = options;

--- a/lib/gui/components/warning-modal/controllers/warning-modal.js
+++ b/lib/gui/components/warning-modal/controllers/warning-modal.js
@@ -20,7 +20,7 @@ module.exports = function($uibModalInstance, options) {
 
   /**
    * @summary Modal options
-   * @property
+   * @type {Object}
    * @public
    */
   this.options = options;

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -24,7 +24,7 @@ const constraints = require('../../shared/drive-constraints');
 
 /**
  * @summary Application default state
- * @type Object
+ * @type {Object}
  * @constant
  * @private
  */
@@ -49,7 +49,7 @@ const DEFAULT_STATE = Immutable.fromJS({
 
 /**
  * @summary State path to be persisted
- * @type String
+ * @type {Object}
  * @constant
  * @private
  */
@@ -57,7 +57,7 @@ const PERSISTED_PATH = 'settings';
 
 /**
  * @summary Application supported action messages
- * @type Object
+ * @type {Object}
  * @constant
  */
 const ACTIONS = _.fromPairs(_.map([

--- a/lib/gui/os/dialog/dialog.js
+++ b/lib/gui/os/dialog/dialog.js
@@ -17,10 +17,10 @@
 'use strict';
 
 /**
- * @module Etcher.OS.Dialog
- *
  * The purpose of this module is to provide an easy way
  * to interact with OS dialogs.
+ *
+ * @module Etcher.OS.Dialog
  */
 
 const angular = require('angular');

--- a/lib/gui/os/notification/notification.js
+++ b/lib/gui/os/notification/notification.js
@@ -17,10 +17,10 @@
 'use strict';
 
 /**
- * @module Etcher.OS.Notification
- *
  * The purpose of this module is to provide an easy way
  * to send desktop notifications.
+ *
+ * @module Etcher.OS.Notification
  */
 
 const angular = require('angular');

--- a/lib/gui/os/window-progress/services/window-progress.js
+++ b/lib/gui/os/window-progress/services/window-progress.js
@@ -22,7 +22,7 @@ module.exports = function() {
 
   /**
    * @summary A reference to the current renderer Electron window
-   * @property
+   * @type {Object}
    * @protected
    *
    * @description

--- a/lib/gui/os/window-progress/window-progress.js
+++ b/lib/gui/os/window-progress/window-progress.js
@@ -17,11 +17,11 @@
 'use strict';
 
 /**
- * @module Etcher.OS.WindowProgress
- *
  * The purpose of this module is to provide an easy way
  * to interact with the operating system's window progress
  * functionality, as described in Electron docs.
+ *
+ * @module Etcher.OS.WindowProgress
  */
 
 const angular = require('angular');

--- a/lib/gui/pages/finish/controllers/finish.js
+++ b/lib/gui/pages/finish/controllers/finish.js
@@ -20,14 +20,14 @@ module.exports = function($state, FlashStateModel, SelectionStateModel, Analytic
 
   /**
    * @summary Settings model
-   * @type Object
+   * @type {Object}
    * @public
    */
   this.settings = SettingsModel;
 
   /**
    * @summary Source checksum
-   * @type String
+   * @type {String}
    * @public
    */
   this.checksum = FlashStateModel.getLastFlashSourceChecksum();

--- a/lib/gui/pages/finish/finish.js
+++ b/lib/gui/pages/finish/finish.js
@@ -17,13 +17,13 @@
 'use strict';
 
 /**
- * @module Etcher.Pages.Finish
- *
  * The finish page represents the application state where
  * the the flash/validation has completed.
  *
  * Its purpose is to display success or failure information,
  * as well as the "next steps".
+ *
+ * @module Etcher.Pages.Finish
  */
 
 const angular = require('angular');

--- a/lib/gui/pages/main/main.js
+++ b/lib/gui/pages/main/main.js
@@ -17,9 +17,9 @@
 'use strict';
 
 /**
- * @module Etcher.Pages.Main
+ * This page represents the application main page.
  *
- * The finish page represents the application main page.
+ * @module Etcher.Pages.Main
  */
 
 const angular = require('angular');

--- a/lib/gui/pages/settings/controllers/settings.js
+++ b/lib/gui/pages/settings/controllers/settings.js
@@ -22,7 +22,7 @@ module.exports = function(WarningModalService, SettingsModel) {
 
   /**
    * @summary Client platform
-   * @type String
+   * @type {String}
    * @constant
    * @public
    */
@@ -39,7 +39,7 @@ module.exports = function(WarningModalService, SettingsModel) {
 
   /**
    * @summary Current settings value
-   * @type Object
+   * @type {Object}
    * @public
    */
   this.currentData = {};
@@ -47,7 +47,7 @@ module.exports = function(WarningModalService, SettingsModel) {
 
   /**
    * @summary Settings model
-   * @type Object
+   * @type {Object}
    * @public
    */
   this.model = SettingsModel;

--- a/lib/gui/utils/byte-size/byte-size.js
+++ b/lib/gui/utils/byte-size/byte-size.js
@@ -17,10 +17,10 @@
 'use strict';
 
 /**
- * @module Etcher.Utils.ByteSize
- *
  * The purpose of this module is to provide utilities
  * to work with sizes in bytes.
+ *
+ * @module Etcher.Utils.ByteSize
  */
 
 const angular = require('angular');

--- a/lib/gui/utils/manifest-bind/manifest-bind.js
+++ b/lib/gui/utils/manifest-bind/manifest-bind.js
@@ -17,11 +17,11 @@
 'use strict';
 
 /**
- * @module Etcher.Utils.ManifestBind
- *
  * The purpose of this module is to provide an attribute
  * directive to bind the current element to a property
  * in the application's `package.json` manifest.
+ *
+ * @module Etcher.Utils.ManifestBind
  */
 
 const angular = require('angular');

--- a/lib/gui/utils/path/path.js
+++ b/lib/gui/utils/path/path.js
@@ -17,10 +17,10 @@
 'use strict';
 
 /**
- * @module Etcher.Utils.Path
- *
  * The purpose of this module is to provide utilities
  * to work with file paths.
+ *
+ * @module Etcher.Utils.Path
  */
 
 const angular = require('angular');


### PR DESCRIPTION
- The type in `@type` should be surrounded by curly braces
- We should use `@type` in some cases where we used `@property`
- `@module` descriptions should go above such tag
- Namespaces should not declare their access type

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>