### PR TITLE
chore(CLI): minify Etcher CLI code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERS
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERSION)-$(TARGET_ARCH).js: \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERSION)-$(TARGET_ARCH)-app \
 	| $(BUILD_DIRECTORY)
-	./scripts/build/concatenate-javascript.sh -e $</lib/cli/etcher.js -o $@
+	./scripts/build/concatenate-javascript.sh -e $</lib/cli/etcher.js -o $@ -m
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH): \
 	$(BUILD_DIRECTORY)/node-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies \

--- a/scripts/build/concatenate-javascript.sh
+++ b/scripts/build/concatenate-javascript.sh
@@ -21,6 +21,7 @@ set -e
 
 BROWSERIFY="./node_modules/.bin/browserify"
 ./scripts/build/check-dependency.sh "$BROWSERIFY"
+./scripts/build/check-dependency.sh uglifyjs
 
 function usage() {
   echo "Usage: $0"
@@ -29,16 +30,19 @@ function usage() {
   echo ""
   echo "    -e <entry point (.js)>"
   echo "    -o <output>"
+  echo "    -m minify"
   exit 1
 }
 
 ARGV_ENTRY_POINT=""
 ARGV_OUTPUT=""
+ARGV_MINIFY=false
 
-while getopts ":e:o:" option; do
+while getopts ":e:o:m" option; do
   case $option in
     e) ARGV_ENTRY_POINT=$OPTARG ;;
     o) ARGV_OUTPUT=$OPTARG ;;
+    m) ARGV_MINIFY=true ;;
     *) usage ;;
   esac
 done
@@ -48,3 +52,8 @@ if [ -z "$ARGV_ENTRY_POINT" ] || [ -z "$ARGV_OUTPUT" ]; then
 fi
 
 "$BROWSERIFY" "$ARGV_ENTRY_POINT" --node --outfile "$ARGV_OUTPUT"
+
+if [ "$ARGV_MINIFY" == "true" ]; then
+  uglifyjs --compress --output "$ARGV_OUTPUT.MIN" -- "$ARGV_OUTPUT"
+  mv "$ARGV_OUTPUT.MIN" "$ARGV_OUTPUT"
+fi

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -34,6 +34,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
+RUN npm install -g uglify-es@3.0.3
 
 # Python
 RUN pip install codespell==1.9.2 awscli cpplint

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -34,6 +34,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
+RUN npm install -g uglify-es@3.0.3
 
 # Python
 RUN pip install codespell==1.9.2 awscli cpplint

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -34,6 +34,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
 RUN npm config set spin=false
+RUN npm install -g uglify-es@3.0.3
 
 # Python
 RUN pip install codespell==1.9.2 awscli cpplint

--- a/scripts/ci/appveyor-install.bat
+++ b/scripts/ci/appveyor-install.bat
@@ -20,7 +20,7 @@ IF "%APPVEYOR_REPO_BRANCH%"=="" (
 )
 
 call npm config set spin=false
-call npm install -g npm@4.4.4
+call npm install -g npm@4.4.4 uglify-es@3.0.3
 
 call choco install nsis -version 2.51
 call choco install jq

--- a/scripts/ci/travis-install.sh
+++ b/scripts/ci/travis-install.sh
@@ -35,7 +35,7 @@ else
   ./scripts/build/check-dependency.sh make
   ./scripts/build/check-dependency.sh npm
 
-  npm install -g npm@3.10.10
+  npm install -g npm@3.10.10 uglify-es@3.0.3
   npm config set spin=false
 
   pip install codespell==1.9.2 awscli cpplint


### PR DESCRIPTION
UglifyJS v3 was recently released, which includes support for
compressing ES6 code.

This commit introduces the following changes:

- Add a boolean `-m` option to `concatenate-javascript.sh`, which when
  set, will minify the final concatenated JavaScript file

- Install `uglify-es` in the CI servers

See: https://news.ycombinator.com/item?id=14285179
See: https://github.com/mishoo/UglifyJS2/tree/harmony
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>