### PR TITLE
minifix(GUI): show Windows warning for images starting with W(8|9|10)

### DIFF
--- a/lib/gui/models/supported-formats.js
+++ b/lib/gui/models/supported-formats.js
@@ -145,7 +145,7 @@ SupportedFormats.service('SupportedFormatsModel', function() {
    * }
    */
   this.looksLikeWindowsImage = (imagePath) => {
-    const regex = /windows|win7|win8|win10|winxp/i;
+    const regex = /windows|win7|win8|win10|winxp|^W\d\d?/i;
     return regex.test(path.basename(imagePath));
   };
 

--- a/tests/gui/models/supported-formats.spec.js
+++ b/tests/gui/models/supported-formats.spec.js
@@ -129,7 +129,11 @@ describe('Browser: SupportedFormats', function() {
         'C:\\path\\to\\en_windows_10_multiple_editions_version_1607_updated_jan_2017_x64_dvd_9714399.iso',
         '/path/to/en_windows_10_multiple_editions_version_1607_updated_jan_2017_x64_dvd_9714399.iso',
         '/path/to/Win10_1607_SingleLang_English_x32.iso',
-        '/path/to/en_winxp_pro_x86_build2600_iso.img'
+        '/path/to/en_winxp_pro_x86_build2600_iso.img',
+        '/path/to/w10_july.img',
+        '/path/to/W10_july.img',
+        '/path/to/W8_july.img',
+        '/path/to/W7_july.img'
       ], (imagePath) => {
 
         it(`should return true if filename is ${imagePath}`, function() {
@@ -141,7 +145,10 @@ describe('Browser: SupportedFormats', function() {
 
       _.each([
         'C:\\path\\to\\2017-01-11-raspbian-jessie.img',
-        '/path/to/2017-01-11-raspbian-jessie.img'
+        '/path/to/2017-01-11-raspbian-jessie.img',
+        '/path/to/2017-01-11-foow10.img',
+        '/path/to/2017-01-11-foow8.img',
+        '/path/to/2017-01-11-foow7.img'
       ], (imagePath) => {
 
         it(`should return false if filename is ${imagePath}`, function() {


### PR DESCRIPTION
Some Windows images start with `W8`, `W9`, or `W10`. This commit extends
the `.looksLikeWindowsImage()` regular expression to catch these cases.

Since a `W` followed by a number can occur in other parts of a file
name, we only attempt to detect this pattern at the beginning of the
file name.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>