### PR TITLE
upgrade: `etcher-image-write` to v9.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2193,9 +2193,9 @@
       "dev": true
     },
     "etcher-image-write": {
-      "version": "9.0.1",
-      "from": "etcher-image-write@9.0.1",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.0.1.tgz",
+      "version": "9.0.2",
+      "from": "etcher-image-write@9.0.2",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.0.2.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "command-join": "^2.0.0",
     "drivelist": "^5.0.16",
     "electron-is-running-in-asar": "^1.0.0",
-    "etcher-image-write": "^9.0.1",
+    "etcher-image-write": "^9.0.2",
     "etcher-latest-version": "^1.0.0",
     "file-type": "^4.1.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This release fixes an uncaught error when there is a validation error.

See: https://github.com/resin-io-modules/etcher-image-write/pull/94
Change-Type: patch
Changelog-Entry: Fix "function createError(opts) {}" error on validation failure.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>