### PR TITLE
doc: Add MSVC Build Tools option to Windows requisites

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -21,9 +21,11 @@ Prerequisites
 
 - [Rimraf](https://github.com/isaacs/rimraf)
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
-- [Visual Studio Community 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48146) (free) (other editions, like Professional and Enterprise, should work too)
-  - Visual Studio 2015 doesn't install C++ by default. You have to rerun the
-    setup, select Modify and then check `Visual C++ -> Common Tools for Visual
+- Either one of the following:
+  - [Visual C++ 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) containing standalone compilers, libraries and scripts
+  - [Visual Studio Community 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48146) (free) (other editions, like Professional and Enterprise, should work too)  
+    **NOTE:** Visual Studio 2015 doesn't install C++ by default. You have to rerun the
+    setup, select "Modify" and then check `Visual C++ -> Common Tools for Visual
     C++ 2015` (see http://stackoverflow.com/a/31955339)
 - [MinGW](http://www.mingw.org)
 


### PR DESCRIPTION
Add Visual C++ 2015 Build Tools as a lighter option to a full blown Visual Studio installation for development requirements on Windows.