### PR TITLE
feat(GUI): show drive name instead of device name

### DIFF
--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -60,8 +60,12 @@
           <div class="step-selection-text"
             ng-class="{
               'text-disabled': main.shouldDriveStepBeDisabled()
-            }">
-            <span class="step-drive step-name">{{ main.selection.getDrive().name }}</span>
+            }"
+            uib-tooltip="{{ main.selection.getDrive().name }}">
+            <span class="step-drive step-name">
+              <!-- middleEllipses errors on undefined, therefore fallback to empty string -->
+              {{ (main.selection.getDrive().description || "") | middleEllipses:11 }}
+            </span>
             <span class="step-drive step-size">{{ main.selection.getDrive().size | gigabyte | number:1 }} GB</span>
           </div>
           <button class="button button-link step-footer"


### PR DESCRIPTION
We show the friendly drive name on the main page with the drive's device name
or mount point now inside a tooltip. Drive names longer than 11 characters are
truncated with a middle ellipsis.

Changelog-Entry: Show friendly drive name instead of device name.
Closes: https://github.com/resin-io/etcher/issues/1170