### PR TITLE
upgrade: `mountutils` to v1.0.5

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -25,6 +25,10 @@ const imageStream = require('../image-stream');
 const errors = require('../shared/errors');
 const constraints = require('../shared/drive-constraints');
 
+// Enable extra logging from mountutils
+// See https://github.com/resin-io-modules/mountutils
+process.env.MOUNTUTILS_DEBUG = true;
+
 /**
  * @summary Write an image to a disk drive
  * @function

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4812,9 +4812,9 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.0.4",
-      "from": "mountutils@1.0.4",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.4.tgz",
+      "version": "1.0.5",
+      "from": "mountutils@1.0.5",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.5.tgz",
       "dependencies": {
         "nan": {
           "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "lodash": "^4.5.1",
     "lzma-native": "^1.5.2",
     "mime-types": "^2.1.15",
-    "mountutils": "^1.0.4",
+    "mountutils": "^1.0.5",
     "node-ipc": "^8.9.2",
     "node-stream-zip": "^1.3.4",
     "path-is-inside": "^1.0.2",


### PR DESCRIPTION
This version accepts a `MOUNTUTILS_DEBUG` environment variable to make
the module output extra logging information, which we enable in this
commit as well.

See: https://github.com/resin-io-modules/mountutils/pull/25
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>