### PR TITLE
chore: create installers (but don't publish) on every pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
 
 script:
   - ./scripts/ci/travis-test.sh
+  - ./scripts/ci/travis-build-installers.sh
 
 deploy:
   provider: script

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,8 @@ TARGET_ARCH_DEBIAN = $(shell ./scripts/build/architecture-convert.sh -r $(TARGET
 PRODUCT_NAME = etcher
 APPLICATION_NAME_LOWERCASE = $(shell echo $(APPLICATION_NAME) | tr A-Z a-z)
 APPLICATION_VERSION_DEBIAN = $(shell echo $(APPLICATION_VERSION) | tr "-" "~")
+
+# Fix hard link Appveyor issues
 CPRF = cp -RLf
 
 # ---------------------------------------------------------------------
@@ -430,6 +432,7 @@ TARGETS = \
 	package-electron \
 	package-cli \
 	cli-develop \
+	installers-all \
 	electron-develop
 
 package-electron: $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH)
@@ -477,6 +480,8 @@ PUBLISH_AWS_S3 += \
 	$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-win32-$(TARGET_ARCH).exe \
 	$(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH).zip
 endif
+
+installers-all: $(PUBLISH_AWS_S3) $(PUBLISH_BINTRAY_DEBIAN)
 
 ifdef PUBLISH_AWS_S3
 publish-aws-s3: $(PUBLISH_AWS_S3)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,11 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - cmd: .\scripts\ci\appveyor-test.bat
+  - .\scripts\ci\appveyor-test.bat
+  - .\scripts\ci\appveyor-build-installers.bat
 
 deploy_script:
-  - cmd: .\scripts\ci\appveyor-deploy.bat
+  - .\scripts\ci\appveyor-deploy.bat
 
 notifications:
 

--- a/scripts/ci/appveyor-build-installers.bat
+++ b/scripts/ci/appveyor-build-installers.bat
@@ -1,0 +1,24 @@
+@echo off
+
+:: Copyright 2017 resin.io
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+IF "%APPVEYOR_REPO_BRANCH%"=="" (
+  ECHO This script is only meant to run in Appveyor CI 1>&2
+  EXIT /B 1
+)
+
+call make installers-all || ( EXIT /B 1 )
+
+EXIT /B %ERRORLEVEL%

--- a/scripts/ci/travis-build-installers.sh
+++ b/scripts/ci/travis-build-installers.sh
@@ -24,15 +24,13 @@ if [ -z "$TRAVIS_OS_NAME" ]; then
   exit 1
 fi
 
-./scripts/build/check-dependency.sh npm
 ./scripts/build/check-dependency.sh make
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   ./scripts/build/docker/run-command.sh \
     -r "$TARGET_ARCH" \
     -s "$(pwd)" \
-    -c 'make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test'
+    -c 'make installers-all'
 else
-  make sanity-checks
-  npm test
+  make installers-all
 fi


### PR DESCRIPTION
This allows us to catch changes that break our installer builds before
merging the problematic changes.

As a way to simplify the CI configuration files, this commit introduces
an `installers-all` Makefile target that builds all installers.

This commit also replaces all the `cp -rf` calls with `cp -RLf` in
Makefile to avoid some weird hard link Appveyor issues.

See: https://github.com/resin-io/etcher/pull/1078
See: https://github.com/resin-io/etcher/pull/1354
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>