### PR TITLE
refactor(GUI): remove angular from SettingsModel

### DIFF
--- a/lib/gui/components/update-notifier/controllers/update-notifier.js
+++ b/lib/gui/components/update-notifier/controllers/update-notifier.js
@@ -16,14 +16,16 @@
 
 'use strict';
 
-module.exports = function($uibModalInstance, SettingsModel, AnalyticsService, UPDATE_NOTIFIER_SLEEP_DAYS, options) {
+const settings = require('../../../models/settings');
+
+module.exports = function($uibModalInstance, AnalyticsService, UPDATE_NOTIFIER_SLEEP_DAYS, options) {
 
   // We update this value in this controller since its the only place
   // where we can be sure the modal was really presented to the user.
   // If the controller is instantiated, means the modal was shown.
   // Compare that to `UpdateNotifierService.notify()`, which could
   // have been called, but the modal could have failed to be shown.
-  SettingsModel.set('lastUpdateNotify', Date.now());
+  settings.set('lastUpdateNotify', Date.now());
 
   /**
    * @summary The number of days the update notified can be put to sleep
@@ -38,7 +40,7 @@ module.exports = function($uibModalInstance, SettingsModel, AnalyticsService, UP
    * @type {Object}
    * @public
    */
-  this.settings = SettingsModel;
+  this.settings = settings;
 
   /**
    * @summary Modal options

--- a/lib/gui/components/update-notifier/services/update-notifier.js
+++ b/lib/gui/components/update-notifier/services/update-notifier.js
@@ -20,8 +20,9 @@ const _ = require('lodash');
 const semver = require('semver');
 const etcherLatestVersion = require('etcher-latest-version');
 const units = require('../../../../shared/units');
+const settings = require('../../../models/settings');
 
-module.exports = function($http, $q, ModalService, UPDATE_NOTIFIER_SLEEP_DAYS, ManifestBindService, SettingsModel) {
+module.exports = function($http, $q, ModalService, UPDATE_NOTIFIER_SLEEP_DAYS, ManifestBindService) {
 
   /**
    * @summary The current application version
@@ -111,14 +112,14 @@ module.exports = function($http, $q, ModalService, UPDATE_NOTIFIER_SLEEP_DAYS, M
    * }
    */
   this.shouldCheckForUpdates = () => {
-    const lastUpdateNotify = SettingsModel.get('lastUpdateNotify');
+    const lastUpdateNotify = settings.get('lastUpdateNotify');
 
-    if (!SettingsModel.get('sleepUpdateCheck') || !lastUpdateNotify) {
+    if (!settings.get('sleepUpdateCheck') || !lastUpdateNotify) {
       return true;
     }
 
     if (lastUpdateNotify - Date.now() > units.daysToMilliseconds(UPDATE_NOTIFIER_SLEEP_DAYS)) {
-      SettingsModel.set('sleepUpdateCheck', false);
+      settings.set('sleepUpdateCheck', false);
       return true;
     }
 

--- a/lib/gui/components/update-notifier/update-notifier.js
+++ b/lib/gui/components/update-notifier/update-notifier.js
@@ -24,7 +24,6 @@ const angular = require('angular');
 const MODULE_NAME = 'Etcher.Components.UpdateNotifier';
 const UpdateNotifier = angular.module(MODULE_NAME, [
   require('../modal/modal'),
-  require('../../models/settings'),
   require('../../utils/manifest-bind/manifest-bind'),
   require('../../os/open-external/open-external'),
   require('../../modules/analytics')

--- a/lib/gui/models/settings.js
+++ b/lib/gui/models/settings.js
@@ -20,64 +20,55 @@
  * @module Etcher.Models.Settings
  */
 
-const angular = require('angular');
 const Store = require('./store');
-const MODULE_NAME = 'Etcher.Models.Settings';
-const SettingsModel = angular.module(MODULE_NAME, []);
 
-SettingsModel.service('SettingsModel', function() {
+/**
+ * @summary Set a setting value
+ * @function
+ * @public
+ *
+ * @param {String} key - setting key
+ * @param {*} value - setting value
+ *
+ * @example
+ * settings.set('unmountOnSuccess', true);
+ */
+exports.set = (key, value) => {
+  Store.dispatch({
+    type: Store.Actions.SET_SETTING,
+    data: {
+      key,
+      value
+    }
+  });
+};
 
-  /**
-   * @summary Set a setting value
-   * @function
-   * @public
-   *
-   * @param {String} key - setting key
-   * @param {*} value - setting value
-   *
-   * @example
-   * SettingsModel.set('unmountOnSuccess', true);
-   */
-  this.set = (key, value) => {
-    Store.dispatch({
-      type: Store.Actions.SET_SETTING,
-      data: {
-        key,
-        value
-      }
-    });
-  };
+/**
+ * @summary Get a setting value
+ * @function
+ * @public
+ *
+ * @param {String} key - setting key
+ * @returns {*} setting value
+ *
+ * @example
+ * const value = settings.get('unmountOnSuccess');
+ */
+exports.get = (key) => {
+  return this.getAll()[key];
+};
 
-  /**
-   * @summary Get a setting value
-   * @function
-   * @public
-   *
-   * @param {String} key - setting key
-   * @returns {*} setting value
-   *
-   * @example
-   * const value = SettingsModel.get('unmountOnSuccess');
-   */
-  this.get = (key) => {
-    return this.getAll()[key];
-  };
-
-  /**
-   * @summary Get all setting values
-   * @function
-   * @public
-   *
-   * @returns {Object} all setting values
-   *
-   * @example
-   * const allSettings = SettingsModel.getAll();
-   * console.log(allSettings.unmountOnSuccess);
-   */
-  this.getAll = () => {
-    return Store.getState().get('settings').toJS();
-  };
-
-});
-
-module.exports = MODULE_NAME;
+/**
+ * @summary Get all setting values
+ * @function
+ * @public
+ *
+ * @returns {Object} all setting values
+ *
+ * @example
+ * const allSettings = settings.getAll();
+ * console.log(allSettings.unmountOnSuccess);
+ */
+exports.getAll = () => {
+  return Store.getState().get('settings').toJS();
+};

--- a/lib/gui/modules/analytics.js
+++ b/lib/gui/modules/analytics.js
@@ -28,6 +28,7 @@ const os = require('os');
 const packageJSON = require('../../../package.json');
 const arch = require('arch');
 const utils = require('../../shared/utils');
+const settings = require('../models/settings');
 
 // Force Mixpanel snippet to load Mixpanel locally
 // instead of using a CDN for performance reasons
@@ -37,8 +38,7 @@ require('../../../bower_components/mixpanel/mixpanel-jslib-snippet.js');
 require('../../../bower_components/angular-mixpanel/src/angular-mixpanel');
 const MODULE_NAME = 'Etcher.Modules.Analytics';
 const analytics = angular.module(MODULE_NAME, [
-  'analytics.mixpanel',
-  require('../models/settings')
+  'analytics.mixpanel'
 ]);
 
 /**
@@ -98,7 +98,7 @@ analytics.run(($window) => {
   });
 });
 
-analytics.service('AnalyticsService', function($log, $window, $mixpanel, SettingsModel) {
+analytics.service('AnalyticsService', function($log, $window, $mixpanel) {
 
   /**
    * @summary Log a debug message
@@ -116,7 +116,7 @@ analytics.service('AnalyticsService', function($log, $window, $mixpanel, Setting
   this.logDebug = (message) => {
     const debugMessage = `${new Date()} ${message}`;
 
-    if (SettingsModel.get('errorReporting') && isRunningInAsar()) {
+    if (settings.get('errorReporting') && isRunningInAsar()) {
       $window.trackJs.console.debug(debugMessage);
     }
 
@@ -142,7 +142,7 @@ analytics.service('AnalyticsService', function($log, $window, $mixpanel, Setting
   this.logEvent = (message, data) => {
     const debugData = utils.hideAbsolutePathsInObject(utils.makeFlatStartCaseObject(data));
 
-    if (SettingsModel.get('errorReporting') && isRunningInAsar()) {
+    if (settings.get('errorReporting') && isRunningInAsar()) {
       $mixpanel.track(message, debugData);
     }
 
@@ -172,7 +172,7 @@ analytics.service('AnalyticsService', function($log, $window, $mixpanel, Setting
    */
   this.logException = (exception) => {
     if (_.every([
-      SettingsModel.get('errorReporting'),
+      settings.get('errorReporting'),
       isRunningInAsar(),
       errors.shouldReport(exception)
     ])) {

--- a/lib/gui/modules/drive-scanner.js
+++ b/lib/gui/modules/drive-scanner.js
@@ -26,13 +26,12 @@ const _ = require('lodash');
 const angular = require('angular');
 const EventEmitter = require('events').EventEmitter;
 const drivelist = require('drivelist');
+const settings = require('../models/settings');
 
 const MODULE_NAME = 'Etcher.Modules.DriveScanner';
-const driveScanner = angular.module(MODULE_NAME, [
-  require('../models/settings')
-]);
+const driveScanner = angular.module(MODULE_NAME, []);
 
-driveScanner.factory('DriveScannerService', (SettingsModel) => {
+driveScanner.factory('DriveScannerService', () => {
   const DRIVE_SCANNER_INTERVAL_MS = 2000;
   const DRIVE_SCANNER_FIRST_SCAN_DELAY_MS = 0;
   const emitter = new EventEmitter();
@@ -64,7 +63,7 @@ driveScanner.factory('DriveScannerService', (SettingsModel) => {
     })
 
     .map((drives) => {
-      if (SettingsModel.get('unsafeMode')) {
+      if (settings.get('unsafeMode')) {
         return drives;
       }
 

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -22,15 +22,15 @@
 
 const angular = require('angular');
 const childWriter = require('../../child-writer');
+const settings = require('../models/settings');
 
 const MODULE_NAME = 'Etcher.Modules.ImageWriter';
 const imageWriter = angular.module(MODULE_NAME, [
-  require('../models/settings'),
   require('../models/selection-state'),
   require('../models/flash-state')
 ]);
 
-imageWriter.service('ImageWriterService', function($q, $rootScope, SettingsModel, SelectionStateModel, FlashStateModel) {
+imageWriter.service('ImageWriterService', function($q, $rootScope, SelectionStateModel, FlashStateModel) {
 
   /**
    * @summary Perform write operation
@@ -57,8 +57,8 @@ imageWriter.service('ImageWriterService', function($q, $rootScope, SettingsModel
   this.performWrite = (image, drive, onProgress) => {
     return $q((resolve, reject) => {
       const child = childWriter.write(image, drive, {
-        validateWriteOnSuccess: SettingsModel.get('validateWriteOnSuccess'),
-        unmountOnSuccess: SettingsModel.get('unmountOnSuccess')
+        validateWriteOnSuccess: settings.get('validateWriteOnSuccess'),
+        unmountOnSuccess: settings.get('unmountOnSuccess')
       });
       child.on('error', reject);
       child.on('done', resolve);

--- a/lib/gui/pages/finish/controllers/finish.js
+++ b/lib/gui/pages/finish/controllers/finish.js
@@ -16,14 +16,16 @@
 
 'use strict';
 
-module.exports = function($state, FlashStateModel, SelectionStateModel, AnalyticsService, SettingsModel) {
+const settings = require('../../../models/settings');
+
+module.exports = function($state, FlashStateModel, SelectionStateModel, AnalyticsService) {
 
   /**
    * @summary Settings model
    * @type {Object}
    * @public
    */
-  this.settings = SettingsModel;
+  this.settings = settings;
 
   /**
    * @summary Source checksum

--- a/lib/gui/pages/finish/finish.js
+++ b/lib/gui/pages/finish/finish.js
@@ -32,8 +32,7 @@ const FinishPage = angular.module(MODULE_NAME, [
   require('angular-ui-router'),
   require('../../modules/analytics'),
   require('../../models/flash-state'),
-  require('../../models/selection-state'),
-  require('../../models/settings')
+  require('../../models/selection-state')
 ]);
 
 FinishPage.controller('FinishController', require('./controllers/finish'));

--- a/lib/gui/pages/main/controllers/drive-selection.js
+++ b/lib/gui/pages/main/controllers/drive-selection.js
@@ -16,7 +16,9 @@
 
 'use strict';
 
-module.exports = function(SelectionStateModel, AnalyticsService, ErrorService, DriveSelectorService, SettingsModel) {
+const settings = require('../../../models/settings');
+
+module.exports = function(SelectionStateModel, AnalyticsService, ErrorService, DriveSelectorService) {
 
   /**
    * @summary Open drive selector
@@ -36,7 +38,7 @@ module.exports = function(SelectionStateModel, AnalyticsService, ErrorService, D
 
       AnalyticsService.logEvent('Select drive', {
         device: drive.device,
-        unsafeMode: SettingsModel.get('unsafeMode')
+        unsafeMode: settings.get('unsafeMode')
       });
     }).catch(ErrorService.reportException);
   };

--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -17,11 +17,11 @@
 'use strict';
 
 const messages = require('../../../../shared/messages');
+const settings = require('../../../models/settings');
 
 module.exports = function(
   $state,
   FlashStateModel,
-  SettingsModel,
   DriveScannerService,
   ImageWriterService,
   AnalyticsService,
@@ -63,7 +63,7 @@ module.exports = function(
     AnalyticsService.logEvent('Flash', {
       image,
       drive,
-      unmountOnSuccess: SettingsModel.get('unmountOnSuccess')
+      unmountOnSuccess: settings.get('unmountOnSuccess')
     });
 
     ImageWriterService.flash(image.path, drive).then(() => {
@@ -120,7 +120,7 @@ module.exports = function(
     } else if (flashState.percentage === PERCENTAGE_MINIMUM && !flashState.speed) {
       return 'Starting...';
     } else if (flashState.percentage === PERCENTAGE_MAXIMUM) {
-      if (isChecking && SettingsModel.get('unmountOnSuccess')) {
+      if (isChecking && settings.get('unmountOnSuccess')) {
         return 'Unmounting...';
       }
 

--- a/lib/gui/pages/main/controllers/main.js
+++ b/lib/gui/pages/main/controllers/main.js
@@ -16,11 +16,12 @@
 
 'use strict';
 
+const settings = require('../../../models/settings');
+
 module.exports = function(
   SelectionStateModel,
   DrivesModel,
   FlashStateModel,
-  SettingsModel,
   TooltipModalService,
   ErrorService,
   OSOpenExternalService,
@@ -31,7 +32,7 @@ module.exports = function(
   this.selection = SelectionStateModel;
   this.drives = DrivesModel;
   this.state = FlashStateModel;
-  this.settings = SettingsModel;
+  this.settings = settings;
   this.external = OSOpenExternalService;
 
   /**

--- a/lib/gui/pages/main/main.js
+++ b/lib/gui/pages/main/main.js
@@ -51,7 +51,6 @@ const MainPage = angular.module(MODULE_NAME, [
   require('../../modules/error'),
   require('../../models/selection-state'),
   require('../../models/flash-state'),
-  require('../../models/settings'),
   require('../../models/supported-formats'),
   require('../../models/drives'),
 

--- a/lib/gui/pages/settings/controllers/settings.js
+++ b/lib/gui/pages/settings/controllers/settings.js
@@ -18,8 +18,9 @@
 
 const os = require('os');
 const _ = require('lodash');
+const settings = require('../../../models/settings');
 
-module.exports = function(WarningModalService, SettingsModel, ErrorService, AnalyticsService) {
+module.exports = function(WarningModalService, ErrorService, AnalyticsService) {
 
   /**
    * @summary Client platform
@@ -35,7 +36,7 @@ module.exports = function(WarningModalService, SettingsModel, ErrorService, Anal
    * @public
    */
   this.refreshSettings = () => {
-    this.currentData = SettingsModel.getAll();
+    this.currentData = settings.getAll();
   };
 
   /**
@@ -51,7 +52,7 @@ module.exports = function(WarningModalService, SettingsModel, ErrorService, Anal
    * @type {Object}
    * @public
    */
-  this.model = SettingsModel;
+  this.model = settings;
 
   /**
    * @summary Toggle setting

--- a/lib/gui/pages/settings/settings.js
+++ b/lib/gui/pages/settings/settings.js
@@ -25,7 +25,6 @@ const MODULE_NAME = 'Etcher.Pages.Settings';
 const SettingsPage = angular.module(MODULE_NAME, [
   require('angular-ui-router'),
   require('../../components/warning-modal/warning-modal'),
-  require('../../models/settings'),
   require('../../modules/error'),
   require('../../modules/analytics')
 ]);

--- a/tests/gui/components/update-notifier.spec.js
+++ b/tests/gui/components/update-notifier.spec.js
@@ -3,6 +3,7 @@
 const m = require('mochainon');
 const angular = require('angular');
 const units = require('../../../lib/shared/units');
+const settings = require('../../../lib/gui/models/settings');
 require('angular-mocks');
 
 describe('Browser: UpdateNotifier', function() {
@@ -16,19 +17,17 @@ describe('Browser: UpdateNotifier', function() {
     describe('.shouldCheckForUpdates()', function() {
 
       let UpdateNotifierService;
-      let SettingsModel;
       let UPDATE_NOTIFIER_SLEEP_DAYS;
 
-      beforeEach(angular.mock.inject(function(_UpdateNotifierService_, _SettingsModel_, _UPDATE_NOTIFIER_SLEEP_DAYS_) {
+      beforeEach(angular.mock.inject(function(_UpdateNotifierService_, _UPDATE_NOTIFIER_SLEEP_DAYS_) {
         UpdateNotifierService = _UpdateNotifierService_;
-        SettingsModel = _SettingsModel_;
         UPDATE_NOTIFIER_SLEEP_DAYS = _UPDATE_NOTIFIER_SLEEP_DAYS_;
       }));
 
       describe('given the `sleepUpdateCheck` is disabled', function() {
 
         beforeEach(function() {
-          SettingsModel.set('sleepUpdateCheck', false);
+          settings.set('sleepUpdateCheck', false);
         });
 
         it('should return true', function() {
@@ -41,13 +40,13 @@ describe('Browser: UpdateNotifier', function() {
       describe('given the `sleepUpdateCheck` is enabled', function() {
 
         beforeEach(function() {
-          SettingsModel.set('sleepUpdateCheck', true);
+          settings.set('sleepUpdateCheck', true);
         });
 
         describe('given the `lastUpdateNotify` was never updated', function() {
 
           beforeEach(function() {
-            SettingsModel.set('lastUpdateNotify', undefined);
+            settings.set('lastUpdateNotify', undefined);
           });
 
           it('should return true', function() {
@@ -60,7 +59,7 @@ describe('Browser: UpdateNotifier', function() {
         describe('given the `lastUpdateNotify` was very recently updated', function() {
 
           beforeEach(function() {
-            SettingsModel.set('lastUpdateNotify', Date.now() + 1000);
+            settings.set('lastUpdateNotify', Date.now() + 1000);
           });
 
           it('should return false', function() {
@@ -74,7 +73,7 @@ describe('Browser: UpdateNotifier', function() {
 
           beforeEach(function() {
             const SLEEP_MS = units.daysToMilliseconds(UPDATE_NOTIFIER_SLEEP_DAYS);
-            SettingsModel.set('lastUpdateNotify', Date.now() + SLEEP_MS + 1000);
+            settings.set('lastUpdateNotify', Date.now() + SLEEP_MS + 1000);
           });
 
           it('should return true', function() {
@@ -83,9 +82,9 @@ describe('Browser: UpdateNotifier', function() {
           });
 
           it('should unset the `sleepUpdateCheck` setting', function() {
-            m.chai.expect(SettingsModel.get('sleepUpdateCheck')).to.be.true;
+            m.chai.expect(settings.get('sleepUpdateCheck')).to.be.true;
             UpdateNotifierService.shouldCheckForUpdates();
-            m.chai.expect(SettingsModel.get('sleepUpdateCheck')).to.be.false;
+            m.chai.expect(settings.get('sleepUpdateCheck')).to.be.false;
           });
 
         });

--- a/tests/gui/models/settings.spec.js
+++ b/tests/gui/models/settings.spec.js
@@ -2,69 +2,59 @@
 
 const m = require('mochainon');
 const _ = require('lodash');
-const angular = require('angular');
-require('angular-mocks');
 const Store = require('../../../lib/gui/models/store');
+const settings = require('../../../lib/gui/models/settings');
 
-describe('Browser: SettingsModel', function() {
+describe('Browser: settings', function() {
 
-  beforeEach(angular.mock.module(
-    require('../../../lib/gui/models/settings')
-  ));
-
-  describe('SettingsModel', function() {
+  describe('settings', function() {
 
     const SUPPORTED_KEYS = _.keys(Store.Defaults.get('settings').toJS());
-    let SettingsModel;
-
-    beforeEach(angular.mock.inject(function(_SettingsModel_) {
-      SettingsModel = _SettingsModel_;
-    }));
 
     beforeEach(function() {
-      this.settings = SettingsModel.getAll();
+      this.settings = settings.getAll();
     });
 
     afterEach(function() {
       _.each(SUPPORTED_KEYS, (supportedKey) => {
-        SettingsModel.set(supportedKey, this.settings[supportedKey]);
+        settings.set(supportedKey, this.settings[supportedKey]);
       });
     });
 
     it('should be able to set and read values', function() {
       const keyUnderTest = _.first(SUPPORTED_KEYS);
-      const originalValue = SettingsModel.get(keyUnderTest);
+      const originalValue = settings.get(keyUnderTest);
 
-      SettingsModel.set(keyUnderTest, !originalValue);
-      m.chai.expect(SettingsModel.get(keyUnderTest)).to.equal(!originalValue);
-      SettingsModel.set(keyUnderTest, originalValue);
-      m.chai.expect(SettingsModel.get(keyUnderTest)).to.equal(originalValue);
+      settings.set(keyUnderTest, !originalValue);
+      m.chai.expect(settings.get(keyUnderTest)).to.equal(!originalValue);
+      settings.set(keyUnderTest, originalValue);
+      m.chai.expect(settings.get(keyUnderTest)).to.equal(originalValue);
     });
 
     describe('.set()', function() {
 
       it('should throw if the key is not supported', function() {
         m.chai.expect(function() {
-          SettingsModel.set('foobar', true);
+          settings.set('foobar', true);
         }).to.throw('Unsupported setting: foobar');
       });
 
       it('should throw if no key', function() {
         m.chai.expect(function() {
-          SettingsModel.set(null, true);
+          settings.set(null, true);
         }).to.throw('Missing setting key');
       });
 
       it('should throw if key is not a string', function() {
         m.chai.expect(function() {
-          SettingsModel.set(1234, true);
+          settings.set(1234, true);
         }).to.throw('Invalid setting key: 1234');
       });
 
       it('should throw if setting an object', function() {
         const keyUnderTest = _.first(SUPPORTED_KEYS);
         m.chai.expect(function() {
-          SettingsModel.set(keyUnderTest, {
+          settings.set(keyUnderTest, {
             setting: 1
           });
         }).to.throw('Invalid setting value: [object Object]');
@@ -73,14 +63,14 @@ describe('Browser: SettingsModel', function() {
       it('should throw if setting an array', function() {
         const keyUnderTest = _.first(SUPPORTED_KEYS);
         m.chai.expect(function() {
-          SettingsModel.set(keyUnderTest, [ 1, 2, 3 ]);
+          settings.set(keyUnderTest, [ 1, 2, 3 ]);
         }).to.throw('Invalid setting value: 1,2,3');
       });
 
       it('should set the key to undefined if no value', function() {
         const keyUnderTest = _.first(SUPPORTED_KEYS);
-        SettingsModel.set(keyUnderTest);
-        m.chai.expect(SettingsModel.get(keyUnderTest)).to.be.undefined;
+        settings.set(keyUnderTest);
+        m.chai.expect(settings.get(keyUnderTest)).to.be.undefined;
       });
 
     });
@@ -88,10 +78,10 @@ describe('Browser: SettingsModel', function() {
     describe('.getAll()', function() {
 
       it('should be able to read all values', function() {
-        const allValues = SettingsModel.getAll();
+        const allValues = settings.getAll();
 
         _.each(SUPPORTED_KEYS, function(supportedKey) {
-          m.chai.expect(allValues[supportedKey]).to.equal(SettingsModel.get(supportedKey));
+          m.chai.expect(allValues[supportedKey]).to.equal(settings.get(supportedKey));
         });
       });
 

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -4,6 +4,7 @@ const m = require('mochainon');
 const _ = require('lodash');
 const path = require('path');
 const angular = require('angular');
+const settings = require('../../../lib/gui/models/settings');
 require('angular-mocks');
 
 describe('Browser: MainPage', function() {
@@ -207,12 +208,10 @@ describe('Browser: MainPage', function() {
 
     let $controller;
     let FlashStateModel;
-    let SettingsModel;
 
-    beforeEach(angular.mock.inject(function(_$controller_, _FlashStateModel_, _SettingsModel_) {
+    beforeEach(angular.mock.inject(function(_$controller_, _FlashStateModel_) {
       $controller = _$controller_;
       FlashStateModel = _FlashStateModel_;
-      SettingsModel = _SettingsModel_;
     }));
 
     describe('.getProgressButtonLabel()', function() {
@@ -244,7 +243,7 @@ describe('Browser: MainPage', function() {
             speed: 100000000000000
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('0%');
         });
 
@@ -260,7 +259,7 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
@@ -276,7 +275,7 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          SettingsModel.set('unmountOnSuccess', false);
+          settings.set('unmountOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
@@ -292,7 +291,7 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
@@ -308,7 +307,7 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          SettingsModel.set('unmountOnSuccess', false);
+          settings.set('unmountOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
@@ -324,7 +323,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
         });
 
@@ -340,7 +339,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', false);
+          settings.set('unmountOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
         });
 
@@ -356,7 +355,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
         });
 
@@ -372,7 +371,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', false);
+          settings.set('unmountOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
         });
 
@@ -388,7 +387,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
         });
 
@@ -404,7 +403,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', false);
+          settings.set('unmountOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
         });
 
@@ -420,7 +419,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', true);
+          settings.set('unmountOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Unmounting...');
         });
 
@@ -436,7 +435,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          SettingsModel.set('unmountOnSuccess', false);
+          settings.set('unmountOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
         });
 


### PR DESCRIPTION
We remove the usage of Angular in SettingsModel in our efforts to make
Etcher as agnostic as possible as we make our move to React.

Changelog-Entry: Remove Angular usage from SettingsModel