### PR TITLE
fix(GUI): disallow reloading the app in macOS using Cmd+R

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const electron = require('electron');
+const _ = require('lodash');
 const path = require('path');
 let mainWindow = null;
 
@@ -69,6 +70,15 @@ electron.app.on('ready', () => {
         mode: 'detach'
       });
     });
+
+    // Disable refreshing the browser window
+    // This is supposed to be handled by the `will-navigate`
+    // event, however there seems to be an issue where such
+    // event is not fired in macOS
+    // See: https://github.com/electron/electron/issues/8841
+    electron.globalShortcut.register('CmdOrCtrl+R', _.noop);
+    electron.globalShortcut.register('F5', _.noop);
+
   });
 
   mainWindow.on('blur', () => {


### PR DESCRIPTION
Users can currently force the browser window to reload by using Cmd+R in
macOS. The `will-navigate` even handler in this same file is supposed to
protect us from this case, however its not fired at all just in macOS
for some reason.

As a solution, we attach dummy keyboard shortcut handlers for Cmd+R,
Ctrl+R, and F5, to override the normal browser window behaviour.

The reason behind disallowing reloads is that a reload during a critical
operation such as writing, validation, elevating, unmounting, drive
scanning, etc will cause undefined behaviour, resulting in non sense
errors that we can't solve coming to TrackJS.

See: https://github.com/electron/electron/issues/8841
Fixes: https://github.com/resin-io/etcher/issues/1210
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>