### PR TITLE
upgrade: `mountutils` to v1.0.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3555,7 +3555,8 @@
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "dev": true
     },
     "jju": {
       "version": "1.3.0",
@@ -4797,14 +4798,14 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.0.2",
-      "from": "mountutils@1.0.2",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.2.tgz",
+      "version": "1.0.3",
+      "from": "mountutils@1.0.3",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.3.tgz",
       "dependencies": {
         "nan": {
-          "version": "2.5.1",
+          "version": "2.6.1",
           "from": "nan@>=2.5.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lodash": "^4.5.1",
     "lodash-deep": "^2.0.0",
     "lzma-native": "^1.5.2",
-    "mountutils": "^1.0.2",
+    "mountutils": "^1.0.3",
     "node-ipc": "^8.9.2",
     "node-stream-zip": "^1.3.4",
     "path-is-inside": "^1.0.2",


### PR DESCRIPTION
This version contains a fix to make the module work fine on a
concatenated JavaScript file.

See: https://github.com/resin-io-modules/mountutils/pull/23
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>