### PR TITLE
chore: make electron-installer-debian a development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     }
   },
   "optionalDependencies": {
+    "electron-installer-debian": "^0.5.1",
     "elevator": "^2.2.2"
   },
   "dependencies": {
@@ -95,7 +96,7 @@
     "semver": "^5.1.0",
     "sudo-prompt": "^6.1.0",
     "trackjs": "^2.1.16",
-    "udif": "^0.7.0",
+    "udif": "^0.8.0",
     "unbzip2-stream": "^1.0.11",
     "yargs": "^4.6.0",
     "yauzl": "^2.6.0"

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
-RUN npm install -g asar electron-installer-debian
+RUN npm install -g asar
 
 # Python
 RUN pip install codespell==1.9.2 awscli

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
-RUN npm install -g asar electron-installer-debian
+RUN npm install -g asar
 
 # Python
 RUN pip install codespell==1.9.2 awscli

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
-RUN npm install -g asar electron-installer-debian
+RUN npm install -g asar
 
 # Python
 RUN pip install codespell==1.9.2 awscli

--- a/scripts/build/electron-installer-debian-linux.sh
+++ b/scripts/build/electron-installer-debian-linux.sh
@@ -25,7 +25,9 @@ if [[ "$OS" != "Linux" ]]; then
   exit 1
 fi
 
-./scripts/build/check-dependency.sh electron-installer-debian
+ELECTRON_INSTALLER_DEBIAN="./node_modules/.bin/electron-installer-debian"
+
+./scripts/build/check-dependency.sh "$ELECTRON_INSTALLER_DEBIAN"
 
 function usage() {
   echo "Usage: $0"
@@ -65,7 +67,7 @@ fi
 DEBIAN_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t debian)
 
 cp scripts/build/debian/etcher-electron.sh "$ARGV_DIRECTORY"
-electron-installer-debian \
+"$ELECTRON_INSTALLER_DEBIAN" \
   --src "$ARGV_DIRECTORY" \
   --dest "$ARGV_OUTPUT" \
   --config "$ARGV_DEBIAN_CONFIGURATION" \


### PR DESCRIPTION
We currently require this module to be available in the environment in
order to be able to build debian packages.

This commit adds it as a development dependency, so we can have control
over the version that we use, to prevent any potential incompatibility.

We also update the `udif` package.json version to match what its on the
shrinkwrap file to avoid npm complaining about version mismatches.

See: https://github.com/resin-io/etcher/pull/1290
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>