### PR TITLE
chore: make use of browserify as a development dependency

### DIFF
--- a/scripts/build/concatenate-javascript.sh
+++ b/scripts/build/concatenate-javascript.sh
@@ -19,7 +19,8 @@
 set -u
 set -e
 
-./scripts/build/check-dependency.sh browserify
+BROWSERIFY="./node_modules/.bin/browserify"
+./scripts/build/check-dependency.sh "$BROWSERIFY"
 
 function usage() {
   echo "Usage: $0"
@@ -46,4 +47,4 @@ if [ -z "$ARGV_ENTRY_POINT" ] || [ -z "$ARGV_OUTPUT" ]; then
   usage
 fi
 
-browserify "$ARGV_ENTRY_POINT" --node --outfile "$ARGV_OUTPUT"
+"$BROWSERIFY" "$ARGV_ENTRY_POINT" --node --outfile "$ARGV_OUTPUT"


### PR DESCRIPTION
This is causing all the snapshot builds to fail when a PR is merged to
master.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>