### PR TITLE
chore: make `asar` a development dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ install:
       ./scripts/build/docker/run-command.sh -r "${TARGET_ARCH}" -s "${PWD}" -c "make info && make electron-develop";
     else
       pip install codespell==1.9.2 awscli;
-      npm install -g asar;
       brew install afsctool jq;
       make info;
       travis_wait make electron-develop;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ matrix:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - npm install -g npm@4.4.4
-  - npm install -g rimraf asar
   - choco install nsis -version 2.51
   - choco install jq
   - choco install curl

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -12,13 +12,11 @@ Prerequisites
 - [NodeJS](https://nodejs.org) (at least v6)
 - [Python](https://www.python.org)
 - [jq](https://stedolan.github.io/jq/)
-- [Asar](https://github.com/electron/asar)
 - [Codespell](https://github.com/lucasdemarchi/codespell)
 - [curl](https://curl.haxx.se/)
 
 ### Windows
 
-- [Rimraf](https://github.com/isaacs/rimraf)
 - [NSIS v2.51](http://nsis.sourceforge.net/Main_Page) (v3.x won't work)
 - Either one of the following:
   - [Visual C++ 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) containing standalone compilers, libraries and scripts

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   },
   "devDependencies": {
     "angular-mocks": "1.6.3",
+    "asar": "^0.10.0",
     "browserify": "^13.0.1",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^3.1.1",

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
-RUN npm install -g asar
 
 # Python
 RUN pip install codespell==1.9.2 awscli

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
-RUN npm install -g asar
 
 # Python
 RUN pip install codespell==1.9.2 awscli

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
-RUN npm install -g asar
 
 # Python
 RUN pip install codespell==1.9.2 awscli

--- a/scripts/build/electron-create-asar.sh
+++ b/scripts/build/electron-create-asar.sh
@@ -19,7 +19,9 @@
 set -u
 set -e
 
-./scripts/build/check-dependency.sh asar
+ASAR="./node_modules/.bin/asar"
+
+./scripts/build/check-dependency.sh "$ASAR"
 
 function usage() {
   echo "Usage: $0"
@@ -49,5 +51,5 @@ fi
 # Omit `*.dll` and `*.node` files from the
 # asar package, otherwise `process.dlopen` and
 # `module.require` can't load them correctly.
-asar pack "$ARGV_DIRECTORY" "$ARGV_OUTPUT" \
+"$ASAR" pack "$ARGV_DIRECTORY" "$ARGV_OUTPUT" \
   --unpack "{*.dll,*.node}"


### PR DESCRIPTION
To prevent any potential version incompatibility caused by simply installing
the latest version of the packages in the CI services.

See: https://github.com/resin-io/etcher/pull/1326
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>