### PR TITLE
chore: list all needed packages on the Dockerfile

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -12,6 +12,8 @@ RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \
+    dpkg \
+    fakeroot \
     fuse \
     git \
     jq \
@@ -20,6 +22,7 @@ RUN apt-get update \
     libgtk2.0-0 \
     libx11-xcb1 \
     libnss3 \
+    libsass0 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -27,8 +30,10 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    rsync \
     unzip \
     xvfb \
+    xauth \
     zip
 
 # Install a C++11 compiler

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -11,6 +11,8 @@ RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \
+    dpkg \
+    fakeroot \
     fuse \
     git \
     jq \
@@ -19,6 +21,7 @@ RUN apt-get update \
     libgtk2.0-0 \
     libx11-xcb1 \
     libnss3 \
+    libsass0 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -26,8 +29,10 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    rsync \
     unzip \
     xvfb \
+    xauth \
     zip
 
 # Install a C++11 compiler

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -14,6 +14,8 @@ RUN apt-get update \
   && apt-get install -y \
     build-essential \
     curl \
+    dpkg \
+    fakeroot \
     fuse \
     git \
     jq \
@@ -22,6 +24,7 @@ RUN apt-get update \
     libgtk2.0-0 \
     libx11-xcb1 \
     libnss3 \
+    libsass0 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -29,8 +32,10 @@ RUN apt-get update \
     python-pip \
     python-dev \
     python-software-properties \
+    rsync \
     unzip \
     xvfb \
+    xauth \
     zip
 
 # Install a C++11 compiler


### PR DESCRIPTION
At the moment, we only install the packages that we need but that are
missing from the base Docker image that we use.

For safety purposes (and to make it easier to switch to another base
image), we list all the needed packages, even if they usually come
pre-installed, since that would only be a no-op in the worst case.

See: https://github.com/resin-io/etcher/commit/296a55463714194d15c28eb79bb2939908f8cffd#commitcomment-22358869
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>