### PR TITLE
Suggest macOS alternative to Rufus

### DIFF
--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -57,7 +57,7 @@ module.exports = {
       'It looks like you are trying to burn a Windows image.\n\n',
       'Unlike other images, Windows images require special processing to be made bootable.',
       'We suggest you use a tool specially designed for this purpose, such as',
-      '<a href="https://rufus.akeo.ie">Rufus</a>.'
+      '<a href="https://rufus.akeo.ie">Rufus</a> (Windows) or Boot Camp Assistant (macOS).'
     ].join(' '))
 
   },


### PR DESCRIPTION
* Specify that Rufus is only an option for Windows.
* Suggest Apple Boot Camp Assistant (built-in) as an alternative for macOS users.

Not sure what to suggest for Linux other than possibly the following online search:
[`Linux "ms-sys" bootable Windows ISO`](https://duckduckgo.com/?q=Linux%20%22ms-sys%22%20bootable%20Windows%20ISO)