### PR TITLE
upgrade: `angular` and `angular-mocks` to v1.6.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "1.0.0-beta.19",
   "dependencies": {
     "angular": {
-      "version": "1.6.1",
-      "from": "angular@>=1.6.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.1.tgz"
+      "version": "1.6.3",
+      "from": "angular@1.6.3",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.3.tgz"
     },
     "angular-if-state": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "removedrive": "^1.1.1"
   },
   "dependencies": {
-    "angular": "^1.6.1",
+    "angular": "^1.6.3",
     "angular-if-state": "^1.0.0",
     "angular-middle-ellipses": "^1.0.0",
     "angular-moment": "^1.0.1",
@@ -105,7 +105,7 @@
     "yauzl": "^2.6.0"
   },
   "devDependencies": {
-    "angular-mocks": "^1.6.1",
+    "angular-mocks": "1.6.3",
     "browserify": "^13.0.1",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^3.1.1",


### PR DESCRIPTION
We recently started hitting the following errors in all our CI builds:

```
TypeError: angular.module(...).info is not a function
    at /etcher/node_modules/angular-mocks/angular-mock
```

The `.info()` function was released in AngularJS 1.6.3. We declare
`angular-mocks@^1.6.1` as a development dependency, which means that
once 1.6.3 was out, npm started resolving `angular-mocks@1.6.3`, however
that version is incompatible with the main Angular version we're
shrinkwrapping (1.6.1), and thus the error.

As a solution, I've upgraded both `angular` and `angular-mocks` to
1.6.3, but also locked down `angular-mocks`, since similar errors will
happen again unless we manually keep these versions in sync.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>