### PR TITLE
chore(scripts): Rebuild instead of removing `node_modules`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,18 +471,7 @@ endif
 
 .PHONY: $(TARGETS)
 
-# Note that we need to remove `node_modules` every time.
-# Since we use an `npm-shrinkwrap.json` file, if you pull changes
-# that update a dependency and try to `npm install` directly, npm
-# will complain that your `node_modules` tree is not equal to what
-# is defined by the `npm-shrinkwrap.json` file, and will thus
-# refuse to do anything but install from scratch.
-# The `node_modules` directory also needs to be wiped out if you're
-# changing between target architectures, since compiled add-ons
-# will not work otherwise.
-
 cli-develop:
-	rm -rf node_modules
 	./scripts/build/dependencies-npm.sh \
 		-r "$(TARGET_ARCH)" \
 		-v "$(ELECTRON_VERSION)" \
@@ -490,7 +479,6 @@ cli-develop:
 		-s "$(TARGET_PLATFORM)"
 
 electron-develop:
-	rm -rf node_modules
 	./scripts/build/dependencies-npm.sh \
 		-r "$(TARGET_ARCH)" \
 		-v "$(ELECTRON_VERSION)" \

--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -96,6 +96,18 @@ if [ "$ARGV_PRODUCTION" == "true" ]; then
 fi
 
 function run_install() {
+
+  # Since we use an `npm-shrinkwrap.json` file, if you pull changes
+  # that update a dependency and try to `npm install` directly, npm
+  # will complain that your `node_modules` tree is not equal to what
+  # is defined by the `npm-shrinkwrap.json` file, and will thus
+  # refuse to do anything but install from scratch.
+  npm prune
+
+  # When changing between target architectures, rebuild all dependencies,
+  # since compiled add-ons will not work otherwise.
+  npm rebuild
+
   npm install $INSTALL_OPTS
 
   if [ "$ARGV_PRODUCTION" == "true" ]; then


### PR DESCRIPTION
As removing the `node_modules` completely and then re-installing is quite time consuming and SSD-thrashing, resort to pruning and rebuilding native add-ons when switching targets.

Change-Type: patch