### PR TITLE
fix(image-stream): interpret iso9660 as application/octet-stream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,7 @@ Makefile text
 *.icns binary
 *.ico binary
 *.img binary
+*.iso binary
 *.png binary
 *.xz binary
 *.zip binary

--- a/lib/image-stream/utils.js
+++ b/lib/image-stream/utils.js
@@ -37,10 +37,14 @@ const fs = require('fs');
  * });
  */
 exports.getArchiveMimeType = (filename) => {
-
+  const MIME_TYPE_RAW_IMAGE = 'application/octet-stream';
   const mimeType = mime.lookup(filename);
 
   if (mimeType) {
+    if (mimeType === 'application/x-iso9660-image') {
+      return Bluebird.resolve(MIME_TYPE_RAW_IMAGE);
+    }
+
     return Bluebird.resolve(mimeType);
   }
 
@@ -53,7 +57,7 @@ exports.getArchiveMimeType = (filename) => {
     const buffer = Buffer.alloc(FILE_TYPE_ID_BYTES);
 
     return fs.readAsync(fileDescriptor, buffer, BUFFER_START, FILE_TYPE_ID_BYTES, null).then(() => {
-      return _.get(fileType(buffer), [ 'mime' ], 'application/octet-stream');
+      return _.get(fileType(buffer), [ 'mime' ], MIME_TYPE_RAW_IMAGE);
     });
   });
 

--- a/tests/image-stream/iso.spec.js
+++ b/tests/image-stream/iso.spec.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const fs = require('fs');
+const path = require('path');
+const DATA_PATH = path.join(__dirname, 'data');
+const IMAGES_PATH = path.join(DATA_PATH, 'images');
+const imageStream = require('../../lib/image-stream/index');
+const tester = require('./tester');
+
+describe('ImageStream: ISO', function() {
+
+  this.timeout(20000);
+
+  describe('.getFromFilePath()', function() {
+
+    describe('given an iso image', function() {
+      tester.extractFromFilePath(
+        path.join(IMAGES_PATH, 'raspberrypi.iso'),
+        path.join(IMAGES_PATH, 'raspberrypi.iso'));
+    });
+
+  });
+
+  describe('.getImageMetadata()', function() {
+
+    it('should return the correct metadata', function() {
+      const image = path.join(IMAGES_PATH, 'raspberrypi.iso');
+      const expectedSize = fs.statSync(image).size;
+
+      return imageStream.getImageMetadata(image).then((metadata) => {
+        m.chai.expect(metadata).to.deep.equal({
+          path: image,
+          size: {
+            original: expectedSize,
+            final: {
+              estimation: false,
+              value: expectedSize
+            }
+          }
+        });
+      });
+    });
+
+  });
+
+});

--- a/tests/image-stream/utils.spec.js
+++ b/tests/image-stream/utils.spec.js
@@ -61,6 +61,13 @@ describe('ImageStream: Utils', function() {
       });
     });
 
+    it('should resolve application/octet-stream for an uncompressed iso', function() {
+      const file = path.join(DATA_PATH, 'images', 'raspberrypi.iso');
+      return utils.getArchiveMimeType(file).then((type) => {
+        m.chai.expect(type).to.equal('application/octet-stream');
+      });
+    });
+
     it('should resolve application/x-apple-diskimage for a compressed Apple disk image', function() {
       const file = path.join(DATA_PATH, 'dmg', 'zlib-compressed.dmg');
       return utils.getArchiveMimeType(file).then((type) => {


### PR DESCRIPTION
This is a regression caused by
https://github.com/resin-io/etcher/pull/1257, which introduced a new way
to detect mime types by using the `mime-types` module.

This module, contrary to `file-type`, will detect certain ISO files as
`application/x-iso9660-image`, which Etcher doesn't know how to handle,
and will therefore should at the user that the format is unsupported.

Change-Type: patch
Changelog-Entry: Don't interpret certain ISO images as unsupported.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>