### PR TITLE
chore: upgrade `npm-shrinkwrap.json` file

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2570,11 +2570,6 @@
       "from": "form-data@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "dependencies": {
-        "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@>=2.1.12 <3.0.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
-        },
         "combined-stream": {
           "version": "1.0.5",
           "from": "combined-stream@^1.0.5",
@@ -2584,6 +2579,16 @@
           "version": "1.0.0",
           "from": "delayed-stream@~1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "mime-db": {
+          "version": "1.24.0",
+          "from": "mime-db@>=1.24.0 <1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.12",
+          "from": "mime-types@>=2.1.12 <3.0.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         }
       }
     },
@@ -4247,6 +4252,11 @@
               "version": "1.0.0",
               "from": "isarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "jodid25519": {
               "version": "1.0.2",


### PR DESCRIPTION
Ensure that the `npm-shrinkwrap.json` is up to date.

These changes were backported from
https://github.com/resin-io/etcher/pull/1379, since it will take a while
for that PR to get merged.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>