### PR TITLE
tests(image-stream): ensure imageStream.getFromFilePath() returns a path

### DIFF
--- a/tests/image-stream/tester.js
+++ b/tests/image-stream/tester.js
@@ -59,6 +59,8 @@ exports.extractFromFilePath = function(file, image) {
     const output = tmp.tmpNameSync();
 
     return imageStream.getFromFilePath(file).then(function(results) {
+      m.chai.expect(results.path).to.equal(file);
+
       if (!_.some([
         results.size.original === fs.statSync(file).size,
         results.size.original === fs.statSync(image).size


### PR DESCRIPTION
This would have prevented https://github.com/resin-io/etcher/pull/1278
from happening.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>