### PR TITLE
upgrade: `elevator` to v2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   },
   "optionalDependencies": {
-    "elevator": "^2.2.1"
+    "elevator": "^2.2.2"
   },
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
This version prints debug messages to `stdout`.

See: https://github.com/resin-io-modules/elevator/pull/11
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>