### PR TITLE
chore: make the CI servers fail-fast if one of their builds fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - TARGET_ARCH=x86
 
 matrix:
+  fast_finish: true
   exclude:
     - os: osx
       env: TARGET_ARCH=x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,9 @@ environment:
     - TARGET_ARCH: x64
     - TARGET_ARCH: x86
 
+matrix:
+  fast_finish: true
+
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm install -g bower rimraf asar


### PR DESCRIPTION
This means that if any architecture build fails, then we stop the other
ones right away, for performance reasons.

See: atom/atom@ce51074
See: https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>