### PR TITLE
upgrade: resin-corvus to 1.0.0.beta-24

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5544,9 +5544,9 @@
       }
     },
     "raven-js": {
-      "version": "3.14.0",
+      "version": "3.14.1",
       "from": "raven-js@>=3.12.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.14.0.tgz"
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.14.1.tgz"
     },
     "rc": {
       "version": "1.1.7",
@@ -5846,9 +5846,9 @@
       }
     },
     "resin-corvus": {
-      "version": "1.0.0-beta.20",
+      "version": "1.0.0-beta.24",
       "from": "resin-corvus@latest",
-      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.20.tgz",
+      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.24.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "redux-localstorage": "^0.4.1",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",
-    "resin-corvus": "^1.0.0-beta.20",
+    "resin-corvus": "^1.0.0-beta.24",
     "rx": "^4.1.0",
     "semver": "^5.1.0",
     "sudo-prompt": "^6.1.0",


### PR DESCRIPTION
This version fixes the release not being sent to Mixpanel.

Change-Type: patch
Changelog-Entry: Upgrade `resin-corvus` to 1.0.0.beta-24