### PR TITLE
fix(image-stream): return a path from the handler

### DIFF
--- a/lib/image-stream/handlers.js
+++ b/lib/image-stream/handlers.js
@@ -142,6 +142,7 @@ module.exports = {
   'application/x-apple-diskimage': (file, options) => {
     return udif.getUncompressedSizeAsync(file).then((size) => {
       return {
+        path: file,
         stream: udif.createReadStream(file),
         size: {
           original: options.size,

--- a/tests/image-stream/dmg.spec.js
+++ b/tests/image-stream/dmg.spec.js
@@ -50,6 +50,7 @@ describe('ImageStream: DMG', function() {
 
         return imageStream.getImageMetadata(image).then((metadata) => {
           m.chai.expect(metadata).to.deep.equal({
+            path: image,
             size: {
               original: compressedSize,
               final: {
@@ -86,6 +87,7 @@ describe('ImageStream: DMG', function() {
 
         return imageStream.getImageMetadata(image).then((metadata) => {
           m.chai.expect(metadata).to.deep.equal({
+            path: image,
             size: {
               original: compressedSize,
               final: {


### PR DESCRIPTION
The `application/x-apple-diskimage` handler doesn't return a path,
causing an issue when fetching the image metadata, and trying using the
path to determine if its a supported image type.

Change-Type: patch
Changelog-Entry: Fix "Path must be a string. Received undefined" when selecting Apple images.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>