### PR TITLE
refactor: get rid of `is-elevated`

### DIFF
--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -19,7 +19,6 @@
 const Bluebird = require('bluebird');
 const childProcess = require('child_process');
 const commandJoin = require('command-join');
-const isElevated = require('is-elevated');
 const ipc = require('node-ipc');
 const _ = require('lodash');
 const os = require('os');
@@ -29,6 +28,7 @@ const utils = require('./utils');
 const EXIT_CODES = require('../shared/exit-codes');
 const errors = require('../shared/errors');
 const robot = require('../shared/robot');
+const permissions = require('../shared/permissions');
 const packageJSON = require('../../package.json');
 
 // This script is in charge of spawning the writer process and
@@ -67,7 +67,7 @@ const OPTIONS_INDEX_START = 2;
  */
 const etcherArguments = process.argv.slice(OPTIONS_INDEX_START);
 
-return isElevated().then((elevated) => {
+return permissions.isElevated().then((elevated) => {
 
   if (!elevated) {
     console.log('Attempting to elevate');

--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -18,7 +18,6 @@
 
 const _ = require('lodash');
 const Bluebird = require('bluebird');
-const isElevated = require('is-elevated');
 const visuals = require('resin-cli-visuals');
 const form = require('resin-cli-form');
 const drivelist = Bluebird.promisifyAll(require('drivelist'));
@@ -29,11 +28,12 @@ const robot = require('../shared/robot');
 const messages = require('../shared/messages');
 const EXIT_CODES = require('../shared/exit-codes');
 const errors = require('../shared/errors');
+const permissions = require('../shared/permissions');
 
 const ARGV_IMAGE_PATH_INDEX = 0;
 const imagePath = options._[ARGV_IMAGE_PATH_INDEX];
 
-isElevated().then((elevated) => {
+permissions.isElevated().then((elevated) => {
   if (!elevated) {
     throw errors.createUserError(
       messages.error.elevationRequired(),

--- a/lib/shared/permissions.js
+++ b/lib/shared/permissions.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const os = require('os');
+const Bluebird = require('bluebird');
+const childProcess = Bluebird.promisifyAll(require('child_process'));
+const _ = require('lodash');
+
+/**
+ * @summary The user id of the UNIX "superuser"
+ * @constant
+ * @type {Number}
+ */
+const UNIX_SUPERUSER_USER_ID = 0;
+
+/**
+ * @summary Check if the current process is running with elevated permissions
+ * @function
+ * @public
+ *
+ * @description
+ * This function has been adapted from https://github.com/sindresorhus/is-elevated,
+ * which was originally licensed under MIT.
+ *
+ * We're not using such module directly given that is
+ * contains dependencies with dynamic undeclared dependencies,
+ * causing a mess when trying to concatenate the code.
+ *
+ * @fulfil {Boolean} - whether the current process has elevated permissions
+ * @returns {Promise}
+ *
+ * @example
+ * permissions.isElevated().then((isElevated) => {
+ *   if (isElevated) {
+ *     console.log('This process has elevated permissions');
+ *   }
+ * });
+ */
+exports.isElevated = () => {
+  if (process.platform === 'win32') {
+
+    // `fltmc` is available on WinPE, XP, Vista, 7, 8, and 10
+    // Works even when the "Server" service is disabled
+    // See http://stackoverflow.com/a/28268802
+    return childProcess.execAsync('fltmc')
+      .then(_.constant(true))
+      .catch({
+        code: os.constants.errno.EPERM
+      }, _.constant(false));
+
+  }
+
+  return Bluebird.resolve(process.geteuid() === UNIX_SUPERUSER_USER_ID);
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2704,11 +2704,6 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "dev": true
     },
-    "get-stream": {
-      "version": "3.0.0",
-      "from": "get-stream@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
-    },
     "get-uri": {
       "version": "0.1.4",
       "from": "get-uri@>=0.1.0 <0.2.0",
@@ -3287,33 +3282,6 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "dev": true
     },
-    "is-admin": {
-      "version": "2.1.0",
-      "from": "is-admin@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-admin/-/is-admin-2.1.0.tgz",
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "from": "cross-spawn@>=5.0.1 <6.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
-        },
-        "execa": {
-          "version": "0.6.2",
-          "from": "execa@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.2.tgz"
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "from": "npm-run-path@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "from": "path-key@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
-        }
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "from": "is-arrayish@>=0.2.1 <0.3.0",
@@ -3360,11 +3328,6 @@
       "from": "is-electron-renderer@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
       "dev": true
-    },
-    "is-elevated": {
-      "version": "2.0.1",
-      "from": "is-elevated@2.0.1",
-      "resolved": "https://registry.npmjs.org/is-elevated/-/is-elevated-2.0.1.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
@@ -3497,16 +3460,6 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "dev": true
     },
-    "is-root": {
-      "version": "1.0.0",
-      "from": "is-root@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "from": "is-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
@@ -3544,7 +3497,8 @@
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "dev": true
     },
     "isobject": {
       "version": "0.2.0",
@@ -3555,7 +3509,8 @@
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "dev": true
     },
     "jju": {
       "version": "1.3.0",
@@ -3944,7 +3899,8 @@
     "lru-cache": {
       "version": "4.0.1",
       "from": "lru-cache@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+      "dev": true
     },
     "lzma-native": {
       "version": "1.5.2",
@@ -5171,11 +5127,6 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "dev": true
     },
-    "p-finally": {
-      "version": "1.0.0",
-      "from": "p-finally@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
-    },
     "pac-proxy-agent": {
       "version": "0.2.0",
       "from": "pac-proxy-agent@>=0.0.0 <1.0.0",
@@ -5470,7 +5421,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "from": "pseudomap@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.0",
@@ -6010,16 +5962,6 @@
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "dev": true
     },
-    "shebang-command": {
-      "version": "1.2.0",
-      "from": "shebang-command@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-    },
     "shell-quote": {
       "version": "1.6.1",
       "from": "shell-quote@>=1.6.1 <2.0.0",
@@ -6041,7 +5983,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "dev": true
     },
     "signcode-tf": {
       "version": "0.7.5",
@@ -6349,11 +6292,6 @@
       "version": "2.0.0",
       "from": "strip-bom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "from": "strip-eof@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -6959,7 +6897,8 @@
     "which": {
       "version": "1.2.10",
       "from": "which@>=1.2.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
+      "dev": true
     },
     "which-module": {
       "version": "1.0.0",
@@ -7067,7 +7006,8 @@
     "yallist": {
       "version": "2.0.0",
       "from": "yallist@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+      "dev": true
     },
     "yargs": {
       "version": "4.7.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "flat": "^2.0.1",
     "flexboxgrid": "^6.3.0",
     "immutable": "^3.8.1",
-    "is-elevated": "^2.0.1",
     "lodash": "^4.5.1",
     "lodash-deep": "^2.0.0",
     "lzma-native": "^1.5.2",


### PR DESCRIPTION
This commit implements our own version of the `is-elevated` module. The
reason behind this is that `is-elevated` relies on lots of unnecessary
modules, that eventually require `spawn-sync` and `try-thread-sleep`,
which conditionally require dependencies that are not even declared in
their `package.json`, causing issues when concatenating the Etcher CLI.

See: https://github.com/resin-io/etcher/pull/1235
See: https://github.com/resin-io/etcher/pull/1228
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>