### PR TITLE
Fix debian package run script

### DIFF
--- a/scripts/build/debian/etcher-electron.sh
+++ b/scripts/build/debian/etcher-electron.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export ETCHER_DISABLE_UPDATES=1
-/usr/share/etcher-electron/etcher "$@"
+/usr/lib/etcher-electron/etcher "$@"


### PR DESCRIPTION
The rc2 debian package is not working because the path where the package files
is installed has changed. The change in paths comes from an upstream change
in the electron-installer-debian node package. So, updating the path here to
match the actuall install location.