### PR TITLE
chore: fix errors during snapshot deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
             ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "make publish-aws-s3";
           else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - npm install -g bower rimraf asar
   - choco install nsis -version 2.51
   - choco install jq
+  - choco install curl
   - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
   - set PATH=C:\Program Files (x86)\NSIS;%PATH%
   - set PATH=C:\MinGW\bin;%PATH%

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -15,6 +15,7 @@ Prerequisites
 - [jq](https://stedolan.github.io/jq/)
 - [Asar](https://github.com/electron/asar)
 - [Codespell](https://github.com/lucasdemarchi/codespell)
+- [curl](https://curl.haxx.se/)
 
 ### Windows
 
@@ -22,7 +23,7 @@ Prerequisites
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
 - Either one of the following:
   - [Visual C++ 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) containing standalone compilers, libraries and scripts
-  - [Visual Studio Community 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48146) (free) (other editions, like Professional and Enterprise, should work too)  
+  - [Visual Studio Community 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48146) (free) (other editions, like Professional and Enterprise, should work too)
     **NOTE:** Visual Studio 2015 doesn't install C++ by default. You have to rerun the
     setup, select "Modify" and then check `Visual C++ -> Common Tools for Visual
     C++ 2015` (see http://stackoverflow.com/a/31955339)
@@ -33,7 +34,6 @@ The following MinGW packages are required:
 - `msys-make`
 - `msys-unzip`
 - `msys-zip`
-- `msys-curl`
 - `msys-bash`
 - `msys-coreutils`
 


### PR DESCRIPTION
This commit addresses some issues with snapshot builds that we didn't
caught given we never ran the deployment step in a "real" deployment
scenario.

- On Travis CI, the service reverts all changes in the source tree
  before starting the `deploy` section, which seems to trigger some
  issues when deleting `node_modules`. The solution is to set the
  `skip_cleanup` option

See
https://s3.amazonaws.com/archive.travis-ci.org/jobs/213614487/log.txt

```
...
warning: failed to remove node_modules/helper-date/node_modules/moment/locale/es.js
warning: failed to remove node_modules/helper-date/node_modules/moment/locale/ky.js
warning: failed to remove node_modules/helper-date/node_modules/moment/locale/pt-br.js
warning: failed to remove node_modules/helper-date/node_modules/moment/locale/hu.js
warning: failed to remove node_modules/helper-date/node_modules/moment/locale/en-nz.js
...
```

- On Appveyor CI, `curl` is not installed

See
https://ci.appveyor.com/project/resin-io/etcher/build/job/54i0erd9tsa1cg5p
as an example.

See: https://github.com/resin-io/etcher/pull/1078
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>