### PR TITLE
fix(writer): Use uncompressed or estimated size for progress

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -84,7 +84,7 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
         size: drive.size
       }, {
         stream: image.stream,
-        size: image.size.original
+        size: image.size.final.value
       }, {
         check: options.validateWriteOnSuccess,
         transform: image.transform,


### PR DESCRIPTION
This makes the writer use the image's uncompressed size, instead of the original size to avoid the progress percentage going above 100%.

Change-Type: patch