### PR TITLE
chore(CLI): fix `cli-develop` Make target headers version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,7 +515,7 @@ endif
 cli-develop:
 	./scripts/build/dependencies-npm.sh \
 		-r "$(TARGET_ARCH)" \
-		-v "$(ELECTRON_VERSION)" \
+		-v "$(NODE_VERSION)" \
 		-t node \
 		-s "$(TARGET_PLATFORM)"
 


### PR DESCRIPTION
The `cli-develop` target was pointing `node-gyp` to the Electron
headers, which caused native add-ons to not work.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>