### PR TITLE
upgrade: `mountutils` to v1.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4812,9 +4812,9 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.0.3",
-      "from": "mountutils@1.0.3",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.3.tgz",
+      "version": "1.0.4",
+      "from": "mountutils@1.0.4",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.4.tgz",
       "dependencies": {
         "nan": {
           "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lodash": "^4.5.1",
     "lzma-native": "^1.5.2",
     "mime-types": "^2.1.15",
-    "mountutils": "^1.0.3",
+    "mountutils": "^1.0.4",
     "node-ipc": "^8.9.2",
     "node-stream-zip": "^1.3.4",
     "path-is-inside": "^1.0.2",


### PR DESCRIPTION
This version contains a fix for when unmounting a physical drive with no
logical volumes attached.

See: http://github.com/resin-io-modules/mountutils/pull/24
Change-Type: patch
Changelog-Entry: Fix "Unmount failed, invalid drive" error on Windows.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>