### PR TITLE
chore(package.json): add dynamic dependencies as optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
   },
   "optionalDependencies": {
     "elevator": "^2.1.0",
-    "removedrive": "^1.1.1"
+    "removedrive": "^1.1.1",
+    "spawn-sync": "^1.0.15",
+    "try-thread-sleep": "^1.0.2"
   },
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
In order to package the Etcher CLI, we concatenate all the code from the
`lib/cli/etcher.js` entry point using browserify.

There are some dependencies down the hierarchy that dynamically require
other dependencies, by enclosing `require()` calls in `try`/`catch`
blocks. The dynamic dependencies these modules require are not even
present in the `package.json`, and thus rightfully confuse browserify.

See https://github.com/ForbesLindesay/spawn-sync/blob/master/lib/spawn-sync.js#L10
See https://github.com/IndigoUnited/node-cross-spawn/blob/master/index.js#L32

There are two solutions to this problem:

- Make browserify stub these problematic dependencies with a blank file
  by using `--ignore`

This approach initially looks like the way to go, however it means that
every module that requires this particular dependency will receive just
a blank stub. It might be that some other dependencies rely on them, so
this approach could cause very obscure bugs later on.

- Add them to `package.json`

This is the approach taken by this commit. We add them to
`optionalDependencies` instead of `dependencies`, so we can still make
use of tools that analyse the code base for unused dependencies.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>