### PR TITLE
refactor(errors): add isUserError utility function

### DIFF
--- a/lib/shared/errors.js
+++ b/lib/shared/errors.js
@@ -293,6 +293,25 @@ exports.createUserError = (options) => {
 };
 
 /**
+ * @summary Check if an error is an user error
+ * @function
+ * @public
+ *
+ * @param {Error} error - error
+ * @returns {Boolean} whether the error is a user error
+ *
+ * @example
+ * const error = errors.createUserError('Foo', 'Bar');
+ *
+ * if (errors.isUserError(error)) {
+ *   console.log('This error is a user error');
+ * }
+ */
+exports.isUserError = (error) => {
+  return _.isNil(error.report) ? false : !error.report;
+};
+
+/**
  * @summary Convert an Error object to a JSON object
  * @function
  * @public

--- a/tests/image-stream/directory.spec.js
+++ b/tests/image-stream/directory.spec.js
@@ -34,7 +34,7 @@ describe('ImageStream: Directory', function() {
           m.chai.expect(error).to.be.an.instanceof(Error);
           m.chai.expect(errors.getTitle(error)).to.equal('Invalid image');
           m.chai.expect(errors.getDescription(error)).to.equal('The image must be a file');
-          m.chai.expect(error.report).to.be.false;
+          m.chai.expect(errors.isUserError(error)).to.be.true;
           done();
         });
       });
@@ -50,7 +50,7 @@ describe('ImageStream: Directory', function() {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(errors.getTitle(error)).to.equal('Invalid image');
         m.chai.expect(errors.getDescription(error)).to.equal('The image must be a file');
-        m.chai.expect(error.report).to.be.false;
+        m.chai.expect(errors.isUserError(error)).to.be.true;
         done();
       });
     });

--- a/tests/shared/errors.spec.js
+++ b/tests/shared/errors.spec.js
@@ -389,33 +389,53 @@ describe('Shared: Errors', function() {
 
   describe('.createError()', function() {
 
-    it('should not set `error.report` by default', function() {
+    it('should not be a user error', function() {
       const error = errors.createError({
         title: 'Foo',
         description: 'Something happened'
       });
 
-      m.chai.expect(error.report).to.be.undefined;
+      m.chai.expect(errors.isUserError(error)).to.be.false;
     });
 
-    it('should set `error.report` to false if `options.report` is false', function() {
+    it('should be a user error if `options.report` is false', function() {
       const error = errors.createError({
         title: 'Foo',
         description: 'Something happened',
         report: false
       });
 
-      m.chai.expect(error.report).to.be.false;
+      m.chai.expect(errors.isUserError(error)).to.be.true;
     });
 
-    it('should set `error.report` to false if `options.report` evaluates to false', function() {
+    it('should be a user error if `options.report` evaluates to false', function() {
       const error = errors.createError({
         title: 'Foo',
         description: 'Something happened',
         report: 0
       });
 
-      m.chai.expect(error.report).to.be.false;
+      m.chai.expect(errors.isUserError(error)).to.be.true;
+    });
+
+    it('should not be a user error if `options.report` is true', function() {
+      const error = errors.createError({
+        title: 'Foo',
+        description: 'Something happened',
+        report: true
+      });
+
+      m.chai.expect(errors.isUserError(error)).to.be.false;
+    });
+
+    it('should not be a user error if `options.report` evaluates to true', function() {
+      const error = errors.createError({
+        title: 'Foo',
+        description: 'Something happened',
+        report: 1
+      });
+
+      m.chai.expect(errors.isUserError(error)).to.be.false;
     });
 
     it('should be an instance of Error', function() {
@@ -498,13 +518,13 @@ describe('Shared: Errors', function() {
 
   describe('.createUserError()', function() {
 
-    it('should set the `report` flag to `false`', function() {
+    it('should be a user error', function() {
       const error = errors.createUserError({
         title: 'Foo',
         description: 'Something happened'
       });
 
-      m.chai.expect(error.report).to.be.false;
+      m.chai.expect(errors.isUserError(error)).to.be.true;
     });
 
     it('should be an instance of Error', function() {
@@ -581,6 +601,41 @@ describe('Shared: Errors', function() {
           title: '   '
         });
       }).to.throw('Invalid error title:    ');
+    });
+
+  });
+
+  describe('.isUserError()', function() {
+
+    _.each([
+      0,
+      '',
+      false
+    ], (value) => {
+
+      it(`should return true if report equals ${value}`, function() {
+        const error = new Error('foo bar');
+        error.report = value;
+        m.chai.expect(errors.isUserError(error)).to.be.true;
+      });
+
+    });
+
+    _.each([
+      undefined,
+      null,
+      true,
+      1,
+      3,
+      'foo'
+    ], (value) => {
+
+      it(`should return false if report equals ${value}`, function() {
+        const error = new Error('foo bar');
+        error.report = value;
+        m.chai.expect(errors.isUserError(error)).to.be.false;
+      });
+
     });
 
   });


### PR DESCRIPTION
This utility function is useful to avoid duplicating the logic of
checking whether an error is a user error across the code base.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>