### PR TITLE
fix(CLI): prevent flashing an image that is larger than the drive

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -22,6 +22,8 @@ const fs = Bluebird.promisifyAll(require('fs'));
 const os = require('os');
 const unmount = require('./unmount');
 const imageStream = require('../image-stream');
+const errors = require('../shared/errors');
+const constraints = require('../shared/constraints');
 
 /**
  * @summary Write an image to a disk drive
@@ -67,6 +69,15 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
     return fs.openAsync(drive.raw, 'rs+');
   }).then((driveFileDescriptor) => {
     return imageStream.getFromFilePath(imagePath).then((image) => {
+      if (!image.size.final.estimation && !constraints.isDriveLargeEnough(drive, {
+        size: image.size.final.value
+      })) {
+        throw errors.createUserError(
+          'The image you selected is too big for this drive',
+          'Plug in a bigger drive and try again'
+        );
+      }
+
       return imageWrite.write({
         fd: driveFileDescriptor,
         device: drive.raw,


### PR DESCRIPTION
The CLI sill happily let you flash an image that doesn't fit on the
drive. This commit prevents such scenario right before flashing, but we
should still implement a smarter CLI drive detection widget for when the
user runs the CLI interactively.

Change-Type: patch
Changelog-Entry: Prevent flashing an image that is larger than the drive with the CLI.
Fixes: https://github.com/resin-io/etcher/issues/858
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>