### PR TITLE
tests(image-stream): remove unnecessary big timeout

### DIFF
--- a/tests/image-stream/directory.spec.js
+++ b/tests/image-stream/directory.spec.js
@@ -25,8 +25,6 @@ const imageStream = require('../../lib/image-stream/index');
 
 describe('ImageStream: Directory', function() {
 
-  this.timeout(20000);
-
   describe('.getFromFilePath()', function() {
 
     describe('given a directory', function() {


### PR DESCRIPTION
See: https://github.com/resin-io/etcher/pull/1279#discussion_r110880004
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>