### PR TITLE
fix: add a delay before the final unmount on success

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -26,6 +26,13 @@ const errors = require('../shared/errors');
 const constraints = require('../shared/drive-constraints');
 
 /**
+ * @summary Timeout, in milliseconds, to wait before unmounting on success
+ * @constant
+ * @type {Number}
+ */
+const UNMOUNT_ON_SUCCESS_TIMEOUT_MS = 2000;
+
+/**
  * @summary Write an image to a disk drive
  * @function
  * @public
@@ -108,7 +115,14 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
           return Bluebird.resolve();
         }
 
-        return mountutils.unmountDiskAsync(drive.device);
+        // Closing a file descriptor on a drive containing mountable
+        // partitions causes macOS to mount the drive. If we try to
+        // unmount to quickly, then the drive might get re-mounted
+        // right afterwards.
+        return Bluebird.delay(UNMOUNT_ON_SUCCESS_TIMEOUT_MS)
+          .return(drive.device)
+          .then(mountutils.unmountDiskAsync);
+
       });
     });
   });


### PR DESCRIPTION
If the user has the "Unmount on success" setting enabled, then Etcher
will unmount the drive after ther flashing process completed, right
after closing the drive file descriptor.

Turns out macOS will attempt to re-mount a drive once its file
descriptor gets closed, which means that if we try to unmount too fast,
then the drive will get re-mounted again.

As a naive solution, we add a timeout before finally unmounting the
drive. Keep in the mind this is only a temporary solution until we fix
mountutils to do the right thing.

See: https://github.com/resin-io/etcher/pull/1414
Fixes: https://github.com/resin-io/etcher/issues/1385
Change-Type: patch
Changelog-Entry: Prevent drive from getting re-mounted in macOS even when the unmount on success setting is enabled.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>