### PR TITLE
upgrade: resin-corvus to 1.0.0-beta.26

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5846,9 +5846,9 @@
       }
     },
     "resin-corvus": {
-      "version": "1.0.0-beta.25",
+      "version": "1.0.0-beta.26",
       "from": "resin-corvus@latest",
-      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.25.tgz",
+      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.26.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "redux-localstorage": "^0.4.1",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",
-    "resin-corvus": "^1.0.0-beta.25",
+    "resin-corvus": "^1.0.0-beta.26",
     "rx": "^4.1.0",
     "semver": "^5.1.0",
     "sudo-prompt": "^6.1.0",


### PR DESCRIPTION
This version solves the issue regarding some messages
getting console logged (and reaching Sentry) as "[object Object]".

Change-Type: patch
Changelog-Entry: Upgrade `resin-corvus` to 1.0.0-beta.26.