### PR TITLE
chore: build armhf on GNU/Linux

### DIFF
--- a/scripts/build/architecture-convert.sh
+++ b/scripts/build/architecture-convert.sh
@@ -25,7 +25,7 @@ function usage() {
   echo "Options"
   echo ""
   echo "    -r <architecture>"
-  echo "    -t <type (debian|redhat|node)>"
+  echo "    -t <type (debian|redhat|node|docker)>"
   exit 1
 }
 
@@ -51,7 +51,7 @@ if [ "$ARGV_TYPE" == "node" ]; then
     RESULT=ia32
   elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
     RESULT=x64
-  elif [ "$ARGV_ARCHITECTURE" == "armv7l" ]; then
+  elif [ "$ARGV_ARCHITECTURE" == "armv7hf" ]; then
     RESULT=arm
   fi
 elif [ "$ARGV_TYPE" == "electron-builder" ]; then
@@ -59,7 +59,7 @@ elif [ "$ARGV_TYPE" == "electron-builder" ]; then
     RESULT=ia32
   elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
     RESULT=x64
-  elif [ "$ARGV_ARCHITECTURE" == "armv7l" ]; then
+  elif [ "$ARGV_ARCHITECTURE" == "armv7hf" ]; then
     RESULT=armv7l
   fi
 elif [ "$ARGV_TYPE" == "debian" ]; then
@@ -67,7 +67,7 @@ elif [ "$ARGV_TYPE" == "debian" ]; then
     RESULT=i386
   elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
     RESULT=amd64
-  elif [ "$ARGV_ARCHITECTURE" == "armv7l" ]; then
+  elif [ "$ARGV_ARCHITECTURE" == "armv7hf" ]; then
     RESULT=armhf
   fi
 elif [ "$ARGV_TYPE" == "redhat" ]; then
@@ -75,12 +75,24 @@ elif [ "$ARGV_TYPE" == "redhat" ]; then
     RESULT=i686
   elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
     RESULT='x86_64'
+  elif [ "$ARGV_ARCHITECTURE" == "armv7hf" ]; then
+    RESULT=armhfp
   fi
 elif [ "$ARGV_TYPE" == "appimage" ]; then
   if [ "$ARGV_ARCHITECTURE" == "x86" ]; then
     RESULT=i386
   elif [ "$ARGV_ARCHITECTURE" == "x64" ]; then
     RESULT='x86_64'
+  elif [ "$ARGV_ARCHITECTURE" == "armv7hf" ]; then
+    RESULT=armhf
+  fi
+elif [ "$ARGV_TYPE" == "docker" ]; then
+  if [ "$ARGV_ARCHITECTURE" == "x64" ]; then
+    RESULT=x86_64
+  elif [ "$ARGV_ARCHITECTURE" == "x86" ]; then
+    RESULT=i686
+  elif [ "$ARGV_ARCHITECTURE" == "armv7hf" ]; then
+    RESULT=armv7hf
   fi
 else
   echo "Unsupported architecture type: $ARGV_TYPE" 1>&2

--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -1,16 +1,11 @@
-FROM <%= image %>
+FROM resin/armv7hf-debian:jessie
 
 # Setup APT sources
-<% if (architecture == 'i686') { %>
-RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/sources.list \
-  && mv /tmp/sources.list /etc/apt/sources.list
-<% } %>
-<% if (architecture == 'x86_64') { %>
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
-<% } %>
-<% if (architecture == 'armv7hf') { %>
+
+
+
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-<% } %>
+
 
 # Install dependencies
 RUN apt-get update \
@@ -41,12 +36,7 @@ RUN apt-get update \
     zip \
     rpm
 
-<% if (architecture != 'armv7hf') { %>
-# Install a C++11 compiler
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
-  && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
-  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
-<% } %>
+
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -7,6 +7,7 @@ RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/
 
 
 
+
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
@@ -36,10 +37,12 @@ RUN apt-get update \
     zip \
     rpm
 
+
 # Install a C++11 compiler
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -6,6 +6,7 @@ FROM ubuntu:12.04
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
 
 
+
 # Install dependencies
 RUN apt-get update \
   && apt-get install -y \
@@ -35,10 +36,12 @@ RUN apt-get update \
     zip \
     rpm
 
+
 # Install a C++11 compiler
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -36,6 +36,10 @@ _.each([
   {
     architecture: 'x86_64',
     image: 'ubuntu:12.04'
+  },
+  {
+    architecture: 'armv7hf',
+    image: 'resin/armv7hf-debian:jessie'
   }
 ], (options) => {
   const result = _.template(template)(options)

--- a/scripts/build/docker/run-command.sh
+++ b/scripts/build/docker/run-command.sh
@@ -54,16 +54,9 @@ then
   usage
 fi
 
-if [ "$ARGV_ARCHITECTURE" == "x64" ]; then
-  DOCKERFILE="$HERE/Dockerfile-x86_64"
-elif [ "$ARGV_ARCHITECTURE" == "x86" ]; then
-  DOCKERFILE="$HERE/Dockerfile-i686"
-else
-  echo "Unsupported architecture: $ARGV_ARCHITECTURE" 1>&2
-  exit 1
-fi
-
-IMAGE_ID="etcher-build-$ARGV_ARCHITECTURE"
+DOCKER_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t docker)
+DOCKERFILE="$HERE/Dockerfile-$DOCKER_ARCHITECTURE"
+IMAGE_ID="etcher-build-$DOCKER_ARCHITECTURE"
 
 docker build -f "$DOCKERFILE" -t "$IMAGE_ID" "$ARGV_SOURCE_CODE_DIRECTORY"
 


### PR DESCRIPTION
This commit makes use of the `resin/armv7hf-debian` Docker image to
test and generate armhf builds.

We needed to add a slash before `build` in `.gitignore` given that git
was refusing to include any changes on `scripts/build` otherwise.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>