### PR TITLE
chore: remove `etcher-latest-version` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "drivelist": "^5.0.19",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.1.2",
-    "etcher-latest-version": "^1.0.0",
     "file-type": "^4.1.0",
     "flexboxgrid": "^6.3.0",
     "immutable": "^3.8.1",


### PR DESCRIPTION
This version is no longer used, and was removed from the shrinkwrap
file, but for some reason, we forgot to remove it from package.json.

See: https://github.com/resin-io/etcher/pull/1183
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>