### PR TITLE
chore: add ensure-npm-valid-dependencies.sh to sanity-checks make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,30 +33,16 @@ os:
   - linux
   - osx
 
-before_install:
-  - npm config set spin=false
-
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/docker/run-command.sh -r "${TARGET_ARCH}" -s "${PWD}" -c "make info && make electron-develop";
-    else
-      pip install codespell==1.9.2 awscli cpplint;
-      brew install afsctool jq;
-      make info;
-      travis_wait make electron-develop;
-    fi
+  - travis_wait ./scripts/ci/travis-install.sh
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ./scripts/build/docker/run-command.sh -r "${TARGET_ARCH}" -s "${PWD}" -c "make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test";
-    else
-      make sanity-checks && npm test;
-    fi
+  - ./scripts/ci/travis-test.sh
 
 deploy:
   provider: script
   skip_cleanup: true
-  script: scripts/ci/deploy-travis.sh
+  script: scripts/ci/travis-deploy.sh
   on:
     branch: master
 

--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,7 @@ sanity-checks:
 	./scripts/ci/ensure-all-node-requirements-available.sh
 	./scripts/ci/ensure-staged-sass.sh
 	./scripts/ci/ensure-npm-dependencies-compatibility.sh
+	./scripts/ci/ensure-npm-valid-dependencies.sh
 	./scripts/ci/ensure-npm-shrinkwrap-versions.sh
 	./scripts/ci/ensure-all-file-extensions-in-gitattributes.sh
 	./scripts/ci/ensure-all-text-files-only-ascii.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,28 +24,21 @@ matrix:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm install -g npm@4.4.4
-  - choco install nsis -version 2.51
-  - choco install jq
-  - choco install curl
   - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
   - set PATH=C:\Program Files (x86)\NSIS;%PATH%
   - set PATH=C:\MinGW\bin;%PATH%
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
-  - pip install codespell==1.9.2 awscli cpplint
-  - make info
-  - make electron-develop
+  - .\scripts\ci\appveyor-install.bat
 
 build: off
 
 test_script:
   - node --version
   - npm --version
-  - make sanity-checks
-  - cmd: npm test
+  - cmd: .\scripts\ci\appveyor-test.bat
 
 deploy_script:
-  - cmd: .\scripts\ci\deploy-appveyor.bat
+  - cmd: .\scripts\ci\appveyor-deploy.bat
 
 notifications:
 

--- a/scripts/ci/appveyor-deploy.bat
+++ b/scripts/ci/appveyor-deploy.bat
@@ -1,0 +1,26 @@
+@echo off
+
+:: Copyright 2017 resin.io
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+IF "%APPVEYOR_REPO_BRANCH%"=="" (
+  ECHO This script is only meant to run in Appveyor CI 1>&2
+  EXIT /B 1
+)
+
+IF %APPVEYOR_REPO_BRANCH%==master (
+  call make publish-aws-s3
+)
+
+EXIT /B %ERRORLEVEL%

--- a/scripts/ci/appveyor-install.bat
+++ b/scripts/ci/appveyor-install.bat
@@ -1,0 +1,34 @@
+@echo off
+
+:: Copyright 2017 resin.io
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+
+IF "%APPVEYOR_REPO_BRANCH%"=="" (
+  ECHO This script is only meant to run in Appveyor CI 1>&2
+  EXIT /B 1
+)
+
+call npm config set spin=false
+call npm install -g npm@4.4.4
+
+call choco install nsis -version 2.51
+call choco install jq
+call choco install curl
+
+call pip install codespell==1.9.2 awscli cpplint
+
+call make info
+call make electron-develop
+
+EXIT /B %ERRORLEVEL%

--- a/scripts/ci/appveyor-test.bat
+++ b/scripts/ci/appveyor-test.bat
@@ -19,8 +19,7 @@ IF "%APPVEYOR_REPO_BRANCH%"=="" (
   EXIT /B 1
 )
 
-IF %APPVEYOR_REPO_BRANCH%==master (
-  make publish-aws-s3
-)
+call make sanity-checks
+call npm test
 
 EXIT /B %ERRORLEVEL%

--- a/scripts/ci/travis-deploy.sh
+++ b/scripts/ci/travis-deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+###
+# Copyright 2017 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -e
+set -u
+
+./scripts/build/check-dependency.sh make
+
+if [ -z "$TRAVIS_OS_NAME" ]; then
+  echo "This script is only meant to run in Travis CI" 1>&2
+  exit 1
+fi
+
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  ./scripts/build/docker/run-command.sh \
+    -r "$TARGET_ARCH" \
+    -s "$(pwd)" \
+    -c "make publish-aws-s3"
+else
+  make publish-aws-s3
+fi

--- a/scripts/ci/travis-install.sh
+++ b/scripts/ci/travis-install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+###
+# Copyright 2017 resin.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+set -e
+set -u
+
+if [ -z "$TRAVIS_OS_NAME" ]; then
+  echo "This script is only meant to run in Travis CI" 1>&2
+  exit 1
+fi
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  ./scripts/build/docker/run-command.sh \
+    -r "$TARGET_ARCH" \
+    -s "$(pwd)" \
+    -c "make info && make electron-develop"
+else
+  ./scripts/build/check-dependency.sh pip
+  ./scripts/build/check-dependency.sh brew
+  ./scripts/build/check-dependency.sh make
+  ./scripts/build/check-dependency.sh npm
+
+  npm install -g npm@3.10.10
+  npm config set spin=false
+
+  pip install codespell==1.9.2 awscli cpplint
+  brew install afsctool jq
+  make info
+  make electron-develop
+fi

--- a/scripts/ci/travis-test.sh
+++ b/scripts/ci/travis-test.sh
@@ -19,15 +19,17 @@
 set -e
 set -u
 
-./scripts/build/check-dependency.sh make
-
 if [ -z "$TRAVIS_OS_NAME" ]; then
   echo "This script is only meant to run in Travis CI" 1>&2
   exit 1
 fi
 
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  ./scripts/build/docker/run-command.sh -r "$TARGET_ARCH" -s "$(pwd)" -c "make publish-aws-s3"
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  ./scripts/build/docker/run-command.sh \
+    -r "$TARGET_ARCH" \
+    -s "$(pwd)" \
+    -c 'make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test'
 else
-  make publish-aws-s3
+  make sanity-checks
+  npm test
 fi


### PR DESCRIPTION
We forgot to do so on the PR that introduces this script.

This commit also moves all the CI code to separate scripts.

See: https://github.com/resin-io/etcher/pull/1371
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>