### PR TITLE
chore(package): Update udif to 0.9.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6772,9 +6772,9 @@
       "dev": true
     },
     "udif": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "from": "udif@latest",
-      "resolved": "https://registry.npmjs.org/udif/-/udif-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/udif/-/udif-0.9.0.tgz",
       "dependencies": {
         "base64-js": {
           "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "semver": "^5.1.0",
     "sudo-prompt": "^6.1.0",
     "trackjs": "^2.1.16",
-    "udif": "^0.8.0",
+    "udif": "^0.9.0",
     "unbzip2-stream": "^1.0.11",
     "yargs": "^4.6.0",
     "yauzl": "^2.6.0"


### PR DESCRIPTION
This updates `udif` from 0.8.0 -> 0.9.0, fixing a stall when flashing
certain dmg images due to `UDIF.ReadStream()` overrunning block regions.

See jhermsmeier/node-udif#5

Change-Type: patch
Changelog-Entry: Fix stall / freezing when flashing certain dmg images
Connects To: #1342