### PR TITLE
chore(gitattributes): Add "hex" diff tag to binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,14 +22,14 @@ Makefile text
 *.yml text
 
 # Binary files (no line-ending conversions)
-*.bz2 binary
-*.gz binary
-*.icns binary
-*.ico binary
-*.img binary
-*.iso binary
-*.png binary
-*.xz binary
-*.zip binary
-*.dmg binary
-*.rpi-sdcard binary
+*.bz2 binary diff=hex
+*.gz binary diff=hex
+*.icns binary diff=hex
+*.ico binary diff=hex
+*.img binary diff=hex
+*.iso binary diff=hex
+*.png binary diff=hex
+*.xz binary diff=hex
+*.zip binary diff=hex
+*.dmg binary diff=hex
+*.rpi-sdcard binary diff=hex


### PR DESCRIPTION
This adds a `diff` tag to binary files in `.gitattributes`,
enabling git to use an external tool to generate diffable output for binary files
by adding a handler to the local or global git config, i.e:

```
[diff "hex"]
  textconv = hexdump
  binary = true
```

![screen shot 2017-04-13 at 03 04 23](https://cloud.githubusercontent.com/assets/244907/25533292/79050ec4-2c30-11e7-83fe-2a6b1fd76d19.png)

Change-Type: patch