### PR TITLE
chore: make `isstream` a top level production development

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3514,8 +3514,7 @@
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jju": {
       "version": "1.3.0",
@@ -4246,11 +4245,6 @@
               "version": "1.0.0",
               "from": "isarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "jodid25519": {
               "version": "1.0.2",


### PR DESCRIPTION
Our `npm-shrinkwrap.json` file contains two entries for the `isstream`
dependency. One of them is in the top level of the file, and marks
`isstream` as a development dependency.

The `request` module makes use of `isstream`, so there is another
instance of `isstream` nested inside `request` which is marked as a
production dependency.

Most NPM versions will realise that there are two instances of
`isstream`, and since one of them is a production development, it will
include it in the final package.

However, there are some NPM version, like 4.6.1, which will only
consider the top level entry, and completely omit `isstream` on the
final package, causing a "Cannot find module 'isstream'" error.

The solution was to manually update the shrinkwrap file to remove the
nested instance, and make the top level instance a production
development.

I don't think there is a way we can protect ourselves from these edge
cases. NPM should have recognised that the dependencies were compatible,
and not create a nested instance on the first place.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>