### PR TITLE
fix(GUI): catch EIO errors and display a user friendly message

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -93,6 +93,12 @@ module.exports = function(
           image,
           drive
         });
+      } else if (error.code === 'EIO') {
+        FlashErrorModalService.show(messages.error.inputOutput());
+        AnalyticsService.logEvent('Input/output error', {
+          image,
+          drive
+        });
       } else if (error.code === 'ENOSPC') {
         FlashErrorModalService.show(messages.error.notEnoughSpaceInDrive());
         AnalyticsService.logEvent('Out of space', {

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -92,6 +92,12 @@ module.exports = {
       'Looks like Etcher lost access to the drive.',
       'Did it get unplugged accidentally?',
       '\n\nSometimes this error is caused by faulty readers that don\'t provide stable access to the drive.'
+    ].join(' ')),
+
+    inputOutput: _.template([
+      'Looks like Etcher is not able to write to this location of the drive.',
+      'This error is usually caused by a faulty drive, reader, or port.',
+      '\n\nPlease try again with another drive, reader, or port.'
     ].join(' '))
 
   }


### PR DESCRIPTION
If we get EIO at this point, then it means that the writer did
everything it could to recover (like multiple retries), and the error
is truly an input/output error coming from the operating system.

In this commit, we show a nice user friendly message explaining what
happened, and advising users to try again with another drive, reader, or
port instead of showing an uncaught EIO error.

Change-Type: patch
Changelog-Entry: Show a friendly user message on EIO after many retries.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>