### PR TITLE
fix(GUI): ignore ECONNRESET and ECONNREFUSED when querying S3

### DIFF
--- a/lib/shared/s3-packages.js
+++ b/lib/shared/s3-packages.js
@@ -149,6 +149,10 @@ exports.getRemoteVersions = _.memoize((bucketUrl) => {
     .catch({
       code: 'ENOTFOUND'
     }, {
+      code: 'ECONNRESET'
+    }, {
+      code: 'ECONNREFUSED'
+    }, {
       code: 'ETIMEDOUT'
     }, () => {
       return [];

--- a/tests/shared/s3-packages.spec.js
+++ b/tests/shared/s3-packages.spec.js
@@ -643,6 +643,52 @@ describe('Shared: s3Packages', function() {
 
     });
 
+    describe('given ECONNRESET', function() {
+
+      beforeEach(function() {
+        const error = new Error('ECONNRESET');
+        error.code = 'ECONNRESET';
+
+        this.requestGetAsyncStub = m.sinon.stub(request, 'getAsync');
+        this.requestGetAsyncStub.returns(Bluebird.reject(error));
+      });
+
+      afterEach(function() {
+        this.requestGetAsyncStub.restore();
+      });
+
+      it('should resolve an empty array', function(done) {
+        s3Packages.getRemoteVersions(s3Packages.BUCKET_URL.PRODUCTION).then((versions) => {
+          m.chai.expect(versions).to.deep.equal([]);
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('given ECONNREFUSED', function() {
+
+      beforeEach(function() {
+        const error = new Error('ECONNREFUSED');
+        error.code = 'ECONNREFUSED';
+
+        this.requestGetAsyncStub = m.sinon.stub(request, 'getAsync');
+        this.requestGetAsyncStub.returns(Bluebird.reject(error));
+      });
+
+      afterEach(function() {
+        this.requestGetAsyncStub.restore();
+      });
+
+      it('should resolve an empty array', function(done) {
+        s3Packages.getRemoteVersions(s3Packages.BUCKET_URL.PRODUCTION).then((versions) => {
+          m.chai.expect(versions).to.deep.equal([]);
+          done();
+        }).catch(done);
+      });
+
+    });
+
   });
 
   describe('.getLatestVersion()', function() {


### PR DESCRIPTION
Querying S3 to determine the latest available versions might throw
`ECONNRESET` and `ECONNREFUSED`. This commit extends the
`s3Packages.getRemoteVersions()` function to handle these errors and
return no available version if so, like we already do with other similar
HTTP errors.

Change-Type: patch
Changelog-Entry: Fix `ECONNRESET` and `ECONNREFUSED` errors when checking for updates on unstable connections.
Fixes: https://github.com/resin-io/etcher/issues/1396
Fixes: https://github.com/resin-io/etcher/issues/1388
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>