### PR TITLE
chore: build on Ubuntu 12.04 Docker base images

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,25 +1,34 @@
-FROM 32bit/debian:jessie
+FROM erwinchang/ubuntu-12.04-32bit-build
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  curl \
-  fuse \
-  git \
-  jq \
-  libasound2 \
-  libgconf-2-4 \
-  libgtk2.0-0 \
-  libnss3 \
-  libxss1 \
-  libxtst6 \
-  libyaml-dev \
-  python \
-  python-pip \
-  python-dev \
-  unzip \
-  xvfb \
-  zip
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list \
+  && apt-get update \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    fuse \
+    git \
+    jq \
+    libasound2 \
+    libgconf-2-4 \
+    libgtk2.0-0 \
+    libx11-xcb1 \
+    libnss3 \
+    libxss1 \
+    libxtst6 \
+    libyaml-dev \
+    python \
+    python-pip \
+    python-dev \
+    python-software-properties \
+    unzip \
+    xvfb \
+    zip
+
+# Install a C++11 compiler
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
+  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
+  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -1,25 +1,34 @@
-FROM debian:jessie
+FROM ubuntu:12.04
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  curl \
-  fuse \
-  git \
-  jq \
-  libasound2 \
-  libgconf-2-4 \
-  libgtk2.0-0 \
-  libnss3 \
-  libxss1 \
-  libxtst6 \
-  libyaml-dev \
-  python \
-  python-pip \
-  python-dev \
-  unzip \
-  xvfb \
-  zip
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list \
+  && apt-get update \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    fuse \
+    git \
+    jq \
+    libasound2 \
+    libgconf-2-4 \
+    libgtk2.0-0 \
+    libx11-xcb1 \
+    libnss3 \
+    libxss1 \
+    libxtst6 \
+    libyaml-dev \
+    python \
+    python-pip \
+    python-dev \
+    python-software-properties \
+    unzip \
+    xvfb \
+    zip
+
+# Install a C++11 compiler
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
+  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
+  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -1,25 +1,34 @@
 FROM <%= image %>
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  curl \
-  fuse \
-  git \
-  jq \
-  libasound2 \
-  libgconf-2-4 \
-  libgtk2.0-0 \
-  libnss3 \
-  libxss1 \
-  libxtst6 \
-  libyaml-dev \
-  python \
-  python-pip \
-  python-dev \
-  unzip \
-  xvfb \
-  zip
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list \
+  && apt-get update \
+  && apt-get install -y \
+    build-essential \
+    curl \
+    fuse \
+    git \
+    jq \
+    libasound2 \
+    libgconf-2-4 \
+    libgtk2.0-0 \
+    libx11-xcb1 \
+    libnss3 \
+    libxss1 \
+    libxtst6 \
+    libyaml-dev \
+    python \
+    python-pip \
+    python-dev \
+    python-software-properties \
+    unzip \
+    xvfb \
+    zip
+
+# Install a C++11 compiler
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
+  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
+  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,11 +31,11 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: '32bit/debian:jessie'
+    image: 'erwinchang/ubuntu-12.04-32bit-build'
   },
   {
     architecture: 'x86_64',
-    image: 'debian:jessie'
+    image: 'ubuntu:12.04'
   }
 ], (options) => {
   const result = _.template(template)(options);

--- a/scripts/build/docker/run-command.sh
+++ b/scripts/build/docker/run-command.sh
@@ -91,6 +91,7 @@ docker run -t \
   --env "TERM=xterm-256color" \
   --env "TARGET_ARCH=$ARGV_ARCHITECTURE" \
   ${DOCKER_ENVVARS[@]+"${DOCKER_ENVVARS[@]}"} \
+  --privileged \
   --cap-add SYS_ADMIN \
   --device /dev/fuse:/dev/fuse:mrw \
   --volume "$ARGV_SOURCE_CODE_DIRECTORY:/etcher" \


### PR DESCRIPTION
We recently discovered that users not running latest GNU/Linux
distributions were having problems when Etcher tried to load native
modules. We used to build packages on Ubuntu 16.04, which ships with
GLIBC 2.23.

In order to solve that issue, we moved our build Docker containers to
Debian Jessie, which ships with GLIBC 2.19, however we noticed that
users running even older Linux distributions were still having the same
issue, so this commit switched the Docker containers to Ubuntu 12.04,
which ships with GLIBC 2.15.

See: https://github.com/resin-io/etcher/pull/1319
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>