### PR TITLE
fix(GUI): send an "elevation cancelled" analytics event

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -68,6 +68,10 @@ module.exports = function(
 
     ImageWriterService.flash(image.path, drive).then(() => {
       if (flashState.wasLastFlashCancelled()) {
+        AnalyticsService.logEvent('Elevation cancelled', {
+          image,
+          drive
+        });
         return;
       }
 


### PR DESCRIPTION
If the user cancels the elevation dialog, then no event is emitted,
making it hard to track down what happened after the flash button was
pressed.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>