### PR TITLE
chore: Stop OSX builds on Travis frequently timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
       npm install -g bower asar;
       brew install afsctool jq;
       make info;
-      make electron-develop;
+      travis_wait make electron-develop;
     fi
 
 script:


### PR DESCRIPTION
See https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

We regularly have OSX builds failing with:
```
Makefile:125: No code-sign identity found (CODE_SIGN_IDENTITY is not set)
Application version : 1.0.0-beta.19+c817076
Release type        : snapshot
Host platform       : darwin
Host arch           : x64
Target platform     : darwin
Target arch         : x64
Makefile:125: No code-sign identity found (CODE_SIGN_IDENTITY is not set)
./scripts/build/dependencies-npm.sh \
		-r "x64" \
		-v "1.4.4" \
		-t electron \
		-s "darwin"
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```