### PR TITLE
chore: create a temporary .dockerignore during the docker build step

### DIFF
--- a/scripts/build/docker/run-command.sh
+++ b/scripts/build/docker/run-command.sh
@@ -65,7 +65,9 @@ fi
 
 IMAGE_ID="etcher-build-$ARGV_ARCHITECTURE"
 
+cp "$ARGV_SOURCE_CODE_DIRECTORY/.gitignore" "$ARGV_SOURCE_CODE_DIRECTORY/.dockerignore"
 docker build -f "$DOCKERFILE" -t "$IMAGE_ID" "$ARGV_SOURCE_CODE_DIRECTORY"
+rm -f "$ARGV_SOURCE_CODE_DIRECTORY/.dockerignore"
 
 # Docker complaints with: ". includes invalid characters for a local
 # volume name, only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed" otherwise


### PR DESCRIPTION
This speeds up the 'docker build' step, as it reduces the amount of 'build
context' that needs to be sent to docker.

Unfortunately we can't append `.git` (a 53MB directory) to the end of `.dockerignore`, because it's needed by the `ensure-staged-sass.sh` script ;-)