### PR TITLE
fix(image-stream): Destroy unused image streams

### DIFF
--- a/lib/image-stream/index.js
+++ b/lib/image-stream/index.js
@@ -108,6 +108,11 @@ exports.getFromFilePath = (file) => {
  */
 exports.getImageMetadata = (file) => {
   return exports.getFromFilePath(file).then((image) => {
+
+    // Since we're not consuming this stream,
+    // destroy() it, to avoid dangling open file descriptors etc.
+    image.stream.destroy();
+
     return _.omitBy(image, isStream);
   });
 };


### PR DESCRIPTION
When fetching metadata, a stream is opened, but never consumed. This destroys the stream when retrieving metadata to avoid dangling open file descriptors and such.

Change-Type: patch