### PR TITLE
fix(CLI): workaround absolute paths in Browserify bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,7 @@ Makefile text
 *.bat text
 *.svg text
 *.yml text
+*.patch text
 
 # Binary files (no line-ending conversions)
 *.bz2 binary diff=hex

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ $(BUILD_DIRECTORY)/node-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies: package.
 		-x $@ \
 		-t node \
 		-s "$(TARGET_PLATFORM)"
+	git apply --directory $@/node_modules/lzma-native patches/cli/lzma-native-index-static-addon-require.patch
 
 $(BUILD_DIRECTORY)/electron-$(TARGET_PLATFORM)-$(APPLICATION_VERSION)-$(TARGET_ARCH)-app: \
 	$(BUILD_DIRECTORY)/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies \
@@ -247,7 +248,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERS
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERSION)-$(TARGET_ARCH).js: \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERSION)-$(TARGET_ARCH)-app \
 	| $(BUILD_DIRECTORY)
-	./scripts/build/concatenate-javascript.sh -e $</lib/cli/etcher.js -o $@ -m
+	./scripts/build/concatenate-javascript.sh -e lib/cli/etcher.js -b $< -o $@ -m
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(TARGET_PLATFORM)-$(TARGET_ARCH): \
 	$(BUILD_DIRECTORY)/node-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies \

--- a/patches/cli/lzma-native-index-static-addon-require.patch
+++ b/patches/cli/lzma-native-index-static-addon-require.patch
@@ -1,0 +1,17 @@
+diff --git a/index.js b/index.js
+index 1e7c766..e42c513 100644
+--- a/index.js
++++ b/index.js
+@@ -7,11 +7,8 @@ var extend = require('util-extend');
+ var assert = require('assert');
+ var fs = require('fs');
+
+-// node-pre-gyp magic
+-var nodePreGyp = require('node-pre-gyp');
+ var path = require('path');
+-var binding_path = nodePreGyp.find(path.resolve(path.join(__dirname,'./package.json')));
+-var native = require(binding_path);
++var native = require(path.join(__dirname, 'binding', 'lzma_native.node'));
+
+ extend(exports, native);
+

--- a/scripts/build/dependencies-npm-extract-addons.sh
+++ b/scripts/build/dependencies-npm-extract-addons.sh
@@ -51,6 +51,7 @@ rsync \
   --prune-empty-dirs \
   --progress \
   --include='*.node' \
+  --include='*.dll' \
   --include='*/' \
   --exclude='*' \
   "$ARGV_NODE_MODULES" "$ARGV_OUTPUT_DIRECTORY"


### PR DESCRIPTION
For some strange reason, Browserify will hardcode absolute paths from
the machine that generated the bundle to be able to resolve `__dirname`
and `__filename` calls. This makes no sense, given that it means that
the Browserify bundle will not work when we move it to another machine,
which went undetected probably for months.

The Browserify community apparently makes modules to fix this particular
issue (like `bundle-collapser`, and `intreq`), however none of this seem
to solve the problem for the Etcher CLI bundle.

I also gave https://github.com/zeit/pkg a go, however I gave up after
not being able to make use of native modules (nothing seems to work; the
packager result will simply not find the addons).

Finally, I ended up making the following workarounds:

- Edit the Browserify bundle file to use its own `__dirname` to
  dynamically resolve the values of `__dirname` and `__filename` of the
  files it contains

- Patch `lzma-native` to statically require its add-on rather than
  relying on dynamic requires from `node-pre-gyp`, which makes it
  impossible to resolve on the final bundle

See: https://github.com/resin-io/etcher/issues/355
See: http://stackoverflow.com/questions/21993073/browserify-with-paths-to-folders-in-my-system
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>