### PR TITLE
fix(GUI): wrap Math.min on ProgressButton controller

### DIFF
--- a/lib/gui/components/progress-button/templates/progress-button.tpl.html
+++ b/lib/gui/components/progress-button/templates/progress-button.tpl.html
@@ -3,5 +3,5 @@
     'progress-button--striped': striped && striped != 'false'
   }">
     <span class="progress-button__content" ng-transclude></span>
-    <span class="progress-button__bar" ng-style="{ width: Math.min(100, percentage) + '%' }"></span>
+    <span class="progress-button__bar" ng-style="{ width: (percentage > 100 ? 100 : percentage) + '%' }"></span>
 </button>


### PR DESCRIPTION
We replace the erroneous direct Math.min usage in ProgressButton's
template with a wrapped version on the controller.

Changelog-Entry: Wrap Math.min on ProgressButton's controller.