### PR TITLE
feat(robot): Support logging arbitrary data to the console

### DIFF
--- a/lib/child-writer/index.js
+++ b/lib/child-writer/index.js
@@ -139,6 +139,8 @@ exports.write = (image, drive, options) => {
       // to provide better encapsulation.
       if (messageCommand === 'error') {
         emitError(robot.recomposeErrorMessage(parsedMessage));
+      } else if (messageCommand === 'log') {
+        console.log(messageData);
       } else {
         emitter.emit(messageCommand, messageData);
       }

--- a/lib/shared/robot/README.md
+++ b/lib/shared/robot/README.md
@@ -48,6 +48,16 @@ console.log(robot.getData(message));
 > }
 ```
 
+**Logging debug data to the console:**
+
+*Child process:*
+
+```js
+// This will log the passed data to parent's console,
+// as `console.log()`ing in the child will cause errors
+robot.log({ debugging: 'things' })
+```
+
 The codename "robot" is inspired by [xz][xz-man], which provides a `--robot`
 option that makes the tool print machine-parseable output:
 

--- a/lib/shared/robot/index.js
+++ b/lib/shared/robot/index.js
@@ -215,3 +215,17 @@ exports.printError = (error) => {
 exports.printMessage = (message, data) => {
   console.log(exports.buildMessage(message, data));
 };
+
+/**
+ * @summary Log a message to the host's console
+ * @function
+ * @public
+ *
+ * @param {Object} [data] - data
+ *
+ * @example
+ * robot.log({ example: 'data' });
+ */
+exports.log = (data) => {
+  exports.printMessage('log', data);
+};


### PR DESCRIPTION
This adds a new command recognition for message type "log",
to enable `console.log()`ing arbitrary data to the parent process console.

Not sure if we'd really want this in, but it's very handy for debugging,
and would keep us from writing these 3 lines every time
we want to inspect something in between those processes.

Change-Type: minor