### PR TITLE
upgrade: `resin-cli-visuals` to v1.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -823,9 +823,9 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-spinner": {
-      "version": "0.2.5",
+      "version": "0.2.6",
       "from": "cli-spinner@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.5.tgz"
+      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz"
     },
     "cli-width": {
       "version": "1.1.1",
@@ -3214,9 +3214,9 @@
       "resolved": "https://registry.npmjs.org/inquirer-dynamic-list/-/inquirer-dynamic-list-1.0.0.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@>=2.10.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "version": "2.11.0",
+          "from": "bluebird@^2.10.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
@@ -3449,6 +3449,11 @@
       "from": "is-primitive@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "from": "is-promise@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
@@ -5886,19 +5891,14 @@
       }
     },
     "resin-cli-visuals": {
-      "version": "1.2.9",
-      "from": "resin-cli-visuals@>=1.2.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.2.9.tgz",
+      "version": "1.3.1",
+      "from": "resin-cli-visuals@1.3.1",
+      "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.3.1.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.10.2",
+          "version": "2.11.0",
           "from": "bluebird@>=2.9.34 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-        },
-        "drivelist": {
-          "version": "3.3.4",
-          "from": "drivelist@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-3.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
@@ -6594,11 +6594,6 @@
           "dev": true
         }
       }
-    },
-    "table-parser": {
-      "version": "0.0.3",
-      "from": "table-parser@0.0.3",
-      "resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.0.3.tgz"
     },
     "tar": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "redux-localstorage": "^0.4.1",
     "request": "^2.81.0",
     "resin-cli-form": "^1.4.1",
-    "resin-cli-visuals": "^1.2.8",
+    "resin-cli-visuals": "^1.3.1",
     "resin-corvus": "^1.0.0-beta.26",
     "rx": "^4.1.0",
     "semver": "^5.1.0",


### PR DESCRIPTION
This version upgrades `drivelist` to v5.0.20, which inlines the scripts
as a JSON file.

See: https://github.com/resin-io-modules/resin-cli-visuals/pull/41
See: https://github.com/resin-io-modules/resin-cli-visuals/blob/master/CHANGELOG.md
See: https://github.com/resin-io/etcher/issues/355
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>

[1.3.0]: https://github.com/resin-io/resin-cli-visuals/compare/v1.2.9...v1.3.0