### PR TITLE
fix(GUI): correct relative notification icon path

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -60,6 +60,8 @@ module.exports = function(
     // otherwise Windows throws EPERM
     DriveScannerService.stop();
 
+    const iconPath = '../../assets/icon.png';
+
     ImageWriterService.flash(image.path, drive).then(() => {
       if (!flashState.wasLastFlashCancelled()) {
         notification.send('Success!', {
@@ -67,7 +69,7 @@ module.exports = function(
             imageBasename: path.basename(image.path),
             drive
           }),
-          icon: '../../../../../assets/icon.png'
+          icon: iconPath
         });
         $state.go('success');
       }
@@ -78,7 +80,7 @@ module.exports = function(
           imageBasename: path.basename(image.path),
           drive
         }),
-        icon: '../../../../../assets/icon.png'
+        icon: iconPath
       });
 
       // TODO: All these error codes to messages translations


### PR DESCRIPTION
We update the relative icon path to the correct relative path containing
the Etcher icon.

See: https://github.com/resin-io/etcher/issues/1443
Changelog-Entry: Correct the relative notification icon path.