### PR TITLE
chore(package): Make clean-shrinkwrap remove optional dependencies

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,10 +44,6 @@ Use the following steps to ensure everything goes flawlessly:
 - Install the new version of the dependency. For example: `npm install --save
   <package>@<version>`. This will update the `npm-shrinkwrap.json` file.
 
-- Run `npm run clean-shrinkwrap`. This is a small script that ensures that
-  operating system specific dependencies that could get included in the
-  previous step are removed from `npm-shrinkwrap.json`.
-
 - Commit *both* `package.json` and `npm-shrinkwrap.json`.
 
 Testing

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "npm run jslint && npm run sasslint && npm run codespell && npm run htmllint",
     "changelog": "versionist",
     "start": "electron lib/start.js",
-    "clean-shrinkwrap": "node ./scripts/clean-shrinkwrap.js"
+    "preshrinkwrap": "node ./scripts/clean-shrinkwrap.js"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
@@ -122,7 +122,6 @@
     "eslint-plugin-lodash": "^2.3.5",
     "file-exists": "^1.0.0",
     "html-angular-validate": "^0.1.9",
-    "jsonfile": "^2.3.1",
     "mochainon": "^1.0.0",
     "node-sass": "^3.8.0",
     "sass-lint": "^1.10.2",


### PR DESCRIPTION
Previously dependencies weren't actually removed from `node_modules`,
this runs `npm rm` on the optional dependencies, effectively excluding
them, and their dependencies from the shrinkwrap file.

Also the script has been hooked to the `preshrinkwrap` hook,
to remove the need of having to run it manually.

**NOTE:** This depends on #1234 being merged first, to avoid mangling the `npm-shrinkwrap.json` several times.

Connects-To: #1234
Change-Type: patch