### PR TITLE
refactor(image-stream): get rid of `isstream`

### DIFF
--- a/lib/image-stream/index.js
+++ b/lib/image-stream/index.js
@@ -19,7 +19,7 @@
 const _ = require('lodash');
 const Bluebird = require('bluebird');
 const fs = Bluebird.promisifyAll(require('fs'));
-const isStream = require('isstream');
+const stream = require('stream');
 const utils = require('./utils');
 const handlers = require('./handlers');
 const supportedFileTypes = require('./supported');
@@ -119,7 +119,9 @@ exports.getImageMetadata = (file) => {
     // destroy() it, to avoid dangling open file descriptors etc.
     image.stream.destroy();
 
-    return _.omitBy(image, isStream);
+    return _.omitBy(image, (property) => {
+      return property instanceof stream.Stream;
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "gzip-uncompressed-size": "^1.0.0",
     "immutable": "^3.8.1",
     "is-elevated": "^2.0.1",
-    "isstream": "^0.1.2",
     "lodash": "^4.5.1",
     "lodash-deep": "^2.0.0",
     "lzma-native": "^1.5.2",


### PR DESCRIPTION
The dependency is not yet removed from `npm-shrinkwrap.json` given that
there another one that keeps requiring it.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>