### PR TITLE
feat(GUI): add metadata and icon to notifications

### DIFF
--- a/lib/gui/os/notification.js
+++ b/lib/gui/os/notification.js
@@ -29,20 +29,23 @@ const electron = require('electron');
  * http://electron.atom.io/docs/v0.37.5/tutorial/desktop-environment-integration/
  *
  * @param {String} title - notification title
- * @param {String} body - notification body
+ * @param {Object} options - options object
+ * @param {String} options.body - notification body
+ * @param {String} options.icon - supported icon path
  * @returns {Object} HTML5 notification instance
  *
  * @example
- * notification.send('Hello', 'Foo Bar Bar');
+ * notification.send('Hello', {
+ *   body: 'Foo Bar Bar',
+ *   icon: 'icon.png'
+ * });
  */
-exports.send = (title, body) => {
+exports.send = (title, options) => {
 
   // `app.dock` is only defined in OS X
   if (electron.remote.app.dock) {
     electron.remote.app.dock.bounce();
   }
 
-  return new Notification(title, {
-    body
-  });
+  return new Notification(title, options);
 };

--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -21,6 +21,7 @@ const settings = require('../../../models/settings');
 const flashState = require('../../../models/flash-state');
 const utils = require('../../../../shared/utils');
 const notification = require('../../../os/notification');
+const path = require('path');
 
 module.exports = function(
   $state,
@@ -61,12 +62,24 @@ module.exports = function(
 
     ImageWriterService.flash(image.path, drive).then(() => {
       if (!flashState.wasLastFlashCancelled()) {
-        notification.send('Success!', messages.info.flashComplete());
+        notification.send('Success!', {
+          body: messages.info.flashComplete({
+            imageBasename: path.basename(image.path),
+            drive
+          }),
+          icon: '../../../../../assets/icon.png'
+        });
         $state.go('success');
       }
     })
     .catch((error) => {
-      notification.send('Oops!', messages.error.flashFailure());
+      notification.send('Oops! Looks like the flash failed.', {
+        body: messages.error.flashFailure({
+          imageBasename: path.basename(image.path),
+          drive
+        }),
+        icon: '../../../../../assets/icon.png'
+      });
 
       // TODO: All these error codes to messages translations
       // should go away if the writer emitted user friendly

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -32,7 +32,10 @@ module.exports = {
    */
   info: {
 
-    flashComplete: _.template('Your flash is complete!')
+    flashComplete: _.template([
+      '<%= imageBasename %> was successfully written to',
+      '<%= drive.description %> (<%= drive.name %>)'
+    ].join(' '))
 
   },
 
@@ -86,7 +89,10 @@ module.exports = {
 
     elevationRequired: _.template('This should should be run with root/administrator permissions.'),
 
-    flashFailure: _.template('Looks like your flash has failed!'),
+    flashFailure: _.template([
+      'Something went wrong while writing <%= imageBasename %>',
+      'to <%= drive.description %> (<%= drive.name %>)'
+    ].join(' ')),
 
     driveUnplugged: _.template([
       'Looks like Etcher lost access to the drive.',


### PR DESCRIPTION
We add the image filename, its destination drive, and application icon
to the notifications.

See: #1443
Changelog-Entry: Add image name, drive name, and icon to notifications.