### PR TITLE
fix(CLI): throw error if image is inaccessible

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -107,7 +107,14 @@ module.exports = yargs
 
   // Assert that image exists
   .check((argv) => {
-    fs.accessSync(argv._[IMAGE_PATH_ARGV_INDEX]);
+    const imagePath = argv._[IMAGE_PATH_ARGV_INDEX];
+
+    try {
+      fs.accessSync(imagePath);
+    } catch (error) {
+      throw errors.createUserError('Unable to access file', `The image ${imagePath} is not accessible`);
+    }
+
     return true;
   })
 


### PR DESCRIPTION
Consider the following scenario:

- The user selects an image from an external drive
- The user selects a drive
- The user unmounts/ejects the external drive
- The user clicks flash

The application state will contain an image path that is no longer
accessible, causing an ENOENT error when spawning the CLI process.

Change-Type: patch
Changelog-Entry: Display a user error if the image is no longer accessible when the writer starts.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>