### PR TITLE
chore: ensure there are no extraneous or invalid npm dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2555,23 +2555,10 @@
       "from": "form-data@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "dev": true
-        },
         "mime-types": {
-          "version": "2.0.14",
-          "from": "mime-types@>=2.0.3 <2.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "dev": true
+          "version": "2.1.12",
+          "from": "mime-types@>=2.1.12 <3.0.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",

--- a/scripts/ci/ensure-npm-valid-dependencies.sh
+++ b/scripts/ci/ensure-npm-valid-dependencies.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+###
+# Copyright 2017 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -u
+set -e
+
+# This command will exit with an error code if there
+# are invalid or extraneous dependencies, printing the
+# problematic ones if so.
+npm ls


### PR DESCRIPTION
The `npm ls` command will exit with an error code if there are invalid
or extraneous dependencies.

This commits adds that command to `make sanity-checks`, so we can catch
those cases early one.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>