### PR TITLE
chore: make use of resin.io's Docker base images

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,17 +1,15 @@
-FROM erwinchang/ubuntu-12.04-32bit-build
+FROM resin/i386-debian:jessie
 
 # Setup APT sources
-
-RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/sources.list \
-  && mv /tmp/sources.list /etc/apt/sources.list
-
-
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \
+    dpkg \
+    fakeroot \
     fuse \
     git \
     jq \
@@ -20,6 +18,7 @@ RUN apt-get update \
     libgtk2.0-0 \
     libx11-xcb1 \
     libnss3 \
+    libsass0 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -27,14 +26,11 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    rsync \
     unzip \
     xvfb \
+    xauth \
     zip
-
-# Install a C++11 compiler
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
-  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
-  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -1,16 +1,15 @@
-FROM ubuntu:12.04
+FROM resin/amd64-debian:jessie
 
 # Setup APT sources
-
-
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
-
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \
+    dpkg \
+    fakeroot \
     fuse \
     git \
     jq \
@@ -19,6 +18,7 @@ RUN apt-get update \
     libgtk2.0-0 \
     libx11-xcb1 \
     libnss3 \
+    libsass0 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -26,14 +26,11 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    rsync \
     unzip \
     xvfb \
+    xauth \
     zip
-
-# Install a C++11 compiler
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
-  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
-  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -1,19 +1,15 @@
 FROM <%= image %>
 
 # Setup APT sources
-<% if (architecture == 'i686') { %>
-RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/sources.list \
-  && mv /tmp/sources.list /etc/apt/sources.list
-<% } %>
-<% if (architecture == 'x86_64') { %>
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
-<% } %>
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
 
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \
+    dpkg \
+    fakeroot \
     fuse \
     git \
     jq \
@@ -22,6 +18,7 @@ RUN apt-get update \
     libgtk2.0-0 \
     libx11-xcb1 \
     libnss3 \
+    libsass0 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -29,14 +26,11 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    rsync \
     unzip \
     xvfb \
+    xauth \
     zip
-
-# Install a C++11 compiler
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
-  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
-  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,11 +31,11 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'erwinchang/ubuntu-12.04-32bit-build'
+    image: 'resin/i386-debian:jessie'
   },
   {
     architecture: 'x86_64',
-    image: 'ubuntu:12.04'
+    image: 'resin/amd64-debian:jessie'
   }
 ], (options) => {
   const result = _.template(template)(options);


### PR DESCRIPTION
Resin.io already publishes multi-arch Docker base images running Jessie,
which is Debian version we wanted before falling back to Ubuntu 12.04.

The main reason behind this change is to be able to use other resin.io
base images (like ARM ones) without requiring a lot of per-base-image
changes.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>