### PR TITLE
chore(scripts): Remove prune from shrinkwrap cleanup

### DIFF
--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -38,7 +38,5 @@ const npm = (command) => {
 
 npm([ 'rm', '--ignore-scripts' ].concat(shrinkwrapIgnore))
   .once('close', () => {
-    npm([ 'prune' ]).once('close', () => {
-      console.log('Done.');
-    });
+    console.log('Done.');
   });


### PR DESCRIPTION
Newer npm versions (4.4+ I believe) even remove dependencies
not shrinkwrapped yet while pruning causing newly installed dependencies
to not always be shrinkwrapped / updated in the shrinkwrap.
Removing the prune allows for this to work properly again and in the future,
with the drawback that care must be taken to not have extraneous dependencies
in the module tree.

Change-Type: patch