### PR TITLE
chore: lock optional dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     }
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^0.5.1",
-    "elevator": "^2.2.3"
+    "electron-installer-debian": "0.5.1",
+    "elevator": "2.2.3"
   },
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
Optional dependencies (and their dependencies) are not tracked by the
shrinkwrap file. In order to prevent incompatibilities, we lock the
versions of all optional dependencies.

See: https://github.com/resin-io/etcher/pull/1304
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>