### PR TITLE
feat(GUI): display drive name and description in tooltip

### DIFF
--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -61,7 +61,7 @@
             ng-class="{
               'text-disabled': main.shouldDriveStepBeDisabled()
             }"
-            uib-tooltip="{{ main.selection.getDrive().name }}">
+            uib-tooltip="{{ main.selection.getDrive().description }} ({{ main.selection.getDrive().name }})">
             <span class="step-drive step-name">
               <!-- middleEllipses errors on undefined, therefore fallback to empty string -->
               {{ (main.selection.getDrive().description || "") | middleEllipses:11 }}


### PR DESCRIPTION
In the main page we show the drive description, and on hover a tooltip
shows the drive name. This behaviour is changed to show both in the
tooltip, un-truncatetd.

Closes: https://github.com/resin-io/etcher/issues/1170
Changelog-Entry: Display both drive name and description in the drive tooltip.