### PR TITLE
style(GUI): normal weight message on success page

### DIFF
--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6651,7 +6651,8 @@ body {
   color: #fff;
   font-weight: 300; }
   .page-finish .fallback-banner .caption {
-    display: flex; }
+    display: flex;
+    font-weight: normal; }
   .page-finish .fallback-banner .caption-big {
     font-size: 30px; }
   .page-finish .fallback-banner .caption-small {

--- a/lib/gui/pages/finish/styles/_finish.scss
+++ b/lib/gui/pages/finish/styles/_finish.scss
@@ -97,6 +97,7 @@
 
   .caption {
     display: flex;
+    font-weight: normal;
   }
 
   .caption-big {


### PR DESCRIPTION
We make the fonts a regular weight instead of bold on the success page's
fallback banner.

Changelog-Entry: Make the fallback success page banner message a normal font
weight.