### PR TITLE
chore(package): Fix codespell binary file warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jslint": "eslint lib tests scripts bin versionist.conf.js",
     "sasslint": "sass-lint lib/gui/scss",
     "htmllint": "node scripts/html-lint.js",
-    "codespell": "codespell.py --skip *.gz,*.bz2,*.xz,*.zip,*.img lib tests docs scripts Makefile *.md LICENSE",
+    "codespell": "codespell.py --skip *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,.DS_Store lib tests docs scripts Makefile *.md LICENSE",
     "lint": "npm run jslint && npm run sasslint && npm run codespell && npm run htmllint",
     "changelog": "versionist",
     "start": "electron lib/start.js",


### PR DESCRIPTION
This avoids codespell printing warnings for binary files
which have been added recently (`.iso`, `.dmg`), as well as dotfiles (i.e. `.DS_Store`).

Change-Type: patch