### PR TITLE
fix(GUI): prevent blank application when sending SIGINT

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -18,9 +18,20 @@
 
 const electron = require('electron');
 const path = require('path');
+const EXIT_CODES = require('../shared/exit-codes');
 let mainWindow = null;
 
 electron.app.on('window-all-closed', electron.app.quit);
+
+// Sending a `SIGINT` (e.g: Ctrl-C) to an Electron app that registers
+// a `beforeunload` window event handler results in a disconnected white
+// browser window in GNU/Linux and macOS.
+// The `before-quit` Electron event is triggered in `SIGINT`, so we can
+// make use of it to ensure the browser window is completely destroyed.
+// See https://github.com/electron/electron/issues/5273
+electron.app.on('before-quit', () => {
+  process.exit(EXIT_CODES.SUCCESS);
+});
 
 electron.app.on('ready', () => {
 


### PR DESCRIPTION
This issue only affects GNU/Linux and macOS. If the user sends SIGINT to
the application, the main process dies, but we get an orphaned blank
browser window. The problem only seems to occur when there is a
`beforeunload` window event handlers, which we use to warn the user when
quitting while flashing.

Change-Type: patch
Changelog-Entry: Prevent blank application when sending SIGINT on GNU/Linux and macOS.
Fixes: https://github.com/resin-io/etcher/issues/1028
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>