### PR TITLE
upgrade: `drivelist` to v5.0.16

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -254,9 +254,9 @@
       "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
     },
     "drivelist": {
-      "version": "5.0.15",
-      "from": "drivelist@5.0.15",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.15.tgz",
+      "version": "5.0.16",
+      "from": "drivelist@5.0.16",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.16.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bluebird": "^3.0.5",
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
-    "drivelist": "^5.0.15",
+    "drivelist": "^5.0.16",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.0.1",
     "etcher-latest-version": "^1.0.0",


### PR DESCRIPTION
See: https://github.com/resin-io-modules/drivelist/pull/150
Fixes: https://github.com/resin-io/etcher/issues/1159
Change-Type: patch
Changelog-Entry: Fix GNU/Linux udev error when `net.ifnames` is set.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>