### PR TITLE
fix(image-stream): throw user error if image is a directory

### DIFF
--- a/lib/image-stream/index.js
+++ b/lib/image-stream/index.js
@@ -67,12 +67,16 @@ const errors = require('../shared/errors');
  * });
  */
 exports.getFromFilePath = (file) => {
-  return utils.getArchiveMimeType(file).then((type) => {
-    if (!_.has(handlers, type)) {
-      throw errors.createUserError('Invalid image', `The ${type} format is not supported`);
+  return fs.statAsync(file).then((fileStats) => {
+    if (!fileStats.isFile()) {
+      throw errors.createUserError('Invalid image', 'The image must be a file');
     }
 
-    return fs.statAsync(file).then((fileStats) => {
+    return utils.getArchiveMimeType(file).then((type) => {
+      if (!_.has(handlers, type)) {
+        throw errors.createUserError('Invalid image', `The ${type} format is not supported`);
+      }
+
       return _.invoke(handlers, type, file, {
         size: fileStats.size
       });

--- a/tests/image-stream/directory.spec.js
+++ b/tests/image-stream/directory.spec.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const path = require('path');
+const DATA_PATH = path.join(__dirname, 'data');
+const IMAGES_PATH = path.join(DATA_PATH, 'images');
+const errors = require('../../lib/shared/errors');
+const imageStream = require('../../lib/image-stream/index');
+
+describe('ImageStream: Directory', function() {
+
+  this.timeout(20000);
+
+  describe('.getFromFilePath()', function() {
+
+    describe('given a directory', function() {
+
+      it('should be rejected with an error', function(done) {
+        imageStream.getFromFilePath(IMAGES_PATH).catch((error) => {
+          m.chai.expect(error).to.be.an.instanceof(Error);
+          m.chai.expect(errors.getTitle(error)).to.equal('Invalid image');
+          m.chai.expect(errors.getDescription(error)).to.equal('The image must be a file');
+          m.chai.expect(error.report).to.be.false;
+          done();
+        });
+      });
+
+    });
+
+  });
+
+  describe('.getImageMetadata()', function() {
+
+    it('should be rejected with an error', function(done) {
+      imageStream.getImageMetadata(IMAGES_PATH).catch((error) => {
+        m.chai.expect(error).to.be.an.instanceof(Error);
+        m.chai.expect(errors.getTitle(error)).to.equal('Invalid image');
+        m.chai.expect(errors.getDescription(error)).to.equal('The image must be a file');
+        m.chai.expect(error.report).to.be.false;
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
If the user tries to drag and drop a directory to the application, then
he'll get a scary `EISDIR` error message. This commit catches this
error, and display a nice user friendly message instead.

Change-Type: patch
Changelog-Entry: Prevent uncaught `EISDIR` when dropping a directory to the application.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>