### PR TITLE
fix(GUI): catch EACCES when querying S3 packages

### DIFF
--- a/lib/shared/s3-packages.js
+++ b/lib/shared/s3-packages.js
@@ -153,6 +153,8 @@ exports.getRemoteVersions = _.memoize((bucketUrl) => {
     }, {
       code: 'ECONNREFUSED'
     }, {
+      code: 'EACCES'
+    }, {
       code: 'ETIMEDOUT'
     }, () => {
       return [];

--- a/tests/shared/s3-packages.spec.js
+++ b/tests/shared/s3-packages.spec.js
@@ -689,6 +689,29 @@ describe('Shared: s3Packages', function() {
 
     });
 
+    describe('given EACCES', function() {
+
+      beforeEach(function() {
+        const error = new Error('EACCES');
+        error.code = 'EACCES';
+
+        this.requestGetAsyncStub = m.sinon.stub(request, 'getAsync');
+        this.requestGetAsyncStub.returns(Bluebird.reject(error));
+      });
+
+      afterEach(function() {
+        this.requestGetAsyncStub.restore();
+      });
+
+      it('should resolve an empty array', function(done) {
+        s3Packages.getRemoteVersions(s3Packages.BUCKET_URL.PRODUCTION).then((versions) => {
+          m.chai.expect(versions).to.deep.equal([]);
+          done();
+        }).catch(done);
+      });
+
+    });
+
   });
 
   describe('.getLatestVersion()', function() {


### PR DESCRIPTION
When the user is behind a firewall, then the HTTP request to query the
latest available version from S3 may throw an EACCES error, eventually
causing a confusin "You don't have access to this resource" error
window.

Change-Type: patch
Changelog-Entry: Fix "You don't have access to this resource" error at startup when behind a firewall.
Fixes: https://github.com/resin-io/etcher/issues/1458
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>