### PR TITLE
upgrade `drivelist` to v5.0.15

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -271,9 +271,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.14",
-      "from": "drivelist@5.0.14",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.14.tgz",
+      "version": "5.0.15",
+      "from": "drivelist@5.0.15",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.15.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.14",
+    "drivelist": "^5.0.15",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.0",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
We're mainly interested in the following change:

- https://github.com/resin-io-modules/drivelist/pull/148

Fixes: https://github.com/resin-io/etcher/issues/1126
Change-Type: patch
Changelog-Entry: Fix errors when unplugging drives exactly when the drive scanning scripts are running.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>