### PR TITLE
WIP chore: include timestamps in snapshot builds as pre-release tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,12 @@ APPLICATION_VERSION = $(PACKAGE_JSON_VERSION)
 S3_BUCKET = resin-production-downloads
 endif
 ifeq ($(RELEASE_TYPE),snapshot)
-CURRENT_COMMIT_HASH = $(shell git log -1 --format="%h")
-APPLICATION_VERSION = $(PACKAGE_JSON_VERSION)+$(CURRENT_COMMIT_HASH)
+CURRENT_COMMIT_INFO = $(shell git log -1 --format="%ct+%h")
+ifneq (,$(findstring -,$(PACKAGE_JSON_VERSION)))
+APPLICATION_VERSION = $(PACKAGE_JSON_VERSION).$(CURRENT_COMMIT_INFO)
+else
+APPLICATION_VERSION = $(PACKAGE_JSON_VERSION)-$(CURRENT_COMMIT_INFO)
+endif
 S3_BUCKET = resin-nightly-downloads
 endif
 ifndef APPLICATION_VERSION
@@ -368,21 +372,11 @@ endif
 
 ifdef PUBLISH_AWS_S3
 publish-aws-s3: $(PUBLISH_AWS_S3)
-ifeq ($(RELEASE_TYPE),production)
 	$(foreach publishable,$^,$(call execute-command,./scripts/publish/aws-s3.sh \
 		-f $(publishable) \
 		-b $(S3_BUCKET) \
 		-v $(APPLICATION_VERSION) \
 		-p $(PRODUCT_NAME)))
-endif
-ifeq ($(RELEASE_TYPE),snapshot)
-	$(foreach publishable,$^,$(call execute-command,./scripts/publish/aws-s3.sh \
-		-f $(publishable) \
-		-b $(S3_BUCKET) \
-		-v $(APPLICATION_VERSION) \
-		-p $(PRODUCT_NAME) \
-		-k $(shell date +"%Y-%m-%d")))
-endif
 
 TARGETS += publish-aws-s3
 endif

--- a/scripts/publish/aws-s3.sh
+++ b/scripts/publish/aws-s3.sh
@@ -31,7 +31,6 @@ function usage() {
   echo "    -b <s3 bucket>"
   echo "    -v <version>"
   echo "    -p <product name>"
-  echo "    -k [S3 key prefix]"
   exit 1
 }
 
@@ -39,15 +38,13 @@ ARGV_FILE=""
 ARGV_BUCKET=""
 ARGV_VERSION=""
 ARGV_PRODUCT_NAME=""
-ARGV_PREFIX=""
 
-while getopts ":f:b:v:p:k:" option; do
+while getopts ":f:b:v:p:" option; do
   case $option in
     f) ARGV_FILE="$OPTARG" ;;
     b) ARGV_BUCKET="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;
     p) ARGV_PRODUCT_NAME="$OPTARG" ;;
-    k) ARGV_PREFIX="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -61,12 +58,7 @@ then
 fi
 
 FILENAME=$(basename "$ARGV_FILE")
-
-if [ -n "$ARGV_PREFIX" ]; then
-  S3_KEY="$ARGV_PRODUCT_NAME/$ARGV_PREFIX/$ARGV_VERSION/$FILENAME"
-else
-  S3_KEY="$ARGV_PRODUCT_NAME/$ARGV_VERSION/$FILENAME"
-fi
+S3_KEY="$ARGV_PRODUCT_NAME/$ARGV_VERSION/$FILENAME"
 
 aws s3api put-object \
   --bucket "$ARGV_BUCKET" \


### PR DESCRIPTION
Current snapshot builds include a version that contains the shorter
current commit hash as a build tag, for example: v1.0.0-beta.19+fbfd6f0.

We want to support update notifications (and auto updates in the
future) on snapshot builds, however we realised that there is no way to
order snapshot build versions based on the information we have at the
moment. For example, how do we determine if v1.0.0-beta.19+fbfd6f0 came
before v1.0.0-beta.19+799ebc6?

Note that we can always roll our custom "smart" comparison logic
querying the git history, etc, however we want to rely on standard
semver comparison rules, so that we can leverage existing third party
auto updates server in the future.

As a solution, we decided to include the timestamp of the commit as part
of the pre release tag. For example: 1.0.0-beta.19.1490192871+fbfd6f0.
Semver implementations consider pre release tags for comparison
purposes, which means that any semver implementation can automatically
determine the ordering of our version.

See: https://github.com/resin-io/etcher/pull/1183
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>