### PR TITLE
style(settings): Clarify meaning of the "Report Errors" button

### DIFF
--- a/lib/gui/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/pages/settings/templates/settings.tpl.html
@@ -7,7 +7,7 @@
         ng-model="settings.currentData.errorReporting"
         ng-change="settings.toggle('errorReporting')">
 
-      <span>Report errors</span>
+      <span>Anonymously report errors and usage statistics to resin.io</span>
     </label>
   </div>
 


### PR DESCRIPTION
To make it clear that this actually controls the reporting of errors back to resin.io, and not the reporting of errors to the user.

See #1383 

If we wanted to be even more explicit, we could even change this to "Report errors and statistics back to resin.io" or "Report errors and anonymous statistics back to resin.io" ?  This would better protect the users' privacy, but also _might_ result in more people unticking the box, leading to less reliable statistics?