### PR TITLE
upgrade: `unbzip2-stream` to v1.0.11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6939,9 +6939,9 @@
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "1.0.10",
-      "from": "unbzip2-stream@>=1.0.10 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.10.tgz"
+      "version": "1.0.11",
+      "from": "unbzip2-stream@1.0.11",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.11.tgz"
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "sudo-prompt": "^6.1.0",
     "tail": "^1.1.0",
     "trackjs": "^2.1.16",
-    "unbzip2-stream": "^1.0.10",
+    "unbzip2-stream": "^1.0.11",
     "username": "^2.1.0",
     "yargs": "^4.6.0",
     "yauzl": "^2.6.0"


### PR DESCRIPTION
We believe this issue fixes the "rawr i'm a dinosaur" error on certain
problematic images.

Gives this only happens on a minority of images, we couldn't confirm
that the fix really solves the issue, but we'll include the upgrade on
the next Etcher version and see how it goes in the real world.

Change-Type: patch
Changelog-Entry: Fix "rawr i'm a dinosaur" bzip2 error.
Fixes: https://github.com/resin-io/etcher/issues/734
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>