### PR TITLE
chore: add `libyaml-dev` to GNU/Linux Docker dependencies

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
   libnss3 \
   libxss1 \
   libxtst6 \
+  libyaml-dev \
   python \
   python-pip \
   python-dev \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
   libnss3 \
   libxss1 \
   libxtst6 \
+  libyaml-dev \
   python \
   python-pip \
   python-dev \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
   libnss3 \
   libxss1 \
   libxtst6 \
+  libyaml-dev \
   python \
   python-pip \
   python-dev \


### PR DESCRIPTION
`pip install awscli` outputs the following warning:

```
Running setup.py install for PyYAML
  checking if libyaml is compilable
  i686-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/check_libyaml.c -o build/temp.linux-x86_64-2.7/check_libyaml.o
  build/temp.linux-x86_64-2.7/check_libyaml.c:2:18: fatal error: yaml.h: No such file or directory
   #include <yaml.h>
                    ^
  compilation terminated.

  libyaml is not found or a compiler error: forcing --without-libyaml
  (if libyaml is installed correctly, you may need to
   specify the option --include-dirs or uncomment and
   modify the parameter include_dirs in setup.cfg)
```

The installation gracefully continues anyway (the `--without-libyaml` is
automatically forced).

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>