### PR TITLE
upgrade: `drivelist` to v5.0.20

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1442,10 +1442,15 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.0.19",
-      "from": "drivelist@5.0.19",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.19.tgz",
+      "version": "5.0.20",
+      "from": "drivelist@5.0.20",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.20.tgz",
       "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "from": "bluebird@>=3.5.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+        },
         "lodash": {
           "version": "4.17.4",
           "from": "lodash@>=4.16.4 <5.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
     "command-join": "^2.0.0",
-    "drivelist": "^5.0.19",
+    "drivelist": "^5.0.20",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.1.3",
     "file-type": "^4.1.0",


### PR DESCRIPTION
This version includes the following fix:

- https://github.com/resin-io-modules/drivelist/pull/164

The above change is also a huge step forward to finalizing the Etcher
CLI packaging story.

See: https://github.com/resin-io/etcher/issues/355
See: https://github.com/resin-io-modules/drivelist/blob/master/CHANGELOG.md
Fixes: https://github.com/resin-io/etcher/issues/1395
Change-Type: patch
Changelog-Entry: Fix error on startup when Windows username contained an ampersand.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>