### PR TITLE
chore: setup .gitattributes to perform correct line-ending conversions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Javascript files must retain LF line-endings (to keep eslint happy)
+*.js text eol=lf
+# CSS and SCSS files must retain LF line-endings (to keep ensure-staged-sass.sh happy)
+*.css text eol=lf
+*.scss text eol=lf
+
+# Text files
+dictionary text
+Dockerfile* text
+.editorconfig text
+etcher text
+.git* text
+*.html text
+*.json text
+LICENSE text
+Makefile text
+*.md text
+*.sh text
+*.svg text
+*.yml text
+
+# Binary files (no line-ending conversions)
+*.bz2 binary
+*.gz binary
+*.icns binary
+*.ico binary
+*.img binary
+*.png binary
+*.xz binary
+*.zip binary

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ sanity-checks:
 	./scripts/ci/ensure-staged-sass.sh
 	./scripts/ci/ensure-npm-dependencies-compatibility.sh
 	./scripts/ci/ensure-npm-shrinkwrap-versions.sh
+	./scripts/ci/ensure-all-file-extensions-in-gitattributes.sh
 
 clean:
 	rm -rf $(BUILD_DIRECTORY)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
 
-init:
-  - git config --global core.autocrlf input
-
 image: Visual Studio 2015
 
 cache:

--- a/scripts/ci/ensure-all-file-extensions-in-gitattributes.sh
+++ b/scripts/ci/ensure-all-file-extensions-in-gitattributes.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+###
+# Copyright 2017 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$HERE/../build/check-dependency.sh" git
+
+# Read list of wildcards from .gitattributes
+wildcards=()
+while IFS='' read -r line || [[ -n "$line" ]]; do
+  if [[ -n "$line" ]]; then
+    if [[ ! "$line" =~ "^#" ]]; then
+      filetype=$(echo "$line" | cut -d ' ' -f 2)
+      if [[ "$filetype" == "text" ]] || [[ "$filetype" == "binary" ]]; then
+        wildcards+=("$(echo "$line" | cut -d ' ' -f 1)")
+      fi
+    fi
+  fi
+done < .gitattributes
+
+# Verify those wildcards against all files stored in the repo
+git ls-tree -r HEAD | while IFS='' read line; do
+  if [[ "$(echo $line | cut -d ' ' -f 2)" == "blob" ]]; then
+    # the cut delimiter in the line below is actually a tab character, not a space
+    filename=$(basename $(echo "$line" | cut -d '	' -f 2))
+    found_match=0
+    for wildcard in "${wildcards[@]}"; do
+      if [[ "$filename" = $wildcard ]]; then
+        found_match=1
+        break
+      fi
+    done
+    if [[ $found_match -eq 0 ]]; then
+      echo "No wildcards match $filename"
+      exit 1
+    fi
+  fi
+done


### PR DESCRIPTION
This allows `npm run lint` to pass regardless of the `core.autocrlf` setting in git

See https://help.github.com/articles/dealing-with-line-endings/ and http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/ for more info.

The CSS and SCSS needs to always be LF, because `node-sass` outputs a horrid mix of CRLF and LF (which confuses `git status`) if any of the input files contain CRLF.