### PR TITLE
chore: perform GNU/Linux builds on Debian Jessie docker containers

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,4 +1,4 @@
-FROM toopher/ubuntu-i386:14.04
+FROM 32bit/debian:jessie
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM debian:jessie
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,11 +31,11 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'toopher/ubuntu-i386:14.04'
+    image: '32bit/debian:jessie'
   },
   {
     architecture: 'x86_64',
-    image: 'ubuntu:14.04'
+    image: 'debian:jessie'
   }
 ], (options) => {
   const result = _.template(template)(options);

--- a/scripts/build/docker/run-command.sh
+++ b/scripts/build/docker/run-command.sh
@@ -89,6 +89,7 @@ done
 # The `-t` and TERM setup is needed to display coloured output.
 docker run -t \
   --env "TERM=xterm-256color" \
+  --env "TARGET_ARCH=$ARGV_ARCHITECTURE" \
   ${DOCKER_ENVVARS[@]+"${DOCKER_ENVVARS[@]}"} \
   --cap-add SYS_ADMIN \
   --device /dev/fuse:/dev/fuse:mrw \


### PR DESCRIPTION
We recently hit an issue where Etcher builds produced on Ubuntu relied
on a too new glibc version, making them incompatible with GNU/Linux
distributions such as Debian Jessie.

As a solution, we will start producing builds on Debian Jessie, which
ensures that the builds will be compatible with the majority of
GNU/Linux versions out there.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>