### PR TITLE
chore: don't compress binaries/libraries with upx

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm install -g bower rimraf asar
   - choco install nsis -version 2.51
-  - choco install upx
   - choco install jq
   - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
   - set PATH=C:\Program Files (x86)\NSIS;%PATH%

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -11,7 +11,6 @@ Prerequisites
 
 - [NodeJS](https://nodejs.org) (at least v6)
 - [Bower](http://bower.io)
-- [UPX](http://upx.sourceforge.net)
 - [Python](https://www.python.org)
 - [jq](https://stedolan.github.io/jq/)
 - [Asar](https://github.com/electron/asar)

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
   python \
   python-pip \
   python-dev \
-  upx \
   unzip \
   wget \
   xvfb \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
   python \
   python-pip \
   python-dev \
-  upx \
   unzip \
   wget \
   xvfb \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
   python \
   python-pip \
   python-dev \
-  upx \
   unzip \
   wget \
   xvfb \

--- a/scripts/build/electron-configure-package-win32.sh
+++ b/scripts/build/electron-configure-package-win32.sh
@@ -25,7 +25,6 @@ if [[ "$OS" != "Msys" ]]; then
   exit 1
 fi
 
-./scripts/build/check-dependency.sh upx
 ./scripts/build/check-dependency.sh unzip
 
 function usage() {
@@ -116,8 +115,6 @@ RCEDIT="$ARGV_DOWNLOAD_DIRECTORY/rcedit.exe"
   --set-file-version "$ARGV_VERSION" \
   --set-product-version "$ARGV_VERSION" \
   --set-icon "$ARGV_ICON"
-
-upx -9 "$ARGV_OUTPUT/*.dll"
 
 cp "$ARGV_ASAR" "$ARGV_OUTPUT/resources/app.asar"
 

--- a/scripts/build/electron-create-appdir.sh
+++ b/scripts/build/electron-create-appdir.sh
@@ -19,8 +19,6 @@
 set -u
 set -e
 
-./scripts/build/check-dependency.sh upx
-
 function usage() {
   echo "Usage: $0"
   echo ""
@@ -84,21 +82,6 @@ EOF
 cp "$ARGV_ICON" "$ARGV_OUTPUT/$APPDIR_ICON_FILENAME.png"
 mkdir -p "$ARGV_OUTPUT/usr/bin"
 cp -rf "$ARGV_PACKAGE"/* "$ARGV_OUTPUT/usr/bin"
-
-# Compress binaries
-upx -9 "$ARGV_OUTPUT/usr/bin/$ARGV_BINARY"
-
-# upx fails with an error if .so are not executables
-chmod +x "$ARGV_OUTPUT"/usr/bin/*.so*
-
-# UPX fails for some reason with some other so libraries
-# other than libnode.so in the x86 build
-if [ "$ARGV_ARCHITECTURE" == "x86" ]; then
-  upx -9 "$ARGV_OUTPUT"/usr/bin/libnode.so
-
-else
-  upx -9 "$ARGV_OUTPUT"/usr/bin/*.so*
-fi
 
 APPIMAGES_TAG=6
 APPIMAGES_GITHUB_RAW_BASE_URL=https://raw.githubusercontent.com/probonopd/AppImageKit/$APPIMAGES_TAG


### PR DESCRIPTION
upx allows to reduce the package size by some mega bytes, but also
considerably slows down the application start time.

This commit ditches upx, since we can re-gain those benefits (and even
increase them) by other means (e.g: minifying JavaScript).

See: https://github.com/resin-io/etcher/issues/1138
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>