### PR TITLE
feat(GUI): add a validateWriteOnSuccess property to the flash event

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -63,7 +63,8 @@ module.exports = function(
     AnalyticsService.logEvent('Flash', {
       image,
       drive,
-      unmountOnSuccess: settings.get('unmountOnSuccess')
+      unmountOnSuccess: settings.get('unmountOnSuccess'),
+      validateWriteOnSuccess: settings.get('validateWriteOnSuccess')
     });
 
     ImageWriterService.flash(image.path, drive).then(() => {


### PR DESCRIPTION
This event property will allow us to inspect how many people are running
Etcher without the validation mechanism.

See: https://github.com/resin-io/etcher/issues/1293
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>