### PR TITLE
fix(writer): Fully eject device after flashing

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,7 +41,7 @@ Options
   --drive, -d    drive
   --check, -c    validate write
   --yes, -y      confirm non-interactively
-  --unmount, -u  unmount on success
+  --eject, -e    eject on success
 ```
 
 Debug mode

--- a/lib/child-writer/cli.js
+++ b/lib/child-writer/cli.js
@@ -68,7 +68,7 @@ exports.getBooleanArgumentForm = (argumentName, value) => {
  * @param {String} options.device - device
  * @param {String} options.entryPoint - entry point
  * @param {Boolean} [options.validateWriteOnSuccess] - validate write on success
- * @param {Boolean} [options.unmountOnSuccess] - unmount on success
+ * @param {Boolean} [options.ejectOnSuccess] - eject on success
  * @returns {String[]} arguments
  *
  * @example
@@ -77,7 +77,7 @@ exports.getBooleanArgumentForm = (argumentName, value) => {
  *   device: '/dev/disk2'
  *   entryPoint: 'path/to/app.asar',
  *   validateWriteOnSuccess: true,
- *   unmountOnSuccess: true
+ *   ejectOnSuccess: true
  * });
  */
 exports.getArguments = (options) => {
@@ -91,7 +91,7 @@ exports.getArguments = (options) => {
     // or negative way in order to be on the safe
     // side in case the Etcher CLI changes the
     // default value of these options.
-    exports.getBooleanArgumentForm('unmount', options.unmountOnSuccess),
+    exports.getBooleanArgumentForm('eject', options.ejectOnSuccess),
     exports.getBooleanArgumentForm('check', options.validateWriteOnSuccess)
 
   ];

--- a/lib/child-writer/index.js
+++ b/lib/child-writer/index.js
@@ -41,7 +41,7 @@ const robot = require('../shared/robot');
  *   device: '/dev/disk2'
  * }, {
  *   validateWriteOnSuccess: true,
- *   unmountOnSuccess: true
+ *   ejectOnSuccess: true
  * });
  *
  * child.on('progress', (state) => {
@@ -64,7 +64,7 @@ exports.write = (image, drive, options) => {
     image,
     device: drive.device,
     validateWriteOnSuccess: options.validateWriteOnSuccess,
-    unmountOnSuccess: options.unmountOnSuccess
+    ejectOnSuccess: options.ejectOnSuccess
   });
 
   // There might be multiple Etcher instances running at

--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -5,8 +5,8 @@ The Etcher CLI is a command line interface to the Etcher writer backend, and
 currently the only module in the "Etcher" umbrella that makes use of this
 backend directly.
 
-This module also has the task of unmounting the drives before and after
-flashing.
+This module also has the task of unmounting the drives before flashing, and
+ejecting after flashing.
 
 Notice the Etcher CLI is not worried about elevation, and assumes it has enough
 permissions to continue, throwing an error otherwise. Consult the

--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -90,7 +90,7 @@ permissions.isElevated().then((elevated) => {
     }
 
     return writer.writeImage(imagePath, selectedDrive, {
-      unmountOnSuccess: options.unmount,
+      ejectOnSuccess: options.eject,
       validateWriteOnSuccess: options.check
     }, (state) => {
 

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -161,10 +161,10 @@ module.exports = yargs
       boolean: true,
       alias: 'y'
     },
-    unmount: {
-      describe: 'unmount on success',
+    eject: {
+      describe: 'eject on success',
       boolean: true,
-      alias: 'u',
+      alias: 'e',
       default: true
     }
   })

--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -26,6 +26,13 @@ const errors = require('../shared/errors');
 const constraints = require('../shared/drive-constraints');
 
 /**
+ * @summary Time to wait, in milliseconds, before ejecting the device
+ * @constant
+ * @type {Number}
+ */
+const EJECT_TIMEOUT_MS = 2000;
+
+/**
  * @summary Write an image to a disk drive
  * @function
  * @public
@@ -37,7 +44,7 @@ const constraints = require('../shared/drive-constraints');
  * @param {String} imagePath - path to image
  * @param {Object} drive - drive
  * @param {Object} options - options
- * @param {Boolean} [options.unmountOnSuccess=false] - unmount on success
+ * @param {Boolean} [options.ejectOnSuccess=false] - eject on success
  * @param {Boolean} [options.validateWriteOnSuccess=false] - validate write on success
  * @param {Function} onProgress - on progress callback (state)
  *
@@ -48,7 +55,7 @@ const constraints = require('../shared/drive-constraints');
  * writer.writeImage('path/to/image.img', {
  *   device: '/dev/disk2'
  * }, {
- *   unmountOnSuccess: true,
+ *   ejectOnSuccess: true,
  *   validateWriteOnSuccess: true
  * }, (state) => {
  *   console.log(state.percentage);
@@ -104,11 +111,16 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
       // right afterwards in some Windows 7 systems.
       return fs.closeAsync(driveFileDescriptor).then(() => {
 
-        if (!options.unmountOnSuccess) {
+        if (!options.ejectOnSuccess) {
           return Bluebird.resolve();
         }
 
-        return mountutils.unmountDiskAsync(drive.device);
+        // Because Mac OS doesn't like immediate unmounting / ejection
+        // after closing the file handle, as it's busy remounting,
+        // we have to wait a moment for it to be able to succeed
+        return Bluebird.delay(EJECT_TIMEOUT_MS)
+          .return(drive.device)
+          .then(mountutils.ejectAsync);
       });
     });
   });

--- a/lib/gui/models/settings.js
+++ b/lib/gui/models/settings.js
@@ -31,7 +31,7 @@ const Store = require('./store');
  * @param {*} value - setting value
  *
  * @example
- * settings.set('unmountOnSuccess', true);
+ * settings.set('ejectOnSuccess', true);
  */
 exports.set = (key, value) => {
   Store.dispatch({
@@ -52,7 +52,7 @@ exports.set = (key, value) => {
  * @returns {*} setting value
  *
  * @example
- * const value = settings.get('unmountOnSuccess');
+ * const value = settings.get('ejectOnSuccess');
  */
 exports.get = (key) => {
   return this.getAll()[key];
@@ -67,7 +67,7 @@ exports.get = (key) => {
  *
  * @example
  * const allSettings = settings.getAll();
- * console.log(allSettings.unmountOnSuccess);
+ * console.log(allSettings.ejectOnSuccess);
  */
 exports.getAll = () => {
   return Store.getState().get('settings').toJS();

--- a/lib/gui/models/store.js
+++ b/lib/gui/models/store.js
@@ -47,7 +47,7 @@ const DEFAULT_STATE = Immutable.fromJS({
   settings: {
     unsafeMode: false,
     errorReporting: true,
-    unmountOnSuccess: true,
+    ejectOnSuccess: true,
     validateWriteOnSuccess: true,
     sleepUpdateCheck: false,
     includeUnstableUpdateChannel: !release.isStableRelease(packageJSON.version),

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -59,7 +59,7 @@ imageWriter.service('ImageWriterService', function($q, $rootScope) {
     return $q((resolve, reject) => {
       const child = childWriter.write(image, drive, {
         validateWriteOnSuccess: settings.get('validateWriteOnSuccess'),
-        unmountOnSuccess: settings.get('unmountOnSuccess')
+        ejectOnSuccess: settings.get('ejectOnSuccess')
       });
       child.on('error', reject);
       child.on('done', resolve);
@@ -97,7 +97,7 @@ imageWriter.service('ImageWriterService', function($q, $rootScope) {
       image,
       drive,
       uuid: flashState.getFlashUuid(),
-      unmountOnSuccess: settings.get('unmountOnSuccess'),
+      ejectOnSuccess: settings.get('ejectOnSuccess'),
       validateWriteOnSuccess: settings.get('validateWriteOnSuccess')
     };
 

--- a/lib/gui/pages/finish/templates/success.tpl.html
+++ b/lib/gui/pages/finish/templates/success.tpl.html
@@ -2,7 +2,7 @@
   <div class="col-xs">
     <div class="box text-center">
       <h3 class="title"><span class="tick tick--success space-right-tiny"></span> Flash Complete!</h3>
-      <p class="soft space-vertical-small" ng-show="finish.settings.get('unmountOnSuccess')">Safely ejected and ready for use</p>
+      <p class="soft space-vertical-small" ng-show="finish.settings.get('ejectOnSuccess')">Safely ejected and ready for use</p>
 
       <div class="row center-xs space-vertical-medium">
         <div class="col-xs-4 space-medium">

--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -109,8 +109,8 @@ module.exports = function(
     } else if (currentFlashState.percentage === utils.PERCENTAGE_MINIMUM && !currentFlashState.speed) {
       return 'Starting...';
     } else if (currentFlashState.percentage === utils.PERCENTAGE_MAXIMUM) {
-      if (isChecking && settings.get('unmountOnSuccess')) {
-        return 'Unmounting...';
+      if (isChecking && settings.get('ejectOnSuccess')) {
+        return 'Ejecting...';
       }
 
       return 'Finishing...';

--- a/lib/gui/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/pages/settings/templates/settings.tpl.html
@@ -14,19 +14,9 @@
   <div class="checkbox">
     <label>
       <input type="checkbox"
-        ng-model="settings.currentData.unmountOnSuccess"
-        ng-change="settings.toggle('unmountOnSuccess')">
-
-      <!-- On Windows, "Unmounting" basically means "ejecting". -->
-      <!-- On top of that, Windows users are usually not even -->
-      <!-- familiar with the meaning of "unmount", which comes -->
-      <!-- from the UNIX world. -->
-
-      <span>
-        <span ng-show="settings.platform == 'win32'">Eject</span>
-        <span ng-hide="settings.platform == 'win32'">Auto-unmount</span>
-        on success
-      </span>
+        ng-model="settings.currentData.ejectOnSuccess"
+        ng-change="settings.toggle('ejectOnSuccess')">
+      <span>Eject on success</span>
     </label>
   </div>
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4877,14 +4877,14 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.0.6",
-      "from": "mountutils@1.0.6",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.6.tgz",
+      "version": "1.1.0",
+      "from": "mountutils@latest",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.1.0.tgz",
       "dependencies": {
         "nan": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "from": "nan@>=2.5.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lodash": "^4.5.1",
     "lzma-native": "^1.5.2",
     "mime-types": "^2.1.15",
-    "mountutils": "^1.0.6",
+    "mountutils": "^1.1.0",
     "nan": "^2.3.5",
     "node-ipc": "^8.9.2",
     "node-stream-zip": "^1.3.4",

--- a/tests/child-writer/cli.spec.js
+++ b/tests/child-writer/cli.spec.js
@@ -43,70 +43,70 @@ describe('ChildWriter CLI', function() {
 
   describe('.getArguments()', function() {
 
-    it('should return a list of arguments given validate = false, unmount = false', function() {
+    it('should return a list of arguments given validate = false, eject = false', function() {
       m.chai.expect(cli.getArguments({
         image: 'path/to/image.img',
         device: '/dev/disk2',
         entryPoint: 'path/to/app.asar',
         validateWriteOnSuccess: false,
-        unmountOnSuccess: false
+        ejectOnSuccess: false
       })).to.deep.equal([
         'path/to/app.asar',
         'path/to/image.img',
         '--drive',
         '/dev/disk2',
-        '--no-unmount',
+        '--no-eject',
         '--no-check'
       ]);
     });
 
-    it('should return a list of arguments given validate = false, unmount = true', function() {
+    it('should return a list of arguments given validate = false, eject = true', function() {
       m.chai.expect(cli.getArguments({
         image: 'path/to/image.img',
         device: '/dev/disk2',
         entryPoint: 'path/to/app.asar',
         validateWriteOnSuccess: false,
-        unmountOnSuccess: true
+        ejectOnSuccess: true
       })).to.deep.equal([
         'path/to/app.asar',
         'path/to/image.img',
         '--drive',
         '/dev/disk2',
-        '--unmount',
+        '--eject',
         '--no-check'
       ]);
     });
 
-    it('should return a list of arguments given validate = true, unmount = false', function() {
+    it('should return a list of arguments given validate = true, eject = false', function() {
       m.chai.expect(cli.getArguments({
         image: 'path/to/image.img',
         device: '/dev/disk2',
         entryPoint: 'path/to/app.asar',
         validateWriteOnSuccess: true,
-        unmountOnSuccess: false
+        ejectOnSuccess: false
       })).to.deep.equal([
         'path/to/app.asar',
         'path/to/image.img',
         '--drive',
         '/dev/disk2',
-        '--no-unmount',
+        '--no-eject',
         '--check'
       ]);
     });
 
-    it('should return a list of arguments given validate = true, unmount = true', function() {
+    it('should return a list of arguments given validate = true, eject = true', function() {
       m.chai.expect(cli.getArguments({
         image: 'path/to/image.img',
         device: '/dev/disk2',
         entryPoint: 'path/to/app.asar',
         validateWriteOnSuccess: true,
-        unmountOnSuccess: true
+        ejectOnSuccess: true
       })).to.deep.equal([
         'path/to/app.asar',
         'path/to/image.img',
         '--drive',
         '/dev/disk2',
-        '--unmount',
+        '--eject',
         '--check'
       ]);
     });

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -245,11 +245,11 @@ describe('Browser: MainPage', function() {
             speed: 100000000000000
           });
 
-          settings.set('unmountOnSuccess', true);
+          settings.set('ejectOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('0%');
         });
 
-        it('should handle percentage == 0, type = write, unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = write, ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -261,11 +261,11 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', true);
+          settings.set('ejectOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
-        it('should handle percentage == 0, type = write, !unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = write, !ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -277,11 +277,11 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', false);
+          settings.set('ejectOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
-        it('should handle percentage == 0, type = check, unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = check, ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -293,11 +293,11 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', true);
+          settings.set('ejectOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
-        it('should handle percentage == 0, type = check, !unmountOnSuccess', function() {
+        it('should handle percentage == 0, type = check, !ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -309,11 +309,11 @@ describe('Browser: MainPage', function() {
             speed: 0
           });
 
-          settings.set('unmountOnSuccess', false);
+          settings.set('ejectOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Starting...');
         });
 
-        it('should handle percentage == 50, type = write, unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = write, ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -325,11 +325,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
+          settings.set('ejectOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
         });
 
-        it('should handle percentage == 50, type = write, !unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = write, !ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -341,11 +341,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
+          settings.set('ejectOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50%');
         });
 
-        it('should handle percentage == 50, type = check, unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = check, ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -357,11 +357,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
+          settings.set('ejectOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
         });
 
-        it('should handle percentage == 50, type = check, !unmountOnSuccess', function() {
+        it('should handle percentage == 50, type = check, !ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -373,11 +373,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
+          settings.set('ejectOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('50% Validating...');
         });
 
-        it('should handle percentage == 100, type = write, unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = write, ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -389,11 +389,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
+          settings.set('ejectOnSuccess', true);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
         });
 
-        it('should handle percentage == 100, type = write, !unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = write, !ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -405,11 +405,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
+          settings.set('ejectOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
         });
 
-        it('should handle percentage == 100, type = check, unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = check, ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -421,11 +421,11 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', true);
-          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Unmounting...');
+          settings.set('ejectOnSuccess', true);
+          m.chai.expect(controller.getProgressButtonLabel()).to.equal('Ejecting...');
         });
 
-        it('should handle percentage == 100, type = check, !unmountOnSuccess', function() {
+        it('should handle percentage == 100, type = check, !ejectOnSuccess', function() {
           const controller = $controller('FlashController', {
             $scope: {}
           });
@@ -437,7 +437,7 @@ describe('Browser: MainPage', function() {
             speed: 1000
           });
 
-          settings.set('unmountOnSuccess', false);
+          settings.set('ejectOnSuccess', false);
           m.chai.expect(controller.getProgressButtonLabel()).to.equal('Finishing...');
         });
 


### PR DESCRIPTION
This updates `mountutils` from 1.0.6 to 1.1.0 (adding ejection functionality),
and ejects the device after flashing & verifying instead of only unmounting it.

**TODO:**
- [ ] Create a user-error if the ejection is unsuccessful

Connects To: #1385