### PR TITLE
docs(README): uninstall instructions for debian/brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ installers for all supported operating systems.
     sudo apt-get install etcher-electron
     ```
 
+##### Uninstall
+
+```sh
+sudo apt-get remove etcher-electron
+sudo rm /etc/apt/sources.list.d/etcher.list
+sudo apt-get update
+```
+
 #### Brew Cask (macOS)
 
 Note that the Etcher Cask has to be updated manually to point to new versions,
@@ -66,6 +74,12 @@ release.
 
 ```sh
 brew cask install etcher
+```
+
+##### Uninstall
+
+```sh
+brew cask uninstall etcher
 ```
 
 Support


### PR DESCRIPTION
We have inline instructions to install Etcher from package managers.
This commit extends them to quickly mention how to uninstall as well.

Fixes: https://github.com/resin-io/etcher/issues/1225
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>