### PR TITLE
chore: track python dependencies with pip

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 *
+!requirements.txt

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@ Makefile text
 *.svg text
 *.yml text
 *.patch text
+*.txt text
 
 # Binary files (no line-ending conversions)
 *.bz2 binary diff=hex

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -12,9 +12,13 @@ Prerequisites
 - [NodeJS](https://nodejs.org) (at least v6)
 - [Python](https://www.python.org)
 - [jq](https://stedolan.github.io/jq/)
-- [Codespell](https://github.com/lucasdemarchi/codespell)
 - [curl](https://curl.haxx.se/)
-- [cpplint](https://github.com/cpplint/cpplint)
+
+```sh
+pip install -r requirements.txt
+```
+
+You might need to run this with `sudo` or administrator permissions.
 
 ### Windows
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+codespell==1.9.2
+cpplint==1.3.0
+awscli==1.11.87

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -37,4 +37,5 @@ RUN npm config set spin=false
 RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1
 
 # Python
-RUN pip install codespell==1.9.2 awscli cpplint
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -37,4 +37,5 @@ RUN npm config set spin=false
 RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1
 
 # Python
-RUN pip install codespell==1.9.2 awscli cpplint
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -37,4 +37,5 @@ RUN npm config set spin=false
 RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1
 
 # Python
-RUN pip install codespell==1.9.2 awscli cpplint
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt

--- a/scripts/ci/appveyor-install.bat
+++ b/scripts/ci/appveyor-install.bat
@@ -26,7 +26,7 @@ call choco install nsis -version 2.51 || ( EXIT /B 1 )
 call choco install jq || ( EXIT /B 1 )
 call choco install curl || ( EXIT /B 1 )
 
-call pip install codespell==1.9.2 awscli cpplint || ( EXIT /B 1 )
+call pip install -r requirements.txt || ( EXIT /B 1 )
 
 call make info || ( EXIT /B 1 )
 call make electron-develop || ( EXIT /B 1 )

--- a/scripts/ci/travis-install.sh
+++ b/scripts/ci/travis-install.sh
@@ -37,7 +37,7 @@ else
 
   npm config set spin=false
   npm install -g uglify-es@3.0.3
-  pip install codespell==1.9.2 awscli cpplint
+  pip install -r requirements.txt
   brew install afsctool jq
   make info
   make electron-develop


### PR DESCRIPTION
We're currently hardcoding various pip dependencies in
`appveyor-install.bat` and `travis-install.sh`.

This commit moves all the dependencies to a `requirements.txt` file in
the root of the project, and makes every install script run `pip install
-r requirements.txt`.

See: https://github.com/resin-io/etcher/pull/1401#discussion_r116547053
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>