### PR TITLE
fix(GUI): stop drive scanning loop if an error occurs

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -143,7 +143,17 @@ app.run(($timeout, DriveScannerService, DrivesModel, ErrorService) => {
     });
   });
 
-  DriveScannerService.on('error', ErrorService.reportException);
+  DriveScannerService.on('error', (error) => {
+
+    // Stop the drive scanning loop in case of errors,
+    // otherwise we risk presenting the same error over
+    // and over again to the user, while also heavily
+    // spamming our error reporting service.
+    DriveScannerService.stop();
+
+    return ErrorService.reportException(error);
+  });
+
   DriveScannerService.start();
 });
 


### PR DESCRIPTION
If the drive scanning scripts cause an error, the error will be
presented to the user over and over again. Not only this is terrible UX,
which even makes hard to close the application since dialogs keep coming
in, but it also spams TrackJS, our error reporting service, and makes it
seem that errors happened dozens of times, and thus obscuring real
trending errors.

Change-Type: patch
Changelog-Entry: Stop drive scanning loop if an error occurs.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>