### PR TITLE
upgrade: `elevator` to v2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "optionalDependencies": {
     "electron-installer-debian": "^0.5.1",
-    "elevator": "^2.2.2"
+    "elevator": "^2.2.3"
   },
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
This version contains a fix where an elevation error was not yielded
correctly.

See: https://github.com/resin-io-modules/elevator/pull/12
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>