### PR TITLE
WIP: chore: chocolatey nupkg support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ BUILD_OUTPUT_DIRECTORY = $(BUILD_DIRECTORY)/out
 
 ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron-prebuilt"]' package.json)
 COMPANY_NAME = $(shell jq -r '.companyName' package.json)
+AUTHOR = resin.io
 APPLICATION_NAME = $(shell jq -r '.displayName' package.json)
+APPLICATION_ID = $(shell jq -r '.name' package.json)
 APPLICATION_DESCRIPTION = $(shell jq -r '.description' package.json)
 APPLICATION_COPYRIGHT = $(shell jq -r '.copyright' package.json)
 APPLICATION_CATEGORY = public.app-category.developer-tools
@@ -150,6 +152,7 @@ endif
 
 APPLICATION_NAME_LOWERCASE = $(shell echo $(APPLICATION_NAME) | tr A-Z a-z)
 APPLICATION_VERSION_DEBIAN = $(shell echo $(APPLICATION_VERSION) | tr "-" "~")
+APPLICATION_VERSION_NUGET = $(shell echo $(APPLICATION_VERSION) | sed 's/[.+]/-/g3')
 
 # ---------------------------------------------------------------------
 # Rules
@@ -295,6 +298,39 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-linux-$(TARGET_ARC
 		-r "$(TARGET_ARCH)" \
 		-w "$(BUILD_TEMPORARY_DIRECTORY)"
 
+$(BUILD_DIRECTORY)/$(APPLICATION_NAME).nuspec: | $(BUILD_DIRECTORY)
+	./scripts/build/electron-create-nuspec.sh \
+		-n $(APPLICATION_NAME) \
+		-x $(APPLICATION_ID) \
+		-s "$(APPLICATION_DESCRIPTION)" \
+		-d "$(APPLICATION_DESCRIPTION)" \
+		-v $(APPLICATION_VERSION_NUGET) \
+		-a $(AUTHOR) \
+		-i https://github.com/resin-io/etcher/raw/master/assets/icon.png \
+		-l https://raw.githubusercontent.com/resin-io/etcher/master/LICENSE \
+		-u https://etcher.io \
+		-b https://github.com/resin-io/etcher/issues \
+		-c https://github.com/resin-io/etcher/tree/master/docs \
+		-o $@
+
+$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-chocolateyInstall.ps1: | $(BUILD_DIRECTORY)
+	./scripts/build/electron-create-chocolatey-install.sh \
+		-i $(APPLICATION_ID) \
+		-u https://resin-production-downloads.s3.amazonaws.com/etcher/1.0.0-beta.19/Etcher-1.0.0-beta.19-win32-x64.exe,https://resin-production-downloads.s3.amazonaws.com/etcher/1.0.0-beta.19/Etcher-1.0.0-beta.19-win32-x86.exe \
+		-c 7d9f6f266986cfd4ec6f0b6f8da1c52f90569d25c0694859867a097273398933,589e34a90e6e2b2179ff54bb1e35f5a32d5ad6c643b10af73cadd5ec9d81a5ea \
+		-t sha256 \
+		-o $@
+
+$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION_NUGET)-nupkg: \
+	$(BUILD_DIRECTORY)/$(APPLICATION_NAME).nuspec \
+	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-chocolateyInstall.ps1 \
+	| $(BUILD_DIRECTORY)
+	./scripts/build/electron-create-nupkg-directory.sh \
+		-i $(APPLICATION_ID) \
+		-n $< \
+		-s $(word 2,$^) \
+		-o $@
+
 $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-linux-$(TARGET_ARCH).zip: \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-linux-$(TARGET_ARCH).AppImage \
 	| $(BUILD_OUTPUT_DIRECTORY)
@@ -323,6 +359,16 @@ ifdef CODE_SIGN_CERTIFICATE_PASSWORD
 		-p $(CODE_SIGN_CERTIFICATE_PASSWORD)
 endif
 endif
+
+$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_ID).$(APPLICATION_VERSION_NUGET).nupkg: \
+	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION_NUGET)-nupkg \
+	| $(BUILD_OUTPUT_DIRECTORY) $(BUILD_TEMPORARY_DIRECTORY)
+	./scripts/build/electron-installer-nupkg-multiarch-win32.sh \
+		-i $(APPLICATION_ID) \
+		-v $(APPLICATION_VERSION_NUGET) \
+		-d $< \
+		-t $(BUILD_TEMPORARY_DIRECTORY) \
+		-o $@
 
 # ---------------------------------------------------------------------
 # Phony targets
@@ -364,9 +410,11 @@ endif
 ifeq ($(TARGET_PLATFORM),win32)
 electron-installer-zip: $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH).zip
 electron-installer-nsis: $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-win32-$(TARGET_ARCH).exe
+electron-installer-nupkg: $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_ID).$(APPLICATION_VERSION_NUGET).nupkg
 TARGETS += \
 	electron-installer-zip \
-	electron-installer-nsis
+	electron-installer-nsis \
+	electron-installer-nupkg
 PUBLISH_AWS_S3 += \
 	$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH).zip \
 	$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-win32-$(TARGET_ARCH).exe

--- a/scripts/build/electron-create-chocolatey-install.sh
+++ b/scripts/build/electron-create-chocolatey-install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -i <application id>"
+  echo "    -u <application urls (comma separated) (x64,x86)>"
+  echo "    -c <application checksums (comma separated) (x64,x86)>"
+  echo "    -t <checksum type>"
+  echo "    -o <output>"
+  exit 1
+}
+
+ARGV_ID=""
+ARGV_URLS=""
+ARGV_CHECKSUMS=""
+ARGV_CHECKSUM_TYPE=""
+ARGV_OUTPUT=""
+
+while getopts ":i:u:c:t:o:" option; do
+  case $option in
+    i) ARGV_ID="$OPTARG" ;;
+    u) ARGV_URLS="$OPTARG" ;;
+    c) ARGV_CHECKSUMS="$OPTARG" ;;
+    t) ARGV_CHECKSUM_TYPE="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_ID" ] ||
+   [ -z "$ARGV_URLS" ] ||
+   [ -z "$ARGV_CHECKSUMS" ] ||
+   [ -z "$ARGV_CHECKSUM_TYPE" ] ||
+   [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+IFS=',' read -a URLS <<< "$ARGV_URLS"
+IFS=',' read -a CHECKSUMS <<< "$ARGV_CHECKSUMS"
+
+URL_X64="${URLS[0]}"
+URL_X86="${URLS[1]}"
+CHECKSUM_X64="${CHECKSUMS[0]}"
+CHECKSUM_X86="${CHECKSUMS[1]}"
+
+cat << EOF > "$ARGV_OUTPUT"
+\$ErrorActionPreference = 'Stop';
+\$packageArgs = @{
+    packageName = '$ARGV_ID'
+    fileType = 'exe'
+    url = '$URL_X86'
+    url64 = '$URL_X64'
+    silentArgs = "/S"
+    checksum = '$CHECKSUM_X86'
+    checksum64 = '$CHECKSUM_X64'
+    checksumType = '$ARGV_CHECKSUM_TYPE'
+}
+
+Install-ChocolateyPackage @packageArgs
+EOF

--- a/scripts/build/electron-create-nupkg-directory.sh
+++ b/scripts/build/electron-create-nupkg-directory.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -i <application id>"
+  echo "    -n <nuspec manifest>"
+  echo "    -s <install script (.ps1)>"
+  echo "    -o <output>"
+  exit 1
+}
+
+ARGV_ID=""
+ARGV_NUSPEC=""
+ARGV_INSTALL_SCRIPT=""
+ARGV_OUTPUT=""
+
+while getopts ":i:n:s:o:" option; do
+  case $option in
+    i) ARGV_ID="$OPTARG" ;;
+    n) ARGV_NUSPEC="$OPTARG" ;;
+    s) ARGV_INSTALL_SCRIPT="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_ID" ] ||
+   [ -z "$ARGV_NUSPEC" ] ||
+   [ -z "$ARGV_INSTALL_SCRIPT" ] ||
+   [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+mkdir "$ARGV_OUTPUT"
+cp "$ARGV_NUSPEC" "$ARGV_OUTPUT/$ARGV_ID.nuspec"
+mkdir "$ARGV_OUTPUT/tools"
+cp "$ARGV_INSTALL_SCRIPT" "$ARGV_OUTPUT/tools/chocolateyInstall.ps1"

--- a/scripts/build/electron-create-nuspec.sh
+++ b/scripts/build/electron-create-nuspec.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -n <application name>"
+  echo "    -x <application id>"
+  echo "    -s <application summary>"
+  echo "    -d <application description>"
+  echo "    -v <application version>"
+  echo "    -a <application author>"
+  echo "    -i <application icon url (.png)>"
+  echo "    -l <license file url>"
+  echo "    -u <project url>"
+  echo "    -b <bug tracker url>"
+  echo "    -c <docs url>"
+  echo "    -t <temporary directory>"
+  echo "    -o <output>"
+  exit 1
+}
+
+ARGV_NAME=""
+ARGV_ID=""
+ARGV_SUMMARY=""
+ARGV_DESCRIPTION=""
+ARGV_VERSION=""
+ARGV_AUTHOR=""
+ARGV_ICON_URL=""
+ARGV_LICENSE_URL=""
+ARGV_URL=""
+ARGV_BUG_TRACKER_URL=""
+ARGV_DOCS_URL=""
+ARGV_OUTPUT=""
+
+while getopts ":n:x:s:d:v:a:i:l:u:b:c:o:" option; do
+  case $option in
+    n) ARGV_NAME="$OPTARG" ;;
+    x) ARGV_ID="$OPTARG" ;;
+    s) ARGV_SUMMARY="$OPTARG" ;;
+    d) ARGV_DESCRIPTION="$OPTARG" ;;
+    v) ARGV_VERSION="$OPTARG" ;;
+    a) ARGV_AUTHOR="$OPTARG" ;;
+    i) ARGV_ICON_URL="$OPTARG" ;;
+    l) ARGV_LICENSE_URL="$OPTARG" ;;
+    u) ARGV_URL="$OPTARG" ;;
+    b) ARGV_BUG_TRACKER_URL="$OPTARG" ;;
+    c) ARGV_DOCS_URL="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_NAME" ] ||
+   [ -z "$ARGV_ID" ] ||
+   [ -z "$ARGV_SUMMARY" ] ||
+   [ -z "$ARGV_DESCRIPTION" ] ||
+   [ -z "$ARGV_VERSION" ] ||
+   [ -z "$ARGV_AUTHOR" ] ||
+   [ -z "$ARGV_ICON_URL" ] ||
+   [ -z "$ARGV_LICENSE_URL" ] ||
+   [ -z "$ARGV_URL" ] ||
+   [ -z "$ARGV_BUG_TRACKER_URL" ] ||
+   [ -z "$ARGV_DOCS_URL" ] ||
+   [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+# Nuspec expect HTML escaped strings
+SUMMARY="$(echo "$ARGV_SUMMARY" | sed 's/&/&amp;/g')"
+DESCRIPTION="$(echo "$ARGV_DESCRIPTION" | sed 's/&/&amp;/g')"
+
+cat << EOF > "$ARGV_OUTPUT"
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>$ARGV_ID</id>
+    <title>$ARGV_NAME</title>
+    <version>$ARGV_VERSION</version>
+    <authors>$ARGV_AUTHOR</authors>
+    <owners>$ARGV_AUTHOR</owners>
+    <summary>$SUMMARY</summary>
+    <description>
+      $DESCRIPTION
+    </description>
+    <projectUrl>$ARGV_URL</projectUrl>
+    <licenseUrl>$ARGV_LICENSE_URL</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <iconUrl>$ARGV_ICON_URL</iconUrl>
+    <bugTrackerUrl>$ARGV_BUG_TRACKER_URL</bugTrackerUrl>
+    <docsUrl>$ARGV_DOCS_URL</docsUrl>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools"/>
+  </files>
+</package>
+EOF

--- a/scripts/build/electron-installer-nupkg-multiarch-win32.sh
+++ b/scripts/build/electron-installer-nupkg-multiarch-win32.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+###
+# Copyright 2016 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+./scripts/build/check-dependency.sh choco
+
+function usage() {
+  echo "Usage: $0"
+  echo ""
+  echo "Options"
+  echo ""
+  echo "    -i <application id>"
+  echo "    -v <application version>"
+  echo "    -d <nupkg directory>"
+  echo "    -t <temporary directory>"
+  echo "    -o <output>"
+  exit 1
+}
+
+ARGV_ID=""
+ARGV_VERSION=""
+ARGV_DIRECTORY=""
+ARGV_TEMPORARY_DIRECTORY=""
+ARGV_OUTPUT=""
+
+while getopts ":i:v:d:t:o:" option; do
+  case $option in
+    i) ARGV_ID="$OPTARG" ;;
+    v) ARGV_VERSION="$OPTARG" ;;
+    d) ARGV_DIRECTORY="$OPTARG" ;;
+    t) ARGV_TEMPORARY_DIRECTORY="$OPTARG" ;;
+    o) ARGV_OUTPUT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+if [ -z "$ARGV_ID" ] ||
+   [ -z "$ARGV_VERSION" ] ||
+   [ -z "$ARGV_DIRECTORY" ] ||
+   [ -z "$ARGV_TEMPORARY_DIRECTORY" ] ||
+   [ -z "$ARGV_OUTPUT" ]; then
+  usage
+fi
+
+choco pack "$ARGV_DIRECTORY/$ARGV_ID.nuspec" \
+  --fail-on-error-output \
+  --outputdirectory "$ARGV_TEMPORARY_DIRECTORY"
+
+mv "$ARGV_TEMPORARY_DIRECTORY/$ARGV_ID.$ARGV_VERSION.nupkg" "$ARGV_OUTPUT"


### PR DESCRIPTION
This commit adds a Makefile target called `electron-installer-nupkg`,
which generates a `.nupkg` file that references Etcher installers
uploaded to S3.

This largely based on @pierrebeaucamp's work, originally published at
https://github.com/pierrebeaucamp/chocolatey.

Fixes: https://github.com/resin-io/etcher/issues/1155
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>