### PR TITLE
chore: fix a CI script to 'properly fail' on Windows

### DIFF
--- a/scripts/ci/ensure-all-node-requirements-available.sh
+++ b/scripts/ci/ensure-all-node-requirements-available.sh
@@ -114,6 +114,9 @@ git ls-tree -r HEAD | while IFS='' read line; do
           exit 1
         fi
       done
+      # see http://unix.stackexchange.com/a/213112
+      err=$?
+      if [[ $err -ne 0 ]]; then exit $err; fi
     fi
   fi
 done


### PR DESCRIPTION
After a lot of experimentation, I eventually found out why https://github.com/resin-io/etcher/pull/1208#issuecomment-291585481 failed on Travis but still passed on Appveyor.

Turns out that `set -e` doesn't work properly in Bash scripts on Windows (I dunno why), so the `exit 1` was only exiting the inner subshell, and not exiting the whole script (the same behaviour could be observed on Linux by commenting out the `set -e` line).

This PR fixes things properly, so that even under Bash on Windows, the `exit 1` error code will still get bubbled all the way up to the top, which would cause `make` to fail, which would cause the Appveryor build to fail as expected.
AFAICT `ensure-all-node-requirements-available.sh` was the only script affected by this issue, as it's the only one that has a subshell pipeline (line 51) nested within an outer loop.