### PR TITLE
feat(gui): Revert locking down image file extensions

### DIFF
--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -337,21 +337,6 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
         });
       }
 
-      if (!action.data.extension) {
-        throw errors.createError({
-          title: 'Missing image extension'
-        });
-      }
-
-      if (_.some([
-        !_.isString(action.data.extension),
-        !_.includes(supportedFormats.getAllExtensions(), action.data.extension)
-      ])) {
-        throw errors.createError({
-          title: `Invalid image extension: ${action.data.extension}`
-        });
-      }
-
       const lastImageExtension = fileExtensions.getLastFileExtension(action.data.path);
 
       if (lastImageExtension !== action.data.extension) {

--- a/lib/gui/pages/main/controllers/image-selection.js
+++ b/lib/gui/pages/main/controllers/image-selection.js
@@ -20,7 +20,6 @@ const _ = require('lodash');
 const Bluebird = require('bluebird');
 const path = require('path');
 const messages = require('../../../../shared/messages');
-const errors = require('../../../../shared/errors');
 const imageStream = require('../../../../image-stream');
 const supportedFormats = require('../../../../shared/supported-formats');
 const analytics = require('../../../modules/analytics');
@@ -67,20 +66,17 @@ module.exports = function(
    *   .then(ImageSelectionController.selectImage);
    */
   this.selectImage = (image) => {
-    if (!supportedFormats.isSupportedImage(image.path)) {
-      const invalidImageError = errors.createUserError({
-        title: 'Invalid image',
-        description: messages.error.invalidImage({
-          image
-        })
-      });
-
-      OSDialogService.showError(invalidImageError);
-      analytics.logEvent('Invalid image', image);
-      return;
-    }
-
     Bluebird.try(() => {
+      if (!supportedFormats.isSupportedImage(image.path)) {
+        analytics.logEvent('Unrecognised image format', image);
+
+        return WarningModalService.display({
+          confirmationLabel: 'Change',
+          rejectionLabel: 'Continue',
+          description: messages.warning.unrecognisedFormat()
+        });
+      }
+
       if (!supportedFormats.looksLikeWindowsImage(image.path)) {
         return false;
       }

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -61,6 +61,11 @@ module.exports = {
       'Unlike other images, Windows images require special processing to be made bootable.',
       'We suggest you use a tool specially designed for this purpose, such as',
       '<a href="https://rufus.akeo.ie">Rufus</a> (Windows) or Boot Camp Assistant (macOS).'
+    ].join(' ')),
+
+    unrecognisedFormat: _.template([
+      'The image format is not recognised by Etcher.\n',
+      'It will be written as-is.'
     ].join(' '))
 
   },


### PR DESCRIPTION
This reverts minor changes made in https://github.com/resin-io/etcher/pull/1347 and https://github.com/resin-io/etcher/pull/1343 which resulted in user being unable to select images with unrecognised extensions by drag 'n' dropping them into Etcher – which initially was intended.

As it turned out though, there are plenty of other non-standard extensions being used in the wild, like `.rpi-sdimg`, `.sdcard`, etc.

Connects To: #1348
Changelog-Entry: Allow selecting an image of any file extension via drag 'n' drop