### PR TITLE
upgrade: `elevator` to v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   },
   "optionalDependencies": {
-    "elevator": "^2.1.0"
+    "elevator": "^2.2.0"
   },
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
This version contains a patch to output debugging information.

See: https://github.com/resin-io-modules/elevator/pull/9
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>