### PR TITLE
doc(github): Add question about flashed image to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,6 @@
 - **Etcher version:**
 - **Operating system and architecture:**
-- **Do you see any meaningful error information on DevTools?**
+- **Image flashed:**
+- **Do you see any meaningful error information in the DevTools?**
 
 <!-- You can open DevTools by pressing `Ctrl+Alt+I`, or `Cmd+Alt+I` if you're running OS X. -->


### PR DESCRIPTION
This adds another field to the issue template, where a user is prompted to specify the image being flashed, as this question quite often arises and is rarely specified by the user up front.