### PR TITLE
chore: automatically enforce compatible angular core module versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,10 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      npm test;
-      ./scripts/ci/ensure-staged-sass.sh;
+      make sanity-checks && npm test;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "xvfb-run --server-args=$XVFB_ARGS npm test && ./scripts/ci/ensure-staged-sass.sh";
+      ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test";
     fi
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,7 @@ endif
 TARGETS = \
 	help \
 	info \
+	sanity-checks \
 	clean \
 	distclean \
 	package \
@@ -422,6 +423,10 @@ info:
 	@echo "Host arch           : $(HOST_ARCH)"
 	@echo "Target platform     : $(TARGET_PLATFORM)"
 	@echo "Target arch         : $(TARGET_ARCH)"
+
+sanity-checks:
+	./scripts/ci/ensure-staged-sass.sh
+	./scripts/ci/ensure-npm-dependencies-compatibility.sh
 
 clean:
 	rm -rf $(BUILD_DIRECTORY)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - bash .\scripts\ci\ensure-staged-sass.sh
+  - make sanity-checks
   - cmd: npm test
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "removedrive": "^1.1.1"
   },
   "dependencies": {
-    "angular": "^1.6.3",
+    "angular": "1.6.3",
     "angular-if-state": "^1.0.0",
     "angular-middle-ellipses": "^1.0.0",
     "angular-moment": "^1.0.1",

--- a/scripts/ci/ensure-npm-dependencies-compatibility.sh
+++ b/scripts/ci/ensure-npm-dependencies-compatibility.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+###
+# Copyright 2017 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$HERE/../build/check-dependency.sh" jq
+
+PACKAGE_JSON=package.json
+
+# Two pair-wise arrays, because associative arrays only work in Bash 4
+PRIMARY_VERSIONS=("dependencies[\"angular\"]")
+SECONDARY_VERSIONS=("devDependencies[\"angular-mocks\"]")
+
+function check_locked {
+    name=$1
+    version=$2
+    if [[ "$version" =~ "^\^" ]]; then
+        echo "Dependency: $name must be version-locked in $PACKAGE_JSON"
+        exit 1
+    fi
+}
+
+if [[ ${#PRIMARY_VERSIONS[@]} -ne ${#SECONDARY_VERSIONS[@]} ]]; then
+    echo "Lengths of PRIMARY_VERSIONS and SECONDARY_VERSIONS arrays must match"
+    exit 1
+fi
+
+for i in ${!PRIMARY_VERSIONS[@]}; do
+    primary=${PRIMARY_VERSIONS[$i]}
+    primary_version=$(jq -r ".$primary" "$PACKAGE_JSON")
+    check_locked "$primary" "$primary_version"
+    secondary=${SECONDARY_VERSIONS[$i]}
+    secondary_version=$(jq -r ".$secondary" "$PACKAGE_JSON")
+    check_locked "$secondary" "$secondary_version"
+    if [[ "$primary_version" != "$secondary_version" ]]; then
+        echo "The following dependencies must have the exact same version in $PACKAGE_JSON:"
+        echo "    $primary"
+        echo "    $secondary"
+        exit 1
+    fi
+done


### PR DESCRIPTION
We've recently had an incident were the `angular-mocks` version we were
running was incompatible with the `angular` version.

Each AngularJS core module is versioned equally, therefore we can write
a small scripts that automatically test that they match, so we're
guarded against forgetting to similarly upgrade different dependencies.

See: https://github.com/resin-io/etcher/pull/1168
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>