### PR TITLE
fix(GUI): ignore UNABLE_TO_VERIFY_LEAF_SIGNATURE HTTP issues

### DIFF
--- a/lib/shared/s3-packages.js
+++ b/lib/shared/s3-packages.js
@@ -156,6 +156,11 @@ exports.getRemoteVersions = _.memoize((bucketUrl) => {
       code: 'EACCES'
     }, {
       code: 'ETIMEDOUT'
+    }, {
+
+      // May happen when behind a proxy
+      code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+
     }, () => {
       return [];
     });

--- a/tests/shared/s3-packages.spec.js
+++ b/tests/shared/s3-packages.spec.js
@@ -712,6 +712,29 @@ describe('Shared: s3Packages', function() {
 
     });
 
+    describe('given UNABLE_TO_VERIFY_LEAF_SIGNATURE', function() {
+
+      beforeEach(function() {
+        const error = new Error('UNABLE_TO_VERIFY_LEAF_SIGNATURE');
+        error.code = 'UNABLE_TO_VERIFY_LEAF_SIGNATURE';
+
+        this.requestGetAsyncStub = m.sinon.stub(request, 'getAsync');
+        this.requestGetAsyncStub.returns(Bluebird.reject(error));
+      });
+
+      afterEach(function() {
+        this.requestGetAsyncStub.restore();
+      });
+
+      it('should resolve an empty array', function(done) {
+        s3Packages.getRemoteVersions(s3Packages.BUCKET_URL.PRODUCTION).then((versions) => {
+          m.chai.expect(versions).to.deep.equal([]);
+          done();
+        }).catch(done);
+      });
+
+    });
+
   });
 
   describe('.getLatestVersion()', function() {


### PR DESCRIPTION
This error may get thrown when fetching the list of S3 packages when the
user is behind a proxy tht causes the SSL certificate to incorrectly not
be trusted.

See: https://github.com/atom/apm/issues/103
See: https://github.com/resin-io/etcher/issues/1465
Change-Type: patch
Changelog-Entry: Fix `UNABLE_TO_VERIFY_LEAF_SIGNATURE` error at startup.
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>