### PR TITLE
test: Use mocha with promises instead of callbacks

### DIFF
--- a/tests/image-stream/archive-hooks/zip.spec.js
+++ b/tests/image-stream/archive-hooks/zip.spec.js
@@ -34,10 +34,10 @@ describe('ImageStream: Archive hooks: ZIP', function() {
         this.zip = path.join(ZIP_PATH, 'zip-directory-empty.zip');
       });
 
-      it('should become an empty array', function(done) {
-        zipHooks.getEntries(this.zip).then((entries) => {
+      it('should become an empty array', function() {
+        return zipHooks.getEntries(this.zip).then((entries) => {
           m.chai.expect(entries).to.deep.equal([]);
-        }).asCallback(done);
+        });
       });
 
     });
@@ -48,8 +48,8 @@ describe('ImageStream: Archive hooks: ZIP', function() {
         this.zip = path.join(ZIP_PATH, 'zip-directory-multiple-images.zip');
       });
 
-      it('should become all entries', function(done) {
-        zipHooks.getEntries(this.zip).then((entries) => {
+      it('should become all entries', function() {
+        return zipHooks.getEntries(this.zip).then((entries) => {
           m.chai.expect(entries).to.deep.equal([
             {
               name: 'multiple-images/edison-config.img',
@@ -60,7 +60,7 @@ describe('ImageStream: Archive hooks: ZIP', function() {
               size: 33554432
             }
           ]);
-        }).asCallback(done);
+        });
       });
 
     });
@@ -71,8 +71,8 @@ describe('ImageStream: Archive hooks: ZIP', function() {
         this.zip = path.join(ZIP_PATH, 'zip-directory-nested-misc.zip');
       });
 
-      it('should become all entries', function(done) {
-        zipHooks.getEntries(this.zip).then((entries) => {
+      it('should become all entries', function() {
+        return zipHooks.getEntries(this.zip).then((entries) => {
           m.chai.expect(entries).to.deep.equal([
             {
               name: 'zip-directory-nested-misc/foo',
@@ -83,7 +83,7 @@ describe('ImageStream: Archive hooks: ZIP', function() {
               size: 4
             }
           ]);
-        }).asCallback(done);
+        });
       });
 
     });
@@ -96,45 +96,41 @@ describe('ImageStream: Archive hooks: ZIP', function() {
       this.zip = path.join(ZIP_PATH, 'zip-directory-nested-misc.zip');
     });
 
-    it('should be able to extract a top-level file', function(done) {
+    it('should be able to extract a top-level file', function() {
       const fileName = 'zip-directory-nested-misc/foo';
-      zipHooks.getEntries(this.zip).then((entries) => {
+      return zipHooks.getEntries(this.zip).then((entries) => {
         return zipHooks.extractFile(this.zip, entries, fileName);
       }).then(utils.extractStream).then((data) => {
         m.chai.expect(data.toString()).to.equal('foo\n');
-        done();
       });
     });
 
-    it('should be able to extract a nested file', function(done) {
+    it('should be able to extract a nested file', function() {
       const fileName = 'zip-directory-nested-misc/hello/there/bar';
-      zipHooks.getEntries(this.zip).then((entries) => {
+      return zipHooks.getEntries(this.zip).then((entries) => {
         return zipHooks.extractFile(this.zip, entries, fileName);
       }).then(utils.extractStream).then((data) => {
         m.chai.expect(data.toString()).to.equal('bar\n');
-        done();
       });
     });
 
-    it('should throw if the entry does not exist', function(done) {
+    it('should throw if the entry does not exist', function() {
       const fileName = 'zip-directory-nested-misc/xxxxxxxxxxxxxxxx';
-      zipHooks.getEntries(this.zip).then((entries) => {
+      return zipHooks.getEntries(this.zip).then((entries) => {
         return zipHooks.extractFile(this.zip, entries, fileName);
       }).catch((error) => {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.message).to.equal(`Invalid entry: ${fileName}`);
-        done();
       });
     });
 
-    it('should throw if the entry is a directory', function(done) {
+    it('should throw if the entry is a directory', function() {
       const fileName = 'zip-directory-nested-misc/hello';
-      zipHooks.getEntries(this.zip).then((entries) => {
+      return zipHooks.getEntries(this.zip).then((entries) => {
         return zipHooks.extractFile(this.zip, entries, fileName);
       }).catch((error) => {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.message).to.equal(`Invalid entry: ${fileName}`);
-        done();
       });
     });
 

--- a/tests/image-stream/bz2.spec.js
+++ b/tests/image-stream/bz2.spec.js
@@ -41,11 +41,11 @@ describe('ImageStream: BZ2', function() {
 
   describe('.getImageMetadata()', function() {
 
-    it('should return the correct metadata', function(done) {
+    it('should return the correct metadata', function() {
       const image = path.join(BZ2_PATH, 'raspberrypi.img.bz2');
       const expectedSize = fs.statSync(image).size;
 
-      imageStream.getImageMetadata(image).then((metadata) => {
+      return imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
           path: image,
           size: {
@@ -56,7 +56,6 @@ describe('ImageStream: BZ2', function() {
             }
           }
         });
-        done();
       });
     });
 

--- a/tests/image-stream/gz.spec.js
+++ b/tests/image-stream/gz.spec.js
@@ -41,12 +41,12 @@ describe('ImageStream: GZ', function() {
 
   describe('.getImageMetadata()', function() {
 
-    it('should return the correct metadata', function(done) {
+    it('should return the correct metadata', function() {
       const image = path.join(GZ_PATH, 'raspberrypi.img.gz');
       const uncompressedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
       const compressedSize = fs.statSync(path.join(GZ_PATH, 'raspberrypi.img.gz')).size;
 
-      imageStream.getImageMetadata(image).then((metadata) => {
+      return imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
           path: image,
           size: {
@@ -57,7 +57,6 @@ describe('ImageStream: GZ', function() {
             }
           }
         });
-        done();
       });
     });
 

--- a/tests/image-stream/img.spec.js
+++ b/tests/image-stream/img.spec.js
@@ -40,11 +40,11 @@ describe('ImageStream: IMG', function() {
 
   describe('.getImageMetadata()', function() {
 
-    it('should return the correct metadata', function(done) {
+    it('should return the correct metadata', function() {
       const image = path.join(IMAGES_PATH, 'raspberrypi.img');
       const expectedSize = fs.statSync(image).size;
 
-      imageStream.getImageMetadata(image).then((metadata) => {
+      return imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
           path: image,
           size: {
@@ -55,7 +55,6 @@ describe('ImageStream: IMG', function() {
             }
           }
         });
-        done();
       });
     });
 

--- a/tests/image-stream/metadata/zip.spec.js
+++ b/tests/image-stream/metadata/zip.spec.js
@@ -68,42 +68,42 @@ describe('ImageStream: Metadata ZIP', function() {
       archive,
       path.join(IMAGES_PATH, 'raspberrypi.img'));
 
-    it('should read the manifest name property', function(done) {
-      testMetadataProperty(archive, 'name', 'Raspberry Pi').asCallback(done);
+    it('should read the manifest name property', function() {
+      return testMetadataProperty(archive, 'name', 'Raspberry Pi');
     });
 
-    it('should read the manifest version property', function(done) {
-      testMetadataProperty(archive, 'version', '1.0.0').asCallback(done);
+    it('should read the manifest version property', function() {
+      return testMetadataProperty(archive, 'version', '1.0.0');
     });
 
-    it('should read the manifest url property', function(done) {
-      testMetadataProperty(archive, 'url', 'https://www.raspberrypi.org').asCallback(done);
+    it('should read the manifest url property', function() {
+      return testMetadataProperty(archive, 'url', 'https://www.raspberrypi.org');
     });
 
-    it('should read the manifest supportUrl property', function(done) {
+    it('should read the manifest supportUrl property', function() {
       const expectedValue = 'https://www.raspberrypi.org/forums/';
-      testMetadataProperty(archive, 'supportUrl', expectedValue).asCallback(done);
+      return testMetadataProperty(archive, 'supportUrl', expectedValue);
     });
 
-    it('should read the manifest releaseNotesUrl property', function(done) {
+    it('should read the manifest releaseNotesUrl property', function() {
       const expectedValue = 'http://downloads.raspberrypi.org/raspbian/release_notes.txt';
-      testMetadataProperty(archive, 'releaseNotesUrl', expectedValue).asCallback(done);
+      return testMetadataProperty(archive, 'releaseNotesUrl', expectedValue);
     });
 
-    it('should read the manifest checksumType property', function(done) {
-      testMetadataProperty(archive, 'checksumType', 'md5').asCallback(done);
+    it('should read the manifest checksumType property', function() {
+      return testMetadataProperty(archive, 'checksumType', 'md5');
     });
 
-    it('should read the manifest checksum property', function(done) {
-      testMetadataProperty(archive, 'checksum', 'add060b285d512f56c175b76b7ef1bee').asCallback(done);
+    it('should read the manifest checksum property', function() {
+      return testMetadataProperty(archive, 'checksum', 'add060b285d512f56c175b76b7ef1bee');
     });
 
-    it('should read the manifest bytesToZeroOutFromTheBeginning property', function(done) {
-      testMetadataProperty(archive, 'bytesToZeroOutFromTheBeginning', 512).asCallback(done);
+    it('should read the manifest bytesToZeroOutFromTheBeginning property', function() {
+      return testMetadataProperty(archive, 'bytesToZeroOutFromTheBeginning', 512);
     });
 
-    it('should read the manifest recommendedDriveSize property', function(done) {
-      testMetadataProperty(archive, 'recommendedDriveSize', 4294967296).asCallback(done);
+    it('should read the manifest recommendedDriveSize property', function() {
+      return testMetadataProperty(archive, 'recommendedDriveSize', 4294967296);
     });
 
   });
@@ -119,8 +119,8 @@ describe('ImageStream: Metadata ZIP', function() {
       ''
     ].join('\n');
 
-    it('should read the logo contents', function(done) {
-      testMetadataProperty(archive, 'logo', logo).asCallback(done);
+    it('should read the logo contents', function() {
+      return testMetadataProperty(archive, 'logo', logo);
     });
 
   });
@@ -145,8 +145,8 @@ describe('ImageStream: Metadata ZIP', function() {
       ''
     ].join('\n');
 
-    it('should read the bmap contents', function(done) {
-      testMetadataProperty(archive, 'bmap', bmap).asCallback(done);
+    it('should read the bmap contents', function() {
+      return testMetadataProperty(archive, 'bmap', bmap);
     });
 
   });
@@ -162,8 +162,8 @@ describe('ImageStream: Metadata ZIP', function() {
       ''
     ].join('\n');
 
-    it('should read the instruction contents', function(done) {
-      testMetadataProperty(archive, 'instructions', instructions).asCallback(done);
+    it('should read the instruction contents', function() {
+      return testMetadataProperty(archive, 'instructions', instructions);
     });
 
   });

--- a/tests/image-stream/tester.js
+++ b/tests/image-stream/tester.js
@@ -44,22 +44,21 @@ const deleteIfExists = (file) => {
 };
 
 exports.expectError = function(file, errorMessage) {
-  it('should be rejected with an error', function(done) {
-    imageStream.getFromFilePath(file).catch((error) => {
+  it('should be rejected with an error', function() {
+    return imageStream.getFromFilePath(file).catch((error) => {
       m.chai.expect(error).to.be.an.instanceof(Error);
       m.chai.expect(error.message).to.equal(errorMessage);
       m.chai.expect(error.description).to.be.a.string;
       m.chai.expect(error.description.length > 0).to.be.true;
-      done();
     });
   });
 };
 
 exports.extractFromFilePath = function(file, image) {
-  it('should be able to extract the image', function(done) {
+  it('should be able to extract the image', function() {
     const output = tmp.tmpNameSync();
 
-    imageStream.getFromFilePath(file).then(function(results) {
+    return imageStream.getFromFilePath(file).then(function(results) {
       if (!_.some([
         results.size.original === fs.statSync(file).size,
         results.size.original === fs.statSync(image).size
@@ -81,6 +80,6 @@ exports.extractFromFilePath = function(file, image) {
       m.chai.expect(areEqual).to.be.true;
     }).finally(function() {
       return deleteIfExists(output);
-    }).nodeify(done);
+    });
   });
 };

--- a/tests/image-stream/utils.spec.js
+++ b/tests/image-stream/utils.spec.js
@@ -97,11 +97,10 @@ describe('ImageStream: Utils', function() {
         };
       });
 
-      it('should yield the stream data', function(done) {
-        utils.extractStream(this.stream).then((data) => {
+      it('should yield the stream data', function() {
+        return utils.extractStream(this.stream).then((data) => {
           m.chai.expect(data.toString()).to.equal('Hello World');
-          done();
-        }).catch(done);
+        });
       });
 
     });
@@ -121,11 +120,10 @@ describe('ImageStream: Utils', function() {
         };
       });
 
-      it('should be rejected with the error', function(done) {
-        utils.extractStream(this.stream).catch((error) => {
+      it('should be rejected with the error', function() {
+        return utils.extractStream(this.stream).catch((error) => {
           m.chai.expect(error).to.be.an.instanceof(Error);
           m.chai.expect(error.message).to.equal('stream error');
-          done();
         });
       });
 

--- a/tests/image-stream/xz.spec.js
+++ b/tests/image-stream/xz.spec.js
@@ -41,12 +41,12 @@ describe('ImageStream: XZ', function() {
 
   describe('.getImageMetadata()', function() {
 
-    it('should return the correct metadata', function(done) {
+    it('should return the correct metadata', function() {
       const image = path.join(XZ_PATH, 'raspberrypi.img.xz');
       const compressedSize = fs.statSync(image).size;
       const uncompressedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
 
-      imageStream.getImageMetadata(image).then((metadata) => {
+      return imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
           path: image,
           size: {
@@ -57,7 +57,6 @@ describe('ImageStream: XZ', function() {
             }
           }
         });
-        done();
       });
     });
 

--- a/tests/image-stream/zip.spec.js
+++ b/tests/image-stream/zip.spec.js
@@ -65,11 +65,11 @@ describe('ImageStream: ZIP', function() {
 
   describe('.getImageMetadata()', function() {
 
-    it('should return the correct metadata', function(done) {
+    it('should return the correct metadata', function() {
       const image = path.join(ZIP_PATH, 'zip-directory-rpi-only.zip');
       const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
 
-      imageStream.getImageMetadata(image).then((metadata) => {
+      return imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
           path: image,
           size: {
@@ -80,7 +80,6 @@ describe('ImageStream: ZIP', function() {
             }
           }
         });
-        done();
       });
     });
 


### PR DESCRIPTION
This changes the test cases to just return the Promises, to avoid timing out on failures and to provide better error messages and stack traces.

Change-Type: patch