### PR TITLE
chore: fix lzma-native not building for the x86 Linux CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_OUTPUT_DIRECTORY = $(BUILD_DIRECTORY)/out
 # ---------------------------------------------------------------------
 
 ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron"]' package.json)
-NODE_VERSION = 6.10.3
+NODE_VERSION = 6.1.0
 COMPANY_NAME = $(shell jq -r '.companyName' package.json)
 APPLICATION_NAME = $(shell jq -r '.displayName' package.json)
 APPLICATION_DESCRIPTION = $(shell jq -r '.description' package.json)
@@ -191,7 +191,7 @@ $(BUILD_DIRECTORY)/electron-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies: pack
 $(BUILD_DIRECTORY)/node-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies: package.json npm-shrinkwrap.json \
 	| $(BUILD_DIRECTORY)
 	mkdir $@
-	./scripts/build/dependencies-npm.sh -p -f \
+	./scripts/build/dependencies-npm.sh -p \
 		-r "$(TARGET_ARCH)" \
 		-v "$(NODE_VERSION)" \
 		-x $@ \

--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -32,7 +32,6 @@ function usage() {
   echo "    -t <target platform (node|electron)>"
   echo "    -s <target operating system>"
   echo "    -x <install prefix>"
-  echo "    -f force install"
   echo "    -p production install"
   exit 1
 }
@@ -42,17 +41,15 @@ ARGV_TARGET_VERSION=""
 ARGV_TARGET_PLATFORM=""
 ARGV_TARGET_OPERATING_SYSTEM=""
 ARGV_PREFIX=""
-ARGV_FORCE=false
 ARGV_PRODUCTION=false
 
-while getopts ":r:v:t:s:x:fp" option; do
+while getopts ":r:v:t:s:x:p" option; do
   case $option in
     r) ARGV_ARCHITECTURE=$OPTARG ;;
     v) ARGV_TARGET_VERSION=$OPTARG ;;
     t) ARGV_TARGET_PLATFORM=$OPTARG ;;
     s) ARGV_TARGET_OPERATING_SYSTEM=$OPTARG ;;
     x) ARGV_PREFIX=$OPTARG ;;
-    f) ARGV_FORCE=true ;;
     p) ARGV_PRODUCTION=true ;;
     *) usage ;;
   esac
@@ -86,10 +83,6 @@ ELECTRON_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHIT
 export npm_config_arch=$ELECTRON_ARCHITECTURE
 
 INSTALL_OPTS=""
-
-if [ "$ARGV_FORCE" == "true" ]; then
-  INSTALL_OPTS="$INSTALL_OPTS --force"
-fi
 
 if [ "$ARGV_PRODUCTION" == "true" ]; then
   INSTALL_OPTS="$INSTALL_OPTS --production"

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -33,6 +33,10 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
+
+# See https://github.com/mapbox/node-pre-gyp/issues/165
+RUN npm config set unsafe-perm=true
+
 RUN npm config set spin=false
 RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1
 

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -33,6 +33,10 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
+
+# See https://github.com/mapbox/node-pre-gyp/issues/165
+RUN npm config set unsafe-perm=true
+
 RUN npm config set spin=false
 RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1
 

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -33,6 +33,10 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && apt-get install -y nodejs
+
+# See https://github.com/mapbox/node-pre-gyp/issues/165
+RUN npm config set unsafe-perm=true
+
 RUN npm config set spin=false
 RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1
 


### PR DESCRIPTION
There are various problems that contributed to this issue:

- `node-pre-gyp` doesn't detect the 6.10.3 node version. We reverted to
  6.1.0, which the module recognised, and which shares the same v8 ABI

- Passing `--force` to `npm install` causes npm to swallow any errors
  and silently continue

- The x86 Docker container has problems writing to `$HOME/.node-gyp`.
  The solution is to enable `unsafe-perm` given that the container is
  running as `root`

Fixes: https://github.com/resin-io/etcher/issues/1444
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>