### PR TITLE
WIP feat(GUI): move settings to an `.etcherrc` JSON file

### DIFF
--- a/lib/gui/models/settings.js
+++ b/lib/gui/models/settings.js
@@ -20,28 +20,11 @@
  * @module Etcher.Models.Settings
  */
 
+const _ = require('lodash');
+const Bluebird = require('bluebird');
 const Store = require('./store');
-
-/**
- * @summary Set a setting value
- * @function
- * @public
- *
- * @param {String} key - setting key
- * @param {*} value - setting value
- *
- * @example
- * settings.set('unmountOnSuccess', true);
- */
-exports.set = (key, value) => {
-  Store.dispatch({
-    type: Store.Actions.SET_SETTING,
-    data: {
-      key,
-      value
-    }
-  });
-};
+const errors = require('../../shared/errors');
+const settings = require('../../shared/settings');
 
 /**
  * @summary Get a setting value
@@ -71,4 +54,47 @@ exports.get = (key) => {
  */
 exports.getAll = () => {
   return Store.getState().get('settings').toJS();
+};
+
+exports.setAll = (object) => {
+  return settings.writeAll(settings.getConfigurationFilePath(), object).then(() => {
+    Store.dispatch({
+      type: Store.Actions.SET_SETTINGS,
+      data: object
+    });
+  });
+};
+
+/**
+ * @summary Set a setting value
+ * @function
+ * @public
+ *
+ * @param {String} key - setting key
+ * @param {*} value - setting value
+ * @returns {Promise}
+ *
+ * @example
+ * settings.set('unmountOnSuccess', true).then(() => {
+ *   console.log('Done!');
+ * });
+ */
+exports.set = (key, value) => {
+  if (_.isNil(key)) {
+    return Bluebird.reject(errors.createError({
+      title: 'Missing setting key'
+    }));
+  }
+
+  if (!_.isString(key)) {
+    return Bluebird.reject(errors.createError({
+      title: `Invalid setting key: ${key}`
+    }));
+  }
+
+  const newSettings = _.merge(exports.getAll(), _.fromPairs([
+    [ key, value ]
+  ]));
+
+  return exports.setAll(newSettings);
 };

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -19,7 +19,6 @@
 const Immutable = require('immutable');
 const _ = require('lodash');
 const redux = require('redux');
-const persistState = require('redux-localstorage');
 const uuidV4 = require('uuid/v4');
 const constraints = require('../../shared/drive-constraints');
 const supportedFormats = require('../../shared/supported-formats');
@@ -55,14 +54,6 @@ const DEFAULT_STATE = Immutable.fromJS({
 });
 
 /**
- * @summary State path to be persisted
- * @type {Object}
- * @constant
- * @private
- */
-const PERSISTED_PATH = 'settings';
-
-/**
  * @summary Application supported action messages
  * @type {Object}
  * @constant
@@ -77,7 +68,7 @@ const ACTIONS = _.fromPairs(_.map([
   'SELECT_IMAGE',
   'REMOVE_DRIVE',
   'REMOVE_IMAGE',
-  'SET_SETTING'
+  'SET_SETTINGS'
 ], (message) => {
   return [ message, message ];
 }));
@@ -450,35 +441,20 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
       return state.deleteIn([ 'selection', 'image' ]);
     }
 
-    case ACTIONS.SET_SETTING: {
-      const key = action.data.key;
-      const value = action.data.value;
-
-      if (!key) {
+    case ACTIONS.SET_SETTINGS: {
+      if (!action.data) {
         throw errors.createError({
-          title: 'Missing setting key'
+          title: 'Missing settings'
         });
       }
 
-      if (!_.isString(key)) {
+      if (!_.isPlainObject(action.data)) {
         throw errors.createError({
-          title: `Invalid setting key: ${key}`
+          title: `Invalid settings: ${action.data}`
         });
       }
 
-      if (!DEFAULT_STATE.get('settings').has(key)) {
-        throw errors.createError({
-          title: `Unsupported setting: ${key}`
-        });
-      }
-
-      if (_.isObject(value)) {
-        throw errors.createError({
-          title: `Invalid setting value: ${value}`
-        });
-      }
-
-      return state.setIn([ 'settings', key ], value);
+      return state.setIn([ 'settings' ], Immutable.fromJS(action.data));
     }
 
     default: {
@@ -488,56 +464,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
   }
 };
 
-module.exports = _.merge(redux.createStore(
-  storeReducer,
-  DEFAULT_STATE,
-  redux.compose(persistState(PERSISTED_PATH, {
-
-    // The following options are set for the sole
-    // purpose of dealing correctly with ImmutableJS
-    // collections.
-    // See: https://github.com/elgerlambert/redux-localstorage#immutable-data
-
-    slicer: (key) => {
-      return (state) => {
-        return state.get(key);
-      };
-    },
-
-    serialize: (collection) => {
-      return JSON.stringify(collection.toJS());
-    },
-
-    deserialize: (data) => {
-      return Immutable.fromJS(JSON.parse(data));
-    },
-
-    merge: (state, subset) => {
-
-      // In the first run, there will be no information
-      // to deserialize. In this case, we avoid merging,
-      // otherwise we will be basically erasing the property
-      // we aim to keep serialising the in future.
-      if (!subset) {
-        return state;
-      }
-
-      // Blindly setting the state to the deserialised subset
-      // means that a user could manually edit `localStorage`
-      // and extend the application state settings with
-      // unsupported properties, since it can bypass validation.
-      //
-      // The alternative, which would be dispatching each
-      // deserialised settins through the appropriate action
-      // is not very elegant, nor performant, so we decide
-      // to intentionally ignore this little flaw since
-      // adding extra properties makes no damage at all.
-      return state.set(PERSISTED_PATH, subset);
-
-    }
-
-  }))
-), {
+module.exports = _.merge(redux.createStore(storeReducer, DEFAULT_STATE), {
   Actions: ACTIONS,
   Defaults: DEFAULT_STATE
 });

--- a/lib/gui/pages/settings/controllers/settings.js
+++ b/lib/gui/pages/settings/controllers/settings.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const os = require('os');
+const Bluebird = require('bluebird');
 const _ = require('lodash');
 const settings = require('../../../models/settings');
 
@@ -88,7 +89,7 @@ module.exports = function(WarningModalService, ErrorService, AnalyticsService) {
     });
 
     if (!value || !dangerous) {
-      return this.model.set(setting, value);
+      return this.model.set(setting, value).catch(ErrorService.reportException);
     }
 
     // Keep the checkbox unchecked until the user confirms
@@ -96,9 +97,10 @@ module.exports = function(WarningModalService, ErrorService, AnalyticsService) {
 
     return WarningModalService.display(options).then((userAccepted) => {
       if (userAccepted) {
-        this.model.set(setting, true);
-        this.refreshSettings();
+        return this.model.set(setting, true).then(this.refreshSettings);
       }
+
+      return Bluebird.resolve();
     }).catch(ErrorService.reportException);
   };
 

--- a/lib/shared/settings.js
+++ b/lib/shared/settings.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const path = require('path');
+const _ = require('lodash');
+const Bluebird = require('bluebird');
+const fs = Bluebird.promisifyAll(require('fs'));
+const os = require('os');
+const errors = require('./errors');
+const packageJSON = require('../../package.json');
+
+/**
+ * @summary Get the file path of the application configuration file
+ * @function
+ * @private
+ *
+ * @returns {String} configuration file path
+ *
+ * @example
+ * const configurationFilePath = settings.getConfigurationFilePath();
+ */
+exports.getConfigurationFilePath = () => {
+  const hiddenFilePrefix = os.platform() === 'win32' ? '_' : '.';
+  return path.join(os.homedir(), `${hiddenFilePrefix}${packageJSON.name}rc`);
+};
+
+/**
+ * @summary Check if a setting value is invalid
+ * @function
+ * @private
+ *
+ * @description
+ * Our settings implementation only supports primitive values.
+ *
+ * @param {*} value - settings value
+ * @returns {Boolean} whether the setting value is invalid
+ *
+ * @example
+ * if (isInvalidSettingValue([ 1, 2, 3 ])) {
+ *   console.log('This setting value is invalid');
+ * }
+ */
+const isInvalidSettingValue = _.overSome([ _.isArray, _.isObject ]);
+
+/**
+ * @summary Read all settings from a configuration file
+ * @function
+ * @public
+ *
+ * @param {String} configurationFilePath - configuration file path
+ * @fulfil {Object} - settings object
+ * @returns {Promise}
+ *
+ * @example
+ * settings.readAll(settings.getConfigurationFilePath()).then((data) => {
+ *   console.log(data);
+ * });
+ */
+exports.readAll = (configurationFilePath) => {
+  return fs.readFileAsync(configurationFilePath, {
+    encoding: 'utf8'
+  }).then((contents) => {
+    if (_.isEmpty(_.trim(contents))) {
+      return {};
+    }
+
+    const result = _.attempt(JSON.parse, contents);
+
+    if (_.isError(result)) {
+      throw errors.createUserError({
+        title: `Invalid settings in ${configurationFilePath}`,
+        description: 'Please fix or delete this file to continue'
+      });
+    }
+
+    return _.omitBy(result, isInvalidSettingValue);
+  }).catch((error) => {
+    if (error.code === 'EPERM' || error.code === 'EACCES') {
+      throw errors.createUserError({
+        title: `Can't access settings in ${configurationFilePath}`,
+        description: 'Please fix or delete this file to continue'
+      });
+    }
+
+    if (error.code === 'ENOENT') {
+      return {};
+    }
+
+    throw error;
+  });
+};
+
+/**
+ * @summary Write all settings to a configuration file
+ * @function
+ * @public
+ *
+ * @description
+ * Note that this function will completely override any settings
+ * on the configuration file.
+ *
+ * @param {String} configurationFilePath - configuration file path
+ * @param {Object} settings - settings object
+ * @returns {Promise}
+ *
+ * @example
+ * settings.writeAll(settings.getConfigurationFilePath(), {
+ *   foo: 'bar'
+ * }).then(() => {
+ *   console.log('Done!');
+ * });
+ */
+exports.writeAll = (configurationFilePath, settings) => {
+  const invalidSettings = _.pickBy(settings, isInvalidSettingValue);
+  const JSON_INDENTATION_SPACES = 2;
+  const serialisedData = JSON.stringify(settings, null, JSON_INDENTATION_SPACES);
+
+  if (!_.isString(serialisedData) || !_.isPlainObject(settings) || !_.isEmpty(invalidSettings)) {
+    return Bluebird.reject(errors.createError({
+      title: 'Invalid settings',
+      description: serialisedData
+    }));
+  }
+
+  return fs.writeFileAsync(configurationFilePath, serialisedData).catch((error) => {
+    if (error.code === 'EPERM' || error.code === 'EACCES') {
+      throw errors.createUserError({
+        title: `Can't access settings in ${configurationFilePath}`,
+        description: 'Please fix or delete this file and try again'
+      });
+    }
+
+    throw error;
+  });
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5705,11 +5705,6 @@
       "from": "redux@>=3.5.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz"
     },
-    "redux-localstorage": {
-      "version": "0.4.1",
-      "from": "redux-localstorage@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz"
-    },
     "regenerator": {
       "version": "0.8.46",
       "from": "regenerator@>=0.8.13 <0.9.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "node-stream-zip": "^1.3.4",
     "path-is-inside": "^1.0.2",
     "redux": "^3.5.2",
-    "redux-localstorage": "^0.4.1",
     "request": "^2.81.0",
     "resin-cli-form": "^1.4.1",
     "resin-cli-visuals": "^1.2.8",

--- a/tests/gui/components/update-notifier.spec.js
+++ b/tests/gui/components/update-notifier.spec.js
@@ -33,7 +33,7 @@ describe('Browser: UpdateNotifier', function() {
         describe('given the `sleepUpdateCheck` is disabled', function() {
 
           beforeEach(function() {
-            settings.set('sleepUpdateCheck', false);
+            return settings.set('sleepUpdateCheck', false);
           });
 
           it('should return true', function() {
@@ -49,13 +49,13 @@ describe('Browser: UpdateNotifier', function() {
         describe('given the `sleepUpdateCheck` is enabled', function() {
 
           beforeEach(function() {
-            settings.set('sleepUpdateCheck', true);
+            return settings.set('sleepUpdateCheck', true);
           });
 
           describe('given the `lastUpdateNotify` was never updated', function() {
 
             beforeEach(function() {
-              settings.set('lastUpdateNotify', undefined);
+              return settings.set('lastUpdateNotify', undefined);
             });
 
             it('should return true', function() {
@@ -71,7 +71,7 @@ describe('Browser: UpdateNotifier', function() {
           describe('given the `lastUpdateNotify` was very recently updated', function() {
 
             beforeEach(function() {
-              settings.set('lastUpdateNotify', Date.now() + 1000);
+              return settings.set('lastUpdateNotify', Date.now() + 1000);
             });
 
             it('should return false', function() {
@@ -88,7 +88,7 @@ describe('Browser: UpdateNotifier', function() {
 
             beforeEach(function() {
               const SLEEP_MS = units.daysToMilliseconds(UPDATE_NOTIFIER_SLEEP_DAYS);
-              settings.set('lastUpdateNotify', Date.now() + SLEEP_MS + 1000);
+              return settings.set('lastUpdateNotify', Date.now() + SLEEP_MS + 1000);
             });
 
             it('should return true', function() {
@@ -124,13 +124,13 @@ describe('Browser: UpdateNotifier', function() {
         describe('given the `sleepUpdateCheck` is enabled', function() {
 
           beforeEach(function() {
-            settings.set('sleepUpdateCheck', true);
+            return settings.set('sleepUpdateCheck', true);
           });
 
           describe('given the `lastUpdateNotify` was very recently updated', function() {
 
             beforeEach(function() {
-              settings.set('lastUpdateNotify', Date.now() + 1000);
+              return settings.set('lastUpdateNotify', Date.now() + 1000);
             });
 
             it('should return true', function() {

--- a/tests/gui/models/settings.spec.js
+++ b/tests/gui/models/settings.spec.js
@@ -7,85 +7,87 @@ const settings = require('../../../lib/gui/models/settings');
 
 describe('Browser: settings', function() {
 
-  describe('settings', function() {
+  const DEFAULT_SETTINGS = Store.Defaults.get('settings').toJS();
 
-    const SUPPORTED_KEYS = _.keys(Store.Defaults.get('settings').toJS());
+  beforeEach(function() {
+    return settings.setAll(DEFAULT_SETTINGS);
+  });
 
-    beforeEach(function() {
-      this.settings = settings.getAll();
+  it('should be able to set and read boolean values', function(done) {
+    settings.set('foo', true).then(() => {
+      m.chai.expect(settings.get('foo')).to.equal(true);
+    }).then(() => {
+      return settings.set('foo', false);
+    }).then(() => {
+      m.chai.expect(settings.get('foo')).to.equal(false);
+      done();
+    }).catch(done);
+  });
+
+  it('should be able to set and read number values', function(done) {
+    settings.set('foo', 1).then(() => {
+      m.chai.expect(settings.get('foo')).to.equal(1);
+    }).then(() => {
+      return settings.set('foo', -50);
+    }).then(() => {
+      m.chai.expect(settings.get('foo')).to.equal(-50);
+      done();
+    }).catch(done);
+  });
+
+  it('should be able to set and read string values', function(done) {
+    settings.set('foo', 'bar').then(() => {
+      m.chai.expect(settings.get('foo')).to.equal('bar');
+    }).then(() => {
+      return settings.set('foo', 'baz');
+    }).then(() => {
+      m.chai.expect(settings.get('foo')).to.equal('baz');
+      done();
+    }).catch(done);
+  });
+
+  describe('.set()', function() {
+
+    it('should throw if no key', function(done) {
+      settings.set(null, true).catch((error) => {
+        m.chai.expect(error.message).to.equal('Missing setting key');
+        done();
+      }).catch(done);
     });
 
-    afterEach(function() {
-      _.each(SUPPORTED_KEYS, (supportedKey) => {
-        settings.set(supportedKey, this.settings[supportedKey]);
-      });
+    it('should throw if key is not a string', function(done) {
+      settings.set(1234, true).catch((error) => {
+        m.chai.expect(error.message).to.equal('Invalid setting key: 1234');
+        done();
+      }).catch(done);
     });
 
-    it('should be able to set and read values', function() {
-      const keyUnderTest = _.first(SUPPORTED_KEYS);
-      const originalValue = settings.get(keyUnderTest);
-
-      settings.set(keyUnderTest, !originalValue);
-      m.chai.expect(settings.get(keyUnderTest)).to.equal(!originalValue);
-      settings.set(keyUnderTest, originalValue);
-      m.chai.expect(settings.get(keyUnderTest)).to.equal(originalValue);
-    });
-
-    describe('.set()', function() {
-
-      it('should throw if the key is not supported', function() {
-        m.chai.expect(function() {
-          settings.set('foobar', true);
-        }).to.throw('Unsupported setting: foobar');
-      });
-
-      it('should throw if no key', function() {
-        m.chai.expect(function() {
-          settings.set(null, true);
-        }).to.throw('Missing setting key');
-      });
-
-      it('should throw if key is not a string', function() {
-        m.chai.expect(function() {
-          settings.set(1234, true);
-        }).to.throw('Invalid setting key: 1234');
-      });
-
-      it('should throw if setting an object', function() {
-        const keyUnderTest = _.first(SUPPORTED_KEYS);
-        m.chai.expect(function() {
-          settings.set(keyUnderTest, {
-            setting: 1
-          });
-        }).to.throw('Invalid setting value: [object Object]');
-      });
-
-      it('should throw if setting an array', function() {
-        const keyUnderTest = _.first(SUPPORTED_KEYS);
-        m.chai.expect(function() {
-          settings.set(keyUnderTest, [ 1, 2, 3 ]);
-        }).to.throw('Invalid setting value: 1,2,3');
-      });
-
-      it('should set the key to undefined if no value', function() {
-        const keyUnderTest = _.first(SUPPORTED_KEYS);
-        settings.set(keyUnderTest);
-        m.chai.expect(settings.get(keyUnderTest)).to.be.undefined;
-      });
-
-    });
-
-    describe('.getAll()', function() {
-
-      it('should be able to read all values', function() {
-        const allValues = settings.getAll();
-
-        _.each(SUPPORTED_KEYS, function(supportedKey) {
-          m.chai.expect(allValues[supportedKey]).to.equal(settings.get(supportedKey));
-        });
-      });
-
+    it('should set the key to undefined if no value', function(done) {
+      settings.set('foo').then(() => {
+        m.chai.expect(settings.get('foo')).to.be.undefined;
+        done();
+      }).catch(done);
     });
 
   });
+
+  describe('.getAll()', function() {
+
+    it('should initially read the default values', function() {
+      const allValues = settings.getAll();
+      m.chai.expect(allValues).to.deep.equal(DEFAULT_SETTINGS);
+    });
+
+    it('should read all values after an update', function(done) {
+      settings.set('foo', 'bar').then(() => {
+        const allValues = settings.getAll();
+        m.chai.expect(allValues).to.deep.equal(_.merge(_.clone(DEFAULT_SETTINGS), {
+          foo: 'bar'
+        }));
+        done();
+      }).catch(done);
+    });
+
+  });
+
 });

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -233,7 +233,7 @@ describe('Browser: MainPage', function() {
           flashState.setFlashingFlag();
         });
 
-        it('should report 0% if percentage == 0 but speed != 0', function() {
+        it('should report 0% if percentage == 0 but speed != 0', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -245,11 +245,13 @@ describe('Browser: MainPage', function() {
             speed: 100000000000000
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('0%');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('0%');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 0, type = write, unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = write, unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -261,11 +263,13 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 0, type = write, !unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = write, !unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -277,11 +281,13 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', false);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+          settings.set('unmountOnSuccess', false).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 0, type = check, unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = check, unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -293,11 +299,13 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 0, type = check, !unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = check, !unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -309,11 +317,13 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', false);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+          settings.set('unmountOnSuccess', false).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 50, type = write, unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = write, unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -325,11 +335,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 50, type = write, !unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = write, !unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -341,11 +353,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
+          settings.set('unmountOnSuccess', false).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 50, type = check, unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = check, unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -357,11 +371,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 50, type = check, !unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = check, !unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -373,11 +389,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
+          settings.set('unmountOnSuccess', false).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 100, type = write, unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = write, unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -389,11 +407,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 100, type = write, !unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = write, !unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -405,11 +425,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
+          settings.set('unmountOnSuccess', false).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 100, type = check, unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = check, unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -421,11 +443,13 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Unmounting...');
+          settings.set('unmountOnSuccess', true).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Unmounting...');
+            done();
+          }).catch(done);
         });
 
-        it('should handle percentage == 100, type = check, !unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = check, !unmountOnSuccess', function(done) {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -437,8 +461,10 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
+          settings.set('unmountOnSuccess', false).then(() => {
+            m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
+            done();
+          }).catch(done);
         });
 
       });

--- a/tests/shared/settings.spec.js
+++ b/tests/shared/settings.spec.js
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2016 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const m = require('mochainon');
+const _ = require('lodash');
+const path = require('path');
+const os = require('os');
+const Bluebird = require('bluebird');
+const fs = Bluebird.promisifyAll(require('fs'));
+const tmp = require('tmp');
+const settings = require('../../lib/shared/settings');
+const errors = require('../../lib/shared/errors');
+const packageJSON = require('../../package.json');
+
+describe('Shared: Settings', function() {
+
+  describe('.getConfigurationFilePath()', function() {
+
+    it('should return an absolute path', function() {
+      m.chai.expect(path.isAbsolute(settings.getConfigurationFilePath())).to.be.true;
+    });
+
+    it('should be a hidden file', function() {
+      const file = path.basename(settings.getConfigurationFilePath());
+
+      if (os.platform() === 'win32') {
+        m.chai.expect(_.first(file)).to.equal('_');
+      } else {
+        m.chai.expect(_.first(file)).to.equal('.');
+      }
+    });
+
+    it('should include the application name in the file name', function() {
+      const file = path.basename(settings.getConfigurationFilePath());
+      m.chai.expect(_.includes(file, packageJSON.name)).to.be.true;
+    });
+
+  });
+
+  describe('.readAll()', function() {
+
+    beforeEach(function() {
+      this.configurationFilePath = tmp.fileSync().name;
+    });
+
+    afterEach(function() {
+      return fs.unlinkAsync(this.configurationFilePath).catch({
+        code: 'ENOENT'
+      }, _.noop);
+    });
+
+    describe('given the file does not exist', function() {
+
+      beforeEach(function() {
+        fs.unlinkSync(this.configurationFilePath);
+      });
+
+      it('should resolve an empty object', function(done) {
+        settings.readAll(this.configurationFilePath).then((data) => {
+          m.chai.expect(data).to.deep.equal({});
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given an empty file', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, '');
+      });
+
+      it('should resolve an empty object', function(done) {
+        settings.readAll(this.configurationFilePath).then((data) => {
+          m.chai.expect(data).to.deep.equal({});
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given the file contains invalid data', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, '<foo>??');
+      });
+
+      it('should be rejected with a user error', function(done) {
+        settings.readAll(this.configurationFilePath).catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.true;
+          m.chai.expect(error.message).to.equal(`Invalid settings in ${this.configurationFilePath}`);
+          done();
+        });
+      });
+
+    });
+
+    _.each([
+      'EPERM',
+      'EACCES'
+    ], (code) => {
+
+      describe(`given reading the file throws ${code}`, function() {
+
+        beforeEach(function() {
+          this.fsReadFileStub = m.sinon.stub(fs, 'readFile');
+          const error = new Error(code);
+          error.code = code;
+          this.fsReadFileStub.yields(error);
+        });
+
+        afterEach(function() {
+          this.fsReadFileStub.restore();
+        });
+
+        it('should be rejected with a user error', function(done) {
+          settings.readAll(this.configurationFilePath).catch((error) => {
+            m.chai.expect(errors.isUserError(error)).to.be.true;
+            m.chai.expect(error.message).to.equal(`Can't access settings in ${this.configurationFilePath}`);
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('given a file with settings', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, JSON.stringify({
+          foo: 'bar',
+          bar: 'baz',
+          baz: 'qux'
+        }));
+      });
+
+      it('should resolve the stored settings', function(done) {
+        settings.readAll(this.configurationFilePath).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            foo: 'bar',
+            bar: 'baz',
+            baz: 'qux'
+          });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given a file with nested settings', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, JSON.stringify({
+          foo: 'bar',
+          bar: {
+            baz: 'hey'
+          },
+          baz: [ 1, 2, 3 ]
+        }));
+      });
+
+      it('should ignore the scalar types', function(done) {
+        settings.readAll(this.configurationFilePath).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            foo: 'bar'
+          });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+  });
+
+  describe('.writeAll()', function() {
+
+    beforeEach(function() {
+      this.configurationFilePath = tmp.fileSync().name;
+    });
+
+    afterEach(function() {
+      return fs.unlinkAsync(this.configurationFilePath).catch({
+        code: 'ENOENT'
+      }, _.noop);
+    });
+
+    describe('given the file does not exist', function() {
+
+      beforeEach(function() {
+        fs.unlinkSync(this.configurationFilePath);
+      });
+
+      it('should completely override the settings', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          hello: 'world'
+        }).then(() => {
+          return settings.readAll(this.configurationFilePath);
+        }).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            hello: 'world'
+          });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given an empty file', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, '');
+      });
+
+      it('should completely override the settings', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          hello: 'world'
+        }).then(() => {
+          return settings.readAll(this.configurationFilePath);
+        }).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            hello: 'world'
+          });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given a file with settings', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, JSON.stringify({
+          foo: 'bar',
+          bar: 'baz',
+          baz: 'qux'
+        }));
+      });
+
+      it('should completely override the settings', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          hello: 'world'
+        }).then(() => {
+          return settings.readAll(this.configurationFilePath);
+        }).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            hello: 'world'
+          });
+          done();
+        }).catch(done);
+      });
+
+      it('should delete settings set to undefined', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          foo: 'bar',
+          bar: undefined,
+          baz: 'qux'
+        }).then(() => {
+          return settings.readAll(this.configurationFilePath);
+        }).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            foo: 'bar',
+            baz: 'qux'
+          });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given the file contains invalid data', function() {
+
+      beforeEach(function() {
+        fs.writeFileSync(this.configurationFilePath, '<foo>??');
+      });
+
+      it('should completely override the settings', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          hello: 'world'
+        }).then(() => {
+          return settings.readAll(this.configurationFilePath);
+        }).then((data) => {
+          m.chai.expect(data).to.deep.equal({
+            hello: 'world'
+          });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given there is an object value', function() {
+
+      it('should be rejected with an error', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          foo: {
+            bar: 'baz'
+          }
+        }).catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.false;
+          m.chai.expect(error.message).to.equal('Invalid settings');
+          done();
+        });
+      });
+
+    });
+
+    describe('given there is an array value', function() {
+
+      it('should be rejected with an error', function(done) {
+        settings.writeAll(this.configurationFilePath, {
+          foo: [ 'bar', 'baz' ]
+        }).catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.false;
+          m.chai.expect(error.message).to.equal('Invalid settings');
+          done();
+        });
+      });
+
+    });
+
+    describe('given the settings are not valid', function() {
+
+      it('should be rejected with an error', function(done) {
+        settings.writeAll(this.configurationFilePath, _.noop).catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.false;
+          m.chai.expect(error.message).to.equal('Invalid settings');
+          done();
+        });
+      });
+
+    });
+
+    describe('given the settings are a string', function() {
+
+      it('should be rejected with an error', function(done) {
+        settings.writeAll(this.configurationFilePath, 'foo').catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.false;
+          m.chai.expect(error.message).to.equal('Invalid settings');
+          done();
+        });
+      });
+
+    });
+
+    describe('given the settings are a number', function() {
+
+      it('should be rejected with an error', function(done) {
+        settings.writeAll(this.configurationFilePath, -456).catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.false;
+          m.chai.expect(error.message).to.equal('Invalid settings');
+          done();
+        });
+      });
+
+    });
+
+    describe('given the settings are an array', function() {
+
+      it('should be rejected with an error', function(done) {
+        settings.writeAll(this.configurationFilePath, [ 1, 2, 3 ]).catch((error) => {
+          m.chai.expect(errors.isUserError(error)).to.be.false;
+          m.chai.expect(error.message).to.equal('Invalid settings');
+          done();
+        });
+      });
+
+    });
+
+    _.each([
+      'EPERM',
+      'EACCES'
+    ], (code) => {
+
+      describe(`given writing the file throws ${code}`, function() {
+
+        beforeEach(function() {
+          this.fsWriteFileStub = m.sinon.stub(fs, 'writeFile');
+          const error = new Error(code);
+          error.code = code;
+          this.fsWriteFileStub.yields(error);
+        });
+
+        afterEach(function() {
+          this.fsWriteFileStub.restore();
+        });
+
+        it('should be rejected with a user error', function(done) {
+          settings.writeAll(this.configurationFilePath, {
+            foo: 'bar'
+          }).catch((error) => {
+            m.chai.expect(errors.isUserError(error)).to.be.true;
+            m.chai.expect(error.message).to.equal(`Can't access settings in ${this.configurationFilePath}`);
+            done();
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
This commit makes Etcher stop storing settings in localStorage, and
instead moves them to a settings file (`.etcherrc`) in the home
directory. This change is motivated by the following reasons:

- The Hard Etcher project needs an easy way to pre-configure Etcher, and
  localStorage is an inaccessible place

- The Redux store is not supposed to contain impure code (e.g: updating
  localStorage)

The below changes can be summarised as:

- Introduce `lib/shared/settings.js`, which handles the gory details of
  reading and writing to/from the setting file in the home directory

- Remove `redux-localstorage`

- Delete the `SET_SETTING` Redux action and add a new `SET_SETTINGS`
  action that is able to set the whole object

- Make the settings model merge the current changes with the new ones
  when the `.set()` function is called

- Make the settings model write to the configuration file before
  updating the Redux store. If there is any error during the write, the
  Redux store is not updated

- Since now we're doing I/O, the `.set()` setting function is now async.
  Update its usage everywhere

See: https://github.com/resin-io/etcher/issues/1356
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>