### PR TITLE
fix(GUI): show a friendly message when the drive is unplugged half-way through

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -87,6 +87,12 @@ module.exports = function(
           image,
           drive
         });
+      } else if (error.code === 'EUNPLUGGED') {
+        FlashErrorModalService.show(messages.error.driveUnplugged());
+        AnalyticsService.logEvent('Drive unplugged', {
+          image,
+          drive
+        });
       } else if (error.code === 'ENOSPC') {
         FlashErrorModalService.show(messages.error.notEnoughSpaceInDrive());
         AnalyticsService.logEvent('Out of space', {

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -86,7 +86,13 @@ module.exports = {
 
     elevationRequired: _.template('This should should be run with root/administrator permissions.'),
 
-    flashFailure: _.template('Looks like your flash has failed!')
+    flashFailure: _.template('Looks like your flash has failed!'),
+
+    driveUnplugged: _.template([
+      'Looks like Etcher lost access to the drive.',
+      'Did it get unplugged accidentally?',
+      '\n\nSometimes this error is caused by faulty readers that don\'t provide stable access to the drive.'
+    ].join(' '))
 
   }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -486,9 +486,9 @@
       "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.10.1.tgz"
     },
     "bmapflash": {
-      "version": "1.2.0",
-      "from": "bmapflash@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bmapflash/-/bmapflash-1.2.0.tgz",
+      "version": "1.2.1",
+      "from": "bmapflash@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bmapflash/-/bmapflash-1.2.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -2193,9 +2193,9 @@
       "dev": true
     },
     "etcher-image-write": {
-      "version": "9.0.2",
-      "from": "etcher-image-write@9.0.2",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.0.2.tgz",
+      "version": "9.1.0",
+      "from": "etcher-image-write@9.1.0",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "command-join": "^2.0.0",
     "drivelist": "^5.0.16",
     "electron-is-running-in-asar": "^1.0.0",
-    "etcher-image-write": "^9.0.2",
+    "etcher-image-write": "^9.1.0",
     "etcher-latest-version": "^1.0.0",
     "file-type": "^4.1.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This commit shows a user friendly message when Etcher loses access to
the drive while flashing/validating, and prevents the cryptic errors
from getting to Sentry.

See: https://github.com/resin-io-modules/etcher-image-write/pull/96
Change-Type: minor
Changelog-Entry: Show a user friendly message when the drive is unplugged half-way through.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>