### PR TITLE
chore(docker): Change APT mirror used by the Ubuntu12.04 32bit docker image

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,8 +1,14 @@
 FROM erwinchang/ubuntu-12.04-32bit-build
 
+# Setup APT sources
+
+RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/sources.list \
+  && mv /tmp/sources.list /etc/apt/sources.list
+
+
+
 # Install dependencies
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list \
-  && apt-get update \
+RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -1,8 +1,13 @@
 FROM ubuntu:12.04
 
+# Setup APT sources
+
+
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
+
+
 # Install dependencies
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list \
-  && apt-get update \
+RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -1,8 +1,16 @@
 FROM <%= image %>
 
+# Setup APT sources
+<% if (architecture == 'i686') { %>
+RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/sources.list \
+  && mv /tmp/sources.list /etc/apt/sources.list
+<% } %>
+<% if (architecture == 'x86_64') { %>
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
+<% } %>
+
 # Install dependencies
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list \
-  && apt-get update \
+RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \


### PR DESCRIPTION
Previously it was using http://ubuntu.stu.edu.tw but this host is no longer
active, which was causing all the 32bit Linux TravisCI builds to fail.