### PR TITLE
fix(CLI): get rid of Browserify absolute path workaround

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -630,9 +630,9 @@
       "dev": true
     },
     "browserify": {
-      "version": "13.3.0",
-      "from": "browserify@>=13.0.1 <14.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
+      "version": "14.3.0",
+      "from": "jviotti/node-browserify#dynamic-dirname-filename",
+      "resolved": "git://github.com/jviotti/node-browserify.git#14691ac9257063000e4aa216073cdad28b9d04e1",
       "dev": true,
       "dependencies": {
         "base64-js": {
@@ -642,15 +642,9 @@
           "dev": true
         },
         "buffer": {
-          "version": "4.9.1",
-          "from": "buffer@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "5.0.6",
+          "from": "buffer@>=5.0.2 <6.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
           "dev": true
         },
         "through2": {
@@ -692,9 +686,9 @@
       "dev": true
     },
     "browserify-sign": {
-      "version": "4.0.0",
+      "version": "4.0.4",
       "from": "browserify-sign@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "dev": true
     },
     "browserify-zlib": {
@@ -1137,15 +1131,15 @@
       }
     },
     "create-hash": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "create-hash@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "dev": true
     },
     "create-hmac": {
-      "version": "1.1.4",
+      "version": "1.1.6",
       "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "dev": true
     },
     "cross-spawn": {
@@ -3047,6 +3041,12 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
       "dev": true
     },
+    "hash-base": {
+      "version": "2.0.2",
+      "from": "hash-base@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "dev": true
+    },
     "hash.js": {
       "version": "1.0.3",
       "from": "hash.js@>=1.0.0 <2.0.0",
@@ -3099,9 +3099,9 @@
       "dev": true
     },
     "hmac-drbg": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "hmac-drbg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "dev": true
     },
     "hoek": {
@@ -3170,9 +3170,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "https-browserify": {
-      "version": "0.0.1",
-      "from": "https-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "version": "1.0.0",
+      "from": "https-browserify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "dev": true
     },
     "https-proxy-agent": {
@@ -3676,9 +3676,9 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonparse": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "jsonparse@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "dev": true
     },
     "jsonpointer": {
@@ -5505,9 +5505,9 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.9",
+      "version": "3.0.12",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "dev": true
     },
     "pend": {
@@ -5597,9 +5597,9 @@
       "dev": true
     },
     "process": {
-      "version": "0.11.9",
+      "version": "0.11.10",
       "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "dev": true
     },
     "process-nextick-args": {
@@ -6104,9 +6104,9 @@
       "dev": true
     },
     "ripemd160": {
-      "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+      "version": "2.0.1",
+      "from": "ripemd160@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "dev": true
     },
     "run-async": {
@@ -6268,7 +6268,7 @@
     },
     "sha.js": {
       "version": "2.4.8",
-      "from": "sha.js@>=2.3.6 <3.0.0",
+      "from": "sha.js@>=2.4.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "dev": true
     },
@@ -6524,11 +6524,29 @@
       "dev": true
     },
     "stream-http": {
-      "version": "2.6.3",
+      "version": "2.7.1",
       "from": "stream-http@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
       "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "from": "readable-stream@>=2.2.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "dev": true
+        },
         "xtend": {
           "version": "4.0.1",
           "from": "xtend@^4.0.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   "devDependencies": {
     "angular-mocks": "1.6.3",
     "asar": "^0.10.0",
-    "browserify": "^13.0.1",
+    "browserify": "github:jviotti/node-browserify#dynamic-dirname-filename",
     "electron": "1.6.6",
     "electron-builder": "^2.6.0",
     "electron-mocha": "^3.1.1",

--- a/scripts/build/concatenate-javascript.sh
+++ b/scripts/build/concatenate-javascript.sh
@@ -55,29 +55,10 @@ if [ -z "$ARGV_ENTRY_POINT" ] ||
   usage
 fi
 
-"$BROWSERIFY" "$ARGV_BASE_DIRECTORY/$ARGV_ENTRY_POINT" --node --outfile "$ARGV_OUTPUT"
-
-# This hack workarounds the fact the Browserify stores absolute paths
-# of the machine that was used to produce the bundle, giving "not found"
-# module errors when executing it in another computer.
-# The fix is to replace absolute paths with `__dirname`
-node <<EOF > "$ARGV_OUTPUT.TMP"
-const separator = process.platform === 'win32' ? '\\\\\\\\\\\\\\\\' : '\\/';
-const baseDirectory = process.platform === 'win32'
-  ? "$ARGV_BASE_DIRECTORY".replace(/\//g, separator)
-  : "$ARGV_BASE_DIRECTORY";
-
-const regex = new RegExp('"(.)+' + baseDirectory.replace(/\+/g, '\\\\+') + separator, 'g');
-const contents = require('fs').readFileSync("$ARGV_OUTPUT", { encoding: 'utf8' });
-
-console.log(contents.split('\n').map((line) => {
-  if (!regex.test(line)) return line;
-  return line
-    .replace(regex, 'require("path").join(__dirname,"')
-    .replace(new RegExp(separator, 'g'), '","') + ')';
-}).join('\n'));
-EOF
-mv "$ARGV_OUTPUT.TMP" "$ARGV_OUTPUT"
+"$BROWSERIFY" "$ARGV_ENTRY_POINT" \
+  --node \
+  --basedir "$ARGV_BASE_DIRECTORY" \
+  --outfile "$ARGV_OUTPUT"
 
 if [ "$ARGV_MINIFY" == "true" ]; then
   ./scripts/build/check-dependency.sh uglifyjs


### PR DESCRIPTION
We encountered a Browserify bug when releasing the CLI, where absolute
paths would be hard-coded in the final bundle. Since we were in the
middle of a release process, we added a quick and dirty
search-and-replace workaround on `concatenate-javascript.sh`.

After the release, we submitted a PR to Browserify which fixes the
issue. This commit makes use of my personal fork to be able to use such
fix while it gets merged to the main project.

See: https://github.com/substack/node-browserify/pull/1725
See: https://github.com/resin-io/etcher/pull/1409
Fixes: https://github.com/resin-io/etcher/issues/1429
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>