### PR TITLE
fix(GUI): correctly log debugging messages on Windows

### DIFF
--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -200,7 +200,12 @@ return permissions.isElevated().then((elevated) => {
             PATH: process.env.PATH,
 
             ELECTRON_RUN_AS_NODE: 1,
-            ETCHER_CLI_ROBOT: 1
+            ETCHER_CLI_ROBOT: 1,
+
+            // Enable extra logging from mountutils
+            // See https://github.com/resin-io-modules/mountutils
+            MOUNTUTILS_DEBUG: 1
+
           }
         });
 

--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -25,10 +25,6 @@ const imageStream = require('../image-stream');
 const errors = require('../shared/errors');
 const constraints = require('../shared/drive-constraints');
 
-// Enable extra logging from mountutils
-// See https://github.com/resin-io-modules/mountutils
-process.env.MOUNTUTILS_DEBUG = true;
-
 /**
  * @summary Write an image to a disk drive
  * @function

--- a/lib/start.js
+++ b/lib/start.js
@@ -16,6 +16,10 @@
 
 'use strict';
 
+// Enable debug information from all modules that use `debug`
+// See https://github.com/visionmedia/debug#browser-support
+process.env.DEBUG = '*';
+
 // See http://electron.atom.io/docs/v0.37.7/api/environment-variables/#electronrunasnode
 //
 // Notice that if running electron with `ELECTRON_RUN_AS_NODE`, the binary


### PR DESCRIPTION
Windows will not react to dynamically set environment variables (e.g:
`process.env.MOUNTUTILS_DEBUG = '1'`), so in order to workaround this
limitation, we set `MOUNTUTILS_DEBUG` in
`lib/child-writer/writer-proxy.js` when spawning the CLI, and we also
set `DEBUG='*'` in `lib/start.js`, so it gets picked up by the child
writer module, which spawns the writer proxy by inheriting the
environment.