### PR TITLE
upgrade: `etcher-image-write` to v9.1.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2193,9 +2193,9 @@
       "dev": true
     },
     "etcher-image-write": {
-      "version": "9.1.0",
-      "from": "etcher-image-write@9.1.0",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.0.tgz",
+      "version": "9.1.1",
+      "from": "etcher-image-write@9.1.1",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "command-join": "^2.0.0",
     "drivelist": "^5.0.16",
     "electron-is-running-in-asar": "^1.0.0",
-    "etcher-image-write": "^9.1.0",
+    "etcher-image-write": "^9.1.1",
     "etcher-latest-version": "^1.0.0",
     "file-type": "^4.1.0",
     "flexboxgrid": "^6.3.0",


### PR DESCRIPTION
This version includes a fix to throw an `EUNPLUGGED` error instead of an
`UNKNOWN` one when unplugging an SD Card from an internal reader on
Windows.

Change-Type: patch
Changelog-Entry: Fix "UNKNOWN: unknown error" error when unplugging an SD Card from an internal reader on Windows.
See: https://github.com/resin-io-modules/etcher-image-write/pull/97
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>