### PR TITLE
upgrade: `elevator` to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   },
   "optionalDependencies": {
-    "elevator": "^2.2.0"
+    "elevator": "^2.2.1"
   },
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
This version improves the error message if the elevate.exe utility
failed.

See: https://github.com/resin-io-modules/elevator/pull/10
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>