### PR TITLE
fix(GUI): stop settings overflow into footer

### DIFF
--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6567,11 +6567,6 @@ body {
 .page-settings .title {
   color: #fff; }
 
-.page-settings .subtitle {
-  color: #fff;
-  margin-top: 20px;
-  margin-bottom: 15px; }
-
 /*
  * Copyright 2016 resin.io
  *

--- a/lib/gui/pages/settings/styles/_settings.scss
+++ b/lib/gui/pages/settings/styles/_settings.scss
@@ -25,9 +25,3 @@
 .page-settings .title {
   color: $palette-theme-dark-foreground;
 }
-
-.page-settings .subtitle {
-  color: $palette-theme-dark-foreground;
-  margin-top: 20px;
-  margin-bottom: 15px;
-}

--- a/lib/gui/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/pages/settings/templates/settings.tpl.html
@@ -50,8 +50,6 @@
     </label>
   </div>
 
-  <h3 class="subtitle">Advanced</h3>
-
   <div class="checkbox">
     <label>
       <input type="checkbox"


### PR DESCRIPTION
By removing the 'advanced' sub-header we stop the settings from
overflowing into the footer.

See: https://github.com/resin-io/etcher/issues/1383
Changelog-Entry: Stop settings from overflowing into the footer.