### PR TITLE
fix(GUI): avoid duplicated TrackJS errors

### DIFF
--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -14,7 +14,10 @@
     <script>
       window._trackJs = {
         token: '032448bc3d9e4cffb1e9b43d29d6c142',
-        application: 'etcher'
+        application: 'etcher',
+        console: {
+          error: false
+        }
       };
     </script>
     <script src="../../node_modules/trackjs/tracker.js"></script>


### PR DESCRIPTION
I've noticed that errors reported to TrackJS appear twice. Turns out
that TrackJS pipes output of `console.error()` as errors, rather than as
extra logging.

The `AnalyticsService.logException()` function reports the exception to
TrackJS using `$window.trackJS.track()`, but then prints it to `stderr`
as well (so it appears on DevTools), causing TrackJS to report that one
too.

The solution is to disable the `console.error` boolean property of the
`_trackJs` object. From the TrackJS documentation:

```
// By default any calls to console.error() will automatically trigger an
// error. Set this to false if you don't want console.error() to
// trigger errors.
error: true,
```

See: http://docs.trackjs.com/tracker/configuration
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>