### PR TITLE
chore(travis): move deploy command to a separate script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@ LICENSE text
 Makefile text
 *.md text
 *.sh text
+*.bat text
 *.svg text
 *.yml text
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "make info && make electron-develop";
+      ./scripts/build/docker/run-command.sh -r "${TARGET_ARCH}" -s "${PWD}" -c "make info && make electron-develop";
     else
       pip install codespell==1.9.2 awscli;
       npm install -g bower asar;
@@ -48,7 +48,7 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test";
+      ./scripts/build/docker/run-command.sh -r "${TARGET_ARCH}" -s "${PWD}" -c "make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test";
     else
       make sanity-checks && npm test;
     fi
@@ -56,11 +56,7 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
-  script: if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-            ./scripts/build/docker/run-command.sh -r ${TARGET_ARCH} -s ${PWD} -c "make publish-aws-s3";
-          else
-            make publish-aws-s3;
-          fi
+  script: scripts/ci/deploy-travis.sh
   on:
     branch: master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ test_script:
   - cmd: npm test
 
 deploy_script:
-  - cmd: IF %APPVEYOR_REPO_BRANCH%==master (make publish-aws-s3)
+  - cmd: .\scripts\ci\deploy-appveyor.bat
 
 notifications:
 

--- a/scripts/ci/deploy-appveyor.bat
+++ b/scripts/ci/deploy-appveyor.bat
@@ -1,0 +1,26 @@
+@echo off
+
+:: Copyright 2017 resin.io
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+IF "%APPVEYOR_REPO_BRANCH%"=="" (
+  ECHO This script is only meant to run in Appveyor CI 1>&2
+  EXIT /B 1
+)
+
+IF %APPVEYOR_REPO_BRANCH%==master (
+  make publish-aws-s3
+)
+
+EXIT /B %ERRORLEVEL%

--- a/scripts/ci/deploy-travis.sh
+++ b/scripts/ci/deploy-travis.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+###
+# Copyright 2017 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -e
+set -u
+
+./scripts/build/check-dependency.sh make
+
+if [ -z "$TRAVIS_OS_NAME" ]; then
+  echo "This script is only meant to run in Travis CI" 1>&2
+  exit 1
+fi
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  ./scripts/build/docker/run-command.sh -r "$TARGET_ARCH" -s "$(pwd)" -c "make publish-aws-s3"
+else
+  make publish-aws-s3
+fi


### PR DESCRIPTION
We're passing a shell conditional to `deploy.script`, however Travis CI
seems to get confused about this in the deploy section, causing
GNU/Linux to run `make publish-aws-s3` directly on the Travis CI build
instead of in the Docker container, which causes the deployment to
eventually fail because of missing dependencies.

According to Travis CI:

> `deploy.script` must be a scalar pointing to an executable file or
> command.

See https://travis-ci.org/resin-io/etcher/jobs/214723725 for a failure
example.

We also move the Appveyor deploy script to a separate file for symmetry
purposes.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>