### PR TITLE
chore(ci): Use npm@5 on CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "6.10.3"
+  - "8.1.0"
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ BUILD_OUTPUT_DIRECTORY = $(BUILD_DIRECTORY)/out
 # Application configuration
 # ---------------------------------------------------------------------
 
-ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron"]' package.json)
-NODE_VERSION = 6.1.0
+ELECTRON_VERSION = $(shell $(NPX) electron --version)
+NODE_VERSION = $(shell node --version)
 COMPANY_NAME = Resinio Ltd
 APPLICATION_NAME = $(shell jq -r '.build.productName' package.json)
 APPLICATION_DESCRIPTION = $(shell jq -r '.description' package.json)
@@ -542,7 +542,9 @@ electron-develop:
 		-s "$(TARGET_PLATFORM)"
 
 sass:
-	$(NPX) node-sass lib/gui/scss/main.scss > lib/gui/css/main.css
+	# NOTE: Since `node-sass` is a native addon, and we install all dependencies for the Electron runtime,
+	# we need to run this through Electron, so that the native module's ABI matches properly
+	$(NPX) ELECTRON_RUN_AS_NODE=1 electron $(which node-sass) lib/gui/scss/main.scss > lib/gui/css/main.css
 
 lint-js:
 	$(NPX) eslint lib tests scripts bin versionist.conf.js

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BUILD_OUTPUT_DIRECTORY = $(BUILD_DIRECTORY)/out
 # Application configuration
 # ---------------------------------------------------------------------
 
-ELECTRON_VERSION = $(shell $(NPX) electron --version)
+ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron"]' package.json)
 NODE_VERSION = $(shell node --version)
 COMPANY_NAME = Resinio Ltd
 APPLICATION_NAME = $(shell jq -r '.build.productName' package.json)

--- a/Makefile
+++ b/Makefile
@@ -544,7 +544,7 @@ electron-develop:
 sass:
 	# NOTE: Since `node-sass` is a native addon, and we install all dependencies for the Electron runtime,
 	# we need to run this through Electron, so that the native module's ABI matches properly
-	$(NPX) ELECTRON_RUN_AS_NODE=1 electron $(which node-sass) lib/gui/scss/main.scss > lib/gui/css/main.css
+	ELECTRON_RUN_AS_NODE=1 $(NPX) electron node_modules/.bin/node-sass lib/gui/scss/main.scss > lib/gui/css/main.css
 
 lint-js:
 	$(NPX) eslint lib tests scripts bin versionist.conf.js

--- a/Makefile
+++ b/Makefile
@@ -542,9 +542,7 @@ electron-develop:
 		-s "$(TARGET_PLATFORM)"
 
 sass:
-	# NOTE: Since `node-sass` is a native addon, and we install all dependencies for the Electron runtime,
-	# we need to run this through Electron, so that the native module's ABI matches properly
-	ELECTRON_RUN_AS_NODE=1 $(NPX) electron node_modules/.bin/node-sass lib/gui/scss/main.scss > lib/gui/css/main.css
+	node-sass lib/gui/scss/main.scss > lib/gui/css/main.css
 
 lint-js:
 	$(NPX) eslint lib tests scripts bin versionist.conf.js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ cache:
 environment:
   global:
     ELECTRON_NO_ATTACH_CONSOLE: true
-    nodejs_version: "6.10.3"
+    nodejs_version: "8.1.0"
   matrix:
     - TARGET_ARCH: x64
     - TARGET_ARCH: x86

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 /*!
- * Bootstrap v3.3.6 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
@@ -1093,7 +1093,6 @@ a {
     color: #b7b7b7;
     text-decoration: none; }
   a:focus {
-    outline: thin dotted;
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px; }
 
@@ -2309,7 +2308,6 @@ select[size] {
 input[type="file"]:focus,
 input[type="radio"]:focus,
 input[type="checkbox"]:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px; }
 
@@ -2863,7 +2861,6 @@ select[multiple].input-lg,
   -ms-user-select: none;
   user-select: none; }
   .btn:focus, .button:focus, .progress-button:focus, .btn.focus, .focus.button, .focus.progress-button, .btn:active:focus, .button:active:focus, .progress-button:active:focus, .btn:active.focus, .button:active.focus, .progress-button:active.focus, .btn.active:focus, .active.button:focus, .active.progress-button:focus, .btn.active.focus, .active.focus.button, .active.focus.progress-button {
-    outline: thin dotted;
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px; }
   .btn:hover, .button:hover, .progress-button:hover, .btn:focus, .button:focus, .progress-button:focus, .btn.focus, .focus.button, .focus.progress-button {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4550,9 +4550,7 @@
       "integrity": "sha1-IjvUMa1/suQMVDT4peRVi+JWj70="
     },
     "node-sass": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
-      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
+      "version": "github:sass/node-sass#61d7e1c1abf762aad22bb2a6b3fdac884ca369bd",
       "dev": true,
       "dependencies": {
         "cross-spawn": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3500,258 +3500,320 @@
       "integrity": "sha512-cM+1OnKRacBh98mw5RJ3PEmFxhl70lDFAL50+x/a+fxzSZryBF1asADf57zliAtGhCNVHYzrJAZX+8R77AGYGg==",
       "dependencies": {
         "abbrev": {
-          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
           "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
         },
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+          "version": "4.11.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
           "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
           "dependencies": {
             "co": {
-              "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "version": "4.6.0",
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
               "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
             }
           }
         },
         "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
           "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
         },
         "aproba": {
-          "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
           "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
         },
         "are-we-there-yet": {
-          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
           "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM="
         },
         "asn1": {
-          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
           "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
         },
         "asynckit": {
-          "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
-          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
         },
         "aws4": {
-          "version": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
           "integrity": "sha1-054L7kEs7Q6O2Uoj4xTzE6lbn9E="
         },
         "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
           "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
         },
         "block-stream": {
-          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
         },
         "boom": {
-          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
         },
         "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
           "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE="
         },
         "buffer-shims": {
-          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
           "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
         },
         "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
           "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
         },
         "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
         },
         "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
-          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
-          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cryptiles": {
-          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
         },
         "dashdash": {
-          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
           "integrity": "sha1-parm/Z2OFWYk6w3ZJZ6xK6JFOFo=",
           "dependencies": {
             "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
               "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
             }
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
         },
         "deep-extend": {
-          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
           "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
         },
         "delayed-stream": {
-          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
-          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "ecc-jsbn": {
-          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "optional": true
         },
         "extend": {
-          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
         },
         "extsprintf": {
-          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
           "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
         },
         "forever-agent": {
-          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
-          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
         },
         "fstream-ignore": {
-          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
         },
         "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
           "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw="
         },
         "har-schema": {
-          "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
           "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
         },
         "has-unicode": {
-          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "hawk": {
-          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
         },
         "hoek": {
-          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-signature": {
-          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
         },
         "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
           "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo="
         },
         "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "ini": {
-          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
           "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
         },
         "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
         },
         "is-typedarray": {
-          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isstream": {
-          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jodid25519": {
-          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "optional": true
         },
         "jsbn": {
-          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
           "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
           "optional": true
         },
         "json-schema": {
-          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
           "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
         },
         "json-stable-stringify": {
-          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
         },
         "json-stringify-safe": {
-          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsonify": {
-          "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
           "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsprim": {
-          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
           "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE="
         },
         "lru-cache": {
-          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
           "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4="
         },
         "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+          "version": "1.22.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
           "integrity": "sha1-qyOmNy3J2G09yRIb0OvTgQWhkEo="
         },
         "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+          "version": "2.1.10",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc="
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
         },
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         },
         "nan": {
@@ -3760,57 +3822,70 @@
           "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
         },
         "node-pre-gyp": {
-          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
+          "version": "0.6.33",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
           "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
           "dependencies": {
             "caseless": {
-              "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "version": "0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
               "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
             },
             "form-data": {
-              "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
               "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
               "dependencies": {
                 "mime-types": {
-                  "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+                  "version": "2.1.14",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                   "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4="
                 }
               }
             },
             "gauge": {
-              "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
               "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk="
             },
             "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
             },
             "har-validator": {
-              "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
               "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
             },
             "mime-db": {
-              "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+              "version": "1.26.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
               "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
             },
             "npmlog": {
-              "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
               "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518="
             },
             "object-assign": {
-              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
             },
             "qs": {
-              "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "version": "6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
               "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
             },
             "request": {
-              "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "version": "2.81.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
               "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
             },
             "rimraf": {
-              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+              "version": "2.5.4",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ="
             },
             "semver": {
@@ -3819,164 +3894,202 @@
               "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
             },
             "signal-exit": {
-              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
             },
             "tough-cookie": {
-              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
               "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
             },
             "tunnel-agent": {
-              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
               "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
             },
             "uuid": {
-              "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
               "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
             }
           }
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
         },
         "number-is-nan": {
-          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
           "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
         },
         "oauth-sign": {
-          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
           "integrity": "sha1-GCQ5vbkTeL90YOdcZOpD5kSN7wY="
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
         },
         "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
         },
         "performance-now": {
-          "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
           "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
         },
         "process-nextick-args": {
-          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
           "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
         },
         "pseudomap": {
-          "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "punycode": {
-          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "rc": {
-          "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
           "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
           "dependencies": {
             "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
           "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY="
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
           "dependencies": {
             "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+              "version": "7.0.5",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
               "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU="
             },
             "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
               "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo="
             }
           }
         },
         "safe-buffer": {
-          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
         },
         "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "sntp": {
-          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
         },
         "sshpk": {
-          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
           "integrity": "sha1-rXtH3vymHIQV2WQkO2KwzmD7yjg="
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
           "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
         },
         "stringstream": {
-          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
         },
         "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
         },
         "tar": {
-          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
         },
         "tar-pack": {
-          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
           "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
           "dependencies": {
             "readable-stream": {
-              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA="
             }
           }
         },
         "tweetnacl": {
-          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+          "version": "0.14.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
           "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
           "optional": true
         },
         "uid-number": {
-          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
         },
         "util-deprecate": {
-          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "verror": {
-          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
         },
         "wide-align": {
-          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
           "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
         },
         "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
           "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
         },
         "yallist": {
-          "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
           "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ="
         }
       }
@@ -5892,7 +6005,8 @@
                           "dev": true,
                           "dependencies": {
                             "iconv-lite": {
-                              "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
+                              "version": "0.4.17",
+                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
                               "integrity": "sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0=",
                               "dev": true
                             }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,39 +4,48 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@types/angular": {
-      "version": "https://registry.npmjs.org/@types/angular/-/angular-1.6.17.tgz",
-      "integrity": "sha1-W9WedzUJQ/+/+4u5jf5xisu27Sc="
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.18.tgz",
+      "integrity": "sha512-BZW2QjWyr6mbji1liIceUeryvmrpX37fC6Rel6MG9s0BeWMpvOrTHcHcB/8f2oII9R/k/ZNXDBorp+tDhTWTBg=="
     },
     "@types/jquery": {
-      "version": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.43.tgz",
-      "integrity": "sha1-4w2XHVbc4ivw1i4CvUsop//boHY="
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.46.tgz",
+      "integrity": "sha512-U64bkZqTfFi4HXHqOckD1Uxvg+oPooCjD5bQ10t9xOG5Ke6cR8tFnvERXrQtrRWvgS428nhAL1V8qv1b88kgyQ=="
     },
     "@types/lodash": {
-      "version": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.64.tgz",
-      "integrity": "sha1-l5zzo9SjaGcIQL+bPkSNwz/+hO4="
+      "version": "4.14.66",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.66.tgz",
+      "integrity": "sha512-LpGSiIy5/utq8AT2bSXGnENnS1kCZJ1m84L1yqKst2UehSZe6VWROmiysYg/lLJR6zu2ooeVoQtkUHToA+mEtQ=="
     },
     "@types/lodash.assign": {
-      "version": "https://registry.npmjs.org/@types/lodash.assign/-/lodash.assign-4.2.2.tgz",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/lodash.assign/-/lodash.assign-4.2.2.tgz",
       "integrity": "sha1-+dLT2xyGqG6Rg8ed+ZpGVayU2ck="
     },
     "@types/lodash.frompairs": {
-      "version": "https://registry.npmjs.org/@types/lodash.frompairs/-/lodash.frompairs-4.0.2.tgz",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/lodash.frompairs/-/lodash.frompairs-4.0.2.tgz",
       "integrity": "sha1-8E5OjpaGT8WSnRd1yRyTpqHJsKo="
     },
     "@types/lodash.mapvalues": {
-      "version": "https://registry.npmjs.org/@types/lodash.mapvalues/-/lodash.mapvalues-4.6.2.tgz",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mapvalues/-/lodash.mapvalues-4.6.2.tgz",
       "integrity": "sha1-Acvr3ltYjQvXMufvk/pX6nF6ZCA="
     },
     "@types/lodash.some": {
-      "version": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz",
       "integrity": "sha1-0NFnq4NBfPTVdM30yqIY/7oyygA="
     },
     "@types/react": {
-      "version": "https://registry.npmjs.org/@types/react/-/react-15.0.24.tgz",
-      "integrity": "sha1-inUpncN5Bt8yfBjKkYv5elXnEjs="
+      "version": "15.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.28.tgz",
+      "integrity": "sha512-B63xn08FhmOGoOwOw4QswI4sMrEMqRMpPtcLmqJeXAABcAD6qha9OcJ890yorRgf5B9pG0GR9u5gGyWSgsLVCQ=="
     },
     "@types/react-dom": {
-      "version": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.0.tgz",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.0.tgz",
       "integrity": "sha1-f0+5YT1AURQXcyQve2tfGkazS9k="
     },
     "7zip-bin": {
@@ -67,89 +76,114 @@
       "optional": true
     },
     "abbrev": {
-      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
       "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
     "acorn": {
-      "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
-      "integrity": "sha1-7c2jvZN+dVZBDULtWGD2c5nHlMA=",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
-    "ajv": {
-      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-      "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "dev": true,
       "dependencies": {
-        "json-stable-stringify": {
-          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
         }
       }
     },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+    },
     "ajv-keywords": {
-      "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
       "dev": true
     },
     "align-text": {
-      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true
     },
     "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "angular": {
-      "version": "https://registry.npmjs.org/angular/-/angular-1.6.3.tgz",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.3.tgz",
       "integrity": "sha1-XTS3mSNOj6F8ajoU4CWHM5NfQ+c="
     },
     "angular-if-state": {
-      "version": "https://registry.npmjs.org/angular-if-state/-/angular-if-state-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/angular-if-state/-/angular-if-state-1.0.0.tgz",
       "integrity": "sha1-NqQ4N88nHs73F/bJCw3/L76WTOQ=",
       "dependencies": {
         "angular-ui-router": {
-          "version": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.3.2.tgz",
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.3.2.tgz",
           "integrity": "sha1-wn4EljCcmSGNVlWYWxZKCWq1IKk="
         }
       }
     },
     "angular-middle-ellipses": {
-      "version": "https://registry.npmjs.org/angular-middle-ellipses/-/angular-middle-ellipses-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/angular-middle-ellipses/-/angular-middle-ellipses-1.0.0.tgz",
       "integrity": "sha1-zb3ECkXOMihJU1foQDV/1AyqUks="
     },
     "angular-mocks": {
-      "version": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.3.tgz",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.3.tgz",
       "integrity": "sha1-Evr8Dx4JA/FoZABLo3W/P7kQHvE=",
       "dev": true
     },
     "angular-moment": {
-      "version": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.0.1.tgz",
       "integrity": "sha1-UJ0zJq6iP3giHP3bK2K/7eaEHTE="
     },
     "angular-seconds-to-date": {
-      "version": "https://registry.npmjs.org/angular-seconds-to-date/-/angular-seconds-to-date-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/angular-seconds-to-date/-/angular-seconds-to-date-1.0.0.tgz",
       "integrity": "sha1-7eN/jrRLZXxo2XRamkBulqbefR8="
     },
     "angular-ui-bootstrap": {
-      "version": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
       "integrity": "sha1-L6zvuRU4ZlXcX0QVAlgDJRcjbQE="
     },
     "angular-ui-router": {
-      "version": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.2.tgz",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.2.tgz",
       "integrity": "sha1-tq7Rymmmg8guOZKJjqvUuhWGhgg="
     },
     "ansi-align": {
@@ -173,139 +207,176 @@
       }
     },
     "ansi-escapes": {
-      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "any-promise": {
-      "version": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
     "apple-data-compression": {
-      "version": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.1.0.tgz",
       "integrity": "sha1-v9ahaDXk+LDnbCNzRbJBqnf13y8="
     },
     "aproba": {
-      "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true
     },
     "arch": {
-      "version": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
       "integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
     },
     "are-we-there-yet": {
-      "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-      "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-      "dev": true
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
     },
     "argparse": {
-      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-      "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
     },
     "arr-diff": {
-      "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true
     },
     "arr-filter": {
-      "version": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "dependencies": {
         "make-iterator": {
-          "version": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
           "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
           "dev": true
         }
       }
     },
     "arr-flatten": {
-      "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-      "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+      "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
       "dev": true
     },
     "array-filter": {
-      "version": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
     "array-find-index": {
-      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-map": {
-      "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
       "dev": true
     },
     "array-reduce": {
-      "version": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
     "array-slice": {
-      "version": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
       "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true
     },
     "array-sort": {
-      "version": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.2.tgz",
       "integrity": "sha1-rqb8klPzP65+jDWwIASzga0NZDM=",
       "dev": true,
       "dependencies": {
         "kind-of": {
-          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true
         }
       }
     },
     "array-union": {
-      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true
     },
     "array-uniq": {
-      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
-      "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arrify": {
-      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
-      "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
       "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
     },
     "asar": {
-      "version": "https://registry.npmjs.org/asar/-/asar-0.10.0.tgz",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-0.10.0.tgz",
       "integrity": "sha1-JK+b8RuQKVQSX+N4Hn9ZKmYR0mc=",
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
-        },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true
         }
       }
@@ -317,178 +388,173 @@
       "dev": true
     },
     "asn1": {
-      "version": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-      "dev": true
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
-      "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true
     },
     "assert": {
-      "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true
     },
     "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "assertion-error": {
-      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "ast-types": {
-      "version": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.12.tgz",
+      "integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k=",
       "dev": true
     },
     "astw": {
-      "version": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
-      "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
     "async-foreach": {
-      "version": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "autolinker": {
-      "version": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
       "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
       "dev": true
     },
     "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
-      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true,
-      "dependencies": {
-        "js-tokens": {
-          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base64-js": {
-      "version": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
     },
     "bcrypt-pbkdf": {
-      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true
     },
     "binary": {
-      "version": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true
     },
     "bindings": {
-      "version": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
     "bl": {
-      "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true
         }
       }
     },
     "block-stream": {
-      "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true
     },
     "bloodline": {
-      "version": "https://registry.npmjs.org/bloodline/-/bloodline-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bloodline/-/bloodline-1.0.1.tgz",
       "integrity": "sha1-E/kwNaTtPG0pUwgkkkWg7XZ7NeI="
     },
     "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
-      "integrity": "sha1-tzHd9I4t077awudeEhWhG8uR+gc="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "bluebird-lst": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.2.tgz",
       "integrity": "sha1-x7JhdrbI+kWL5wPesGRKKPZKR1s=",
-      "dev": true,
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "bluebird-retry": {
-      "version": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.10.1.tgz",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.10.1.tgz",
       "integrity": "sha1-zfdrAdSm3U/sTiyENgqKCQB/Z9o="
     },
     "bmapflash": {
-      "version": "https://registry.npmjs.org/bmapflash/-/bmapflash-1.2.1.tgz",
-      "integrity": "sha1-O96v+FBrBBj+4G5FbloIxc9xvLY=",
-      "dependencies": {
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
-        },
-        "xml2js": {
-          "version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-          "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
-      }
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bmapflash/-/bmapflash-1.2.1.tgz",
+      "integrity": "sha1-O96v+FBrBBj+4G5FbloIxc9xvLY="
     },
     "bn.js": {
-      "version": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
       "dev": true
     },
     "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
     },
     "bootstrap-sass": {
-      "version": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.6.tgz",
-      "integrity": "sha1-NjsNMA6GjT5wE0wadCuxcohET9E="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
     },
     "boxen": {
       "version": "1.1.0",
@@ -517,145 +583,171 @@
       }
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true
     },
     "braces": {
-      "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true
     },
     "brorand": {
-      "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-pack": {
-      "version": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
-      "dev": true,
-      "dependencies": {
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "browser-resolve": {
-      "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
       "dev": true,
       "dependencies": {
         "resolve": {
-          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
       }
     },
     "browser-stdout": {
-      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "browserify": {
-      "version": "git://github.com/jviotti/node-browserify.git#14691ac9257063000e4aa216073cdad28b9d04e1",
-      "integrity": "sha1-XF/jMVrxa5Oggni58N2FixQUonY=",
+      "version": "github:jviotti/node-browserify#14691ac9257063000e4aa216073cdad28b9d04e1",
       "dev": true,
       "dependencies": {
-        "base64-js": {
-          "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-          "dev": true
-        },
         "buffer": {
-          "version": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
           "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
           "dev": true
         },
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true,
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+              "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+              "dev": true
+            }
+          }
+        },
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "browserify-aes": {
-      "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
       "dev": true
     },
     "browserify-cipher": {
-      "version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true
     },
     "browserify-des": {
-      "version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true
     },
     "browserify-rsa": {
-      "version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true
     },
     "browserify-sign": {
-      "version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true
     },
     "browserify-zlib": {
-      "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true
     },
     "buffer": {
-      "version": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+        },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
     "buffer-crc32": {
-      "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
-      "integrity": "sha1-2wA6wmceYuvW7OeOosLhtAVzbpE="
-    },
-    "buffer-shims": {
-      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-xor": {
-      "version": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "buffers": {
-      "version": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "builtin-modules": {
-      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "builtin-status-codes": {
-      "version": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
@@ -666,31 +758,37 @@
       "dev": true
     },
     "cached-path-relative": {
-      "version": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
       "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
       "dev": true
     },
     "caller-path": {
-      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true
     },
     "callsites": {
-      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
-      "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "camelcase-keys": {
-      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
@@ -703,56 +801,67 @@
       "dev": true
     },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
-      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "optional": true
     },
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true
     },
     "chai-as-promised": {
-      "version": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
       "dev": true
     },
     "chai-datetime": {
-      "version": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
       "integrity": "sha1-M3n8GNng0A8u1GWZh1JNYhHGQqg=",
       "dev": true
     },
     "chai-interface": {
-      "version": "https://registry.npmjs.org/chai-interface/-/chai-interface-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/chai-interface/-/chai-interface-2.0.3.tgz",
       "integrity": "sha1-9SMW0k1kHMz2gKHGe87hgZCVv2c=",
       "dev": true
     },
     "chai-string": {
-      "version": "https://registry.npmjs.org/chai-string/-/chai-string-1.3.0.tgz",
-      "integrity": "sha1-32E58pQ5GxA1vlYG9gqEOzpQQec=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
+      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk=",
       "dev": true
     },
     "chai-things": {
-      "version": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
       "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
       "dev": true
     },
     "chainsaw": {
-      "version": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true
     },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "chromium-pickle-js": {
-      "version": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
       "integrity": "sha1-HUixB9ghJqLz4hHC6iX4A7pVGyE=",
       "dev": true
     },
@@ -763,12 +872,14 @@
       "dev": true
     },
     "cipher-base": {
-      "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
       "dev": true
     },
     "circular-json": {
-      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
       "dev": true
     },
@@ -779,42 +890,51 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
     },
     "cli-spinner": {
-      "version": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz",
       "integrity": "sha1-illwMyTpOpCPbmAeTnT1uFs3Hlw="
     },
     "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
     },
     "cliui": {
-      "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
     },
     "clone": {
-      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
     },
     "clone-stats": {
-      "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-context": {
-      "version": "https://registry.npmjs.org/code-context/-/code-context-0.5.3.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/code-context/-/code-context-0.5.3.tgz",
       "integrity": "sha1-42jHvSR9OscRANkbX9AuTmb6kCI=",
       "dev": true
     },
     "code-point-at": {
-      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-      "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "0.5.3",
@@ -823,29 +943,34 @@
       "dev": true
     },
     "colors": {
-      "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "columnify": {
-      "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs="
     },
     "combine-source-map": {
-      "version": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
       "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
       "dev": true
     },
     "combined-stream": {
-      "version": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "dev": true
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
     },
     "command-join": {
-      "version": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
       "integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
     },
     "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ="
     },
     "compare-version": {
@@ -854,23 +979,33 @@
       "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
     "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true
         }
@@ -883,48 +1018,86 @@
       "dev": true
     },
     "connective": {
-      "version": "https://registry.npmjs.org/connective/-/connective-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/connective/-/connective-1.0.0.tgz",
       "integrity": "sha1-F9XdQ21BbH3OMJ3M4z2x7gWUseg=",
       "dev": true
     },
     "console-browserify": {
-      "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true
     },
     "console-control-strings": {
-      "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
-      "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "convert-source-map": {
-      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
     },
     "cookie": {
-      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
-      "version": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
       "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
     },
     "crc32-stream": {
-      "version": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.1.tgz",
-      "integrity": "sha1-zixdw72P+zgw+ctH9UAiLGPJD6s="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.1.tgz",
+      "integrity": "sha1-zixdw72P+zgw+ctH9UAiLGPJD6s=",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+        }
+      }
     },
     "create-ecdh": {
-      "version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true
     },
@@ -935,32 +1108,35 @@
       "dev": true
     },
     "create-frame": {
-      "version": "https://registry.npmjs.org/create-frame/-/create-frame-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/create-frame/-/create-frame-0.1.4.tgz",
       "integrity": "sha1-wJzZiK0lX0O6T7GjvVB7FebSbDw=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "create-hash": {
-      "version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true
     },
     "create-hmac": {
-      "version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true
     },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
     },
     "cross-spawn-async": {
       "version": "2.2.5",
@@ -969,11 +1145,13 @@
       "dev": true
     },
     "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
     },
     "crypto-browserify": {
-      "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
       "dev": true
     },
@@ -984,223 +1162,235 @@
       "dev": true
     },
     "ctype": {
-      "version": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "dev": true
     },
     "cuint": {
-      "version": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
       "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
       "dev": true
     },
     "currently-unhandled": {
-      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true
     },
     "cwd": {
-      "version": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
       "integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
       "dev": true
     },
     "d": {
-      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
     },
     "dashdash": {
-      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "data-uri-to-buffer": {
-      "version": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz",
       "integrity": "sha1-RuE6udqOMJdFyNAc5UchPr2y/j8=",
       "dev": true
     },
     "date-now": {
-      "version": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "date.js": {
-      "version": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
       "integrity": "sha1-OefHx3rcdl0Qvs9JbKzTkTMtfMg=",
       "dev": true,
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         }
       }
     },
     "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs="
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "decamelize": {
-      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decompress-zip": {
-      "version": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
       "integrity": "sha1-vOYMEWZPLWYPykvPY0r23l1sFMc=",
       "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true
         }
       }
     },
     "deep-eql": {
-      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "dependencies": {
         "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-extend": {
-      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-      "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
     "deep-is": {
-      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "deep-map-keys": {
-      "version": "https://registry.npmjs.org/deep-map-keys/-/deep-map-keys-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/deep-map-keys/-/deep-map-keys-1.2.0.tgz",
       "integrity": "sha1-Q0GLgoykPSYajod7SSfknQxHjNk="
     },
     "defaults": {
-      "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730="
     },
     "define-property": {
-      "version": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true
     },
     "defined": {
-      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "degenerator": {
-      "version": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
-      "dev": true,
-      "dependencies": {
-        "esprima": {
-          "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
-      }
-    },
-    "del": {
-      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "dependencies": {
-        "globby": {
-          "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true
-        }
-      }
-    },
-    "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
       "dev": true
     },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "delegates": {
-      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "deps-sort": {
-      "version": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-      "dev": true,
-      "dependencies": {
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "des.js": {
-      "version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true
     },
     "detect-node": {
-      "version": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
     },
     "detect-process": {
-      "version": "https://registry.npmjs.org/detect-process/-/detect-process-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/detect-process/-/detect-process-1.0.4.tgz",
       "integrity": "sha1-Bmeklc2JVCKYdzsW9EPCh9kNVjo="
     },
     "detective": {
-      "version": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
       "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
       "dev": true
     },
     "dev-null-stream": {
-      "version": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz",
       "integrity": "sha1-oqLie025mSjW2NRNXF9++9TLQ3I="
     },
     "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
     "diffie-hellman": {
-      "version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true
     },
     "doctrine": {
-      "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
       }
     },
     "domain-browser": {
-      "version": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
@@ -1213,24 +1403,33 @@
     "drivelist": {
       "version": "5.0.22",
       "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.22.tgz",
-      "integrity": "sha1-ZAKaFtUwtIXXwrP3SBScm8bocfA=",
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
+      "integrity": "sha1-ZAKaFtUwtIXXwrP3SBScm8bocfA="
     },
     "duplexer2": {
-      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1238,42 +1437,22 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "easy-stack": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz",
+      "integrity": "sha1-EskbMIWjfwuqM26UhurEv5Tj54g="
+    },
     "ecc-jsbn": {
-      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true
     },
     "electron": {
-      "version": "https://registry.npmjs.org/electron/-/electron-1.6.6.tgz",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.6.tgz",
       "integrity": "sha1-F9+M33PsLATPrXq7QTV5uLja/Cg=",
-      "dev": true,
-      "dependencies": {
-        "electron-download": {
-          "version": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
-          "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true
-        },
-        "nugget": {
-          "version": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-          "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-          "dev": true
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
-        "single-line-log": {
-          "version": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-          "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "electron-builder": {
       "version": "18.6.2",
@@ -1285,24 +1464,6 @@
           "version": "5.1.5",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.5.tgz",
           "integrity": "sha1-hzSTG2AfANT+73xlc4130bZdH2g=",
-          "dev": true
-        },
-        "ajv-keywords": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true
         },
         "camelcase": {
@@ -1317,22 +1478,10 @@
           "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
           "dev": true
         },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "execa": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+        "electron-download-tf": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
+          "integrity": "sha1-eTDySgjjZp6q04pffyiKEEYcr3I=",
           "dev": true
         },
         "find-up": {
@@ -1341,16 +1490,10 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true
         },
-        "get-stream": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -1359,16 +1502,10 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "js-yaml": {
-          "version": "3.8.4",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-          "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-          "dev": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+        "jsonfile": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
           "dev": true
         },
         "load-json-file": {
@@ -1377,40 +1514,16 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true
         },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-type": {
@@ -1431,18 +1544,6 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true
         },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
@@ -1453,6 +1554,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "sumchecker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+          "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
           "dev": true
         },
         "which-module": {
@@ -1485,103 +1592,55 @@
       "version": "18.6.0",
       "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.6.0.tgz",
       "integrity": "sha512-/kNnHN2gslrbZdT+K8hF8tNnfn/QTvJvj/lGudXFVvbn0PPgQ6Nb/bwAh67v0DSyJE1XMgzsbn5qSShrY19gyA==",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "electron-builder-util": {
       "version": "18.6.0",
       "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-18.6.0.tgz",
       "integrity": "sha512-8Kmfl5lpIhh1jFF2ZTnWIKs3jWsu7zoy0fhuZQn9srxPPbTG3ZD/uGnkEenH5QsNu5FGPtF+JmTMerJBH8No8A==",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
-    "electron-download-tf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
-      "integrity": "sha1-eTDySgjjZp6q04pffyiKEEYcr3I=",
+    "electron-download": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
+      "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
       "dev": true,
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
-        "sumchecker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
-          "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "electron-is-running-in-asar": {
-      "version": "https://registry.npmjs.org/electron-is-running-in-asar/-/electron-is-running-in-asar-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/electron-is-running-in-asar/-/electron-is-running-in-asar-1.0.0.tgz",
       "integrity": "sha1-9ufRapejP+R99S4/lUazcBfx+so="
     },
     "electron-mocha": {
-      "version": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-3.3.0.tgz",
-      "integrity": "sha1-09Yzepmedmw7eCqWOF+DrsUW038=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-3.5.0.tgz",
+      "integrity": "sha512-ynm4tZ4LZfHMXulsUOLtcg/Vd/8ZmkDLEC2PUm6HjXj9Qg1tuD5RhxMd3jrvaSZXMbEKl8SZ6jM1zRYP/QpkCg==",
       "dev": true,
       "dependencies": {
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true
         },
-        "fs-extra": {
-          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+        "jsonfile": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
           "dev": true
         }
       }
@@ -1592,22 +1651,10 @@
       "integrity": "sha1-I5ji18q1wdjD7quxzUkDdlKOw5o=",
       "dev": true,
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
@@ -1619,21 +1666,25 @@
       "dev": true
     },
     "electron-window": {
-      "version": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
       "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
       "dev": true
     },
     "elliptic": {
-      "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true
     },
     "encoding": {
-      "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
     },
     "ent": {
-      "version": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
@@ -1644,110 +1695,86 @@
       "dev": true
     },
     "error": {
-      "version": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dependencies": {
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "error-ex": {
-      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
     },
     "es5-ext": {
-      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc="
+      "version": "0.10.23",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg="
     },
     "es6-iterator": {
-      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
     },
     "es6-map": {
-      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
-          "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
-          "dev": true
-        },
-        "es6-iterator": {
-          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true
-        },
-        "es6-symbol": {
-          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "es6-promise": {
-      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
       "integrity": "sha1-3aA8qPn4m8WX5omEKSnee6jOvfA=",
       "dev": true
     },
     "es6-set": {
-      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
-          "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
-          "dev": true
-        },
-        "es6-iterator": {
-          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-          "dev": true
-        },
-        "es6-symbol": {
-          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "es6-symbol": {
-      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
     },
     "es6-weak-map": {
-      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-      "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8="
     },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
           "dev": true
         },
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
           "optional": true
@@ -1755,444 +1782,441 @@
       }
     },
     "escope": {
-      "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true
     },
     "eslint": {
-      "version": "https://registry.npmjs.org/eslint/-/eslint-3.18.0.tgz",
-      "integrity": "sha1-ZH6YXErnFQLSCsYsEJ9m1RBMiks=",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "dependencies": {
         "cli-width": {
-          "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
           "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
           "dev": true
         },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        },
         "inquirer": {
-          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true
         },
-        "json-stable-stringify": {
-          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true
-        },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
       }
     },
     "eslint-plugin-lodash": {
-      "version": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.3.6.tgz",
-      "integrity": "sha1-BUJBfEQqVxjpmvcahB2eRI5ONxc=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.4.2.tgz",
+      "integrity": "sha1-oDFgEG34FKuUN2xUL/NIY0FKn3A=",
       "dev": true
     },
     "espree": {
-      "version": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
-      "integrity": "sha1-QWVvpWKOBCh4Al70Z+ePEly4bh0=",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
-          "integrity": "sha1-F6jWp6bE71OLgU7Jq6wneSk78wo=",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+          "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
-      "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esquery": {
-      "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true
     },
     "esrecurse": {
-      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
       "dependencies": {
         "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
           "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
           "dev": true
         }
       }
     },
     "estraverse": {
-      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etcher-image-write": {
-      "version": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.3.tgz",
-      "integrity": "sha1-2TOTH3ZsbmFUD9Prj01kJz2nYJw=",
-      "dependencies": {
-        "bluebird": {
-          "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-        },
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
-          "integrity": "sha1-qfpvvpykPPHnn3O3XAGJy7fW21o="
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
-        },
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
-      }
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.3.tgz",
+      "integrity": "sha1-2TOTH3ZsbmFUD9Prj01kJz2nYJw="
     },
     "event-emitter": {
-      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
-        },
-        "es5-ext": {
-          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
-          "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "event-pubsub": {
-      "version": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.2.3.tgz",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.2.3.tgz",
       "integrity": "sha1-DTFC9HrH4No4zcOEAtl+JRC8Xsw="
     },
     "events": {
-      "version": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "evp_bytestokey": {
-      "version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
       "dev": true
     },
     "execa": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-      "dev": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+      "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY="
     },
     "exit-hook": {
-      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
     },
     "expand-brackets": {
-      "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true
     },
     "expand-range": {
-      "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true
     },
     "expand-tilde": {
-      "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "dev": true
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
-      "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true
     },
     "extglob": {
-      "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true
     },
     "extract-zip": {
-      "version": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.0.tgz",
-      "integrity": "sha1-f0AMlgfqhm7Kt6ptVPuXjusRYho=",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
       "dev": true,
       "dependencies": {
         "concat-stream": {
-          "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
         "mkdirp": {
-          "version": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true
         },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true
         },
         "yauzl": {
-          "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true
         }
       }
     },
     "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
     },
     "fast-levenshtein": {
-      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fbjs": {
-      "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-      "dependencies": {
-        "core-js": {
-          "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
-      }
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
     },
     "fd-slicer": {
-      "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU="
     },
     "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
     },
     "file-contents": {
-      "version": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
       "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-          "dev": true
-        },
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "file-entry-cache": {
-      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true
     },
     "file-exists": {
-      "version": "https://registry.npmjs.org/file-exists/-/file-exists-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-1.0.0.tgz",
       "integrity": "sha1-5tJptWVnuJIlgTmOmQ3XB49y1hY=",
       "dev": true
     },
     "file-name": {
-      "version": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
       "integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc=",
       "dev": true
     },
     "file-stat": {
-      "version": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
       "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-          "dev": true
-        },
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "file-type": {
-      "version": "https://registry.npmjs.org/file-type/-/file-type-4.1.0.tgz",
-      "integrity": "sha1-aQtwKTcV1/05aX4496EI66slUbk="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+      "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
     },
     "file-uri-to-path": {
-      "version": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz",
       "integrity": "sha1-N83RtbkFQEs/BeGyNkW+aU/3D4I=",
       "dev": true
     },
     "filename-regex": {
-      "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "filendir": {
-      "version": "https://registry.npmjs.org/filendir/-/filendir-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/filendir/-/filendir-1.0.0.tgz",
       "integrity": "sha1-dFtEWvzElwpM2wD9lTnHftlCrfY=",
       "dev": true
     },
     "fill-range": {
-      "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         }
       }
     },
     "find-file-up": {
-      "version": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
       "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
       "dev": true
     },
     "find-pkg": {
-      "version": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
       "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
       "dev": true
     },
     "find-up": {
-      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
     },
     "flat": {
-      "version": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
       "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8="
     },
     "flat-cache": {
-      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true
     },
     "flexboxgrid": {
-      "version": "https://registry.npmjs.org/flexboxgrid/-/flexboxgrid-6.3.0.tgz",
-      "integrity": "sha1-jclF7717EpWkKb8mpXQfS7iCXSw="
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/flexboxgrid/-/flexboxgrid-6.3.1.tgz",
+      "integrity": "sha1-6ZiYr8B7cEdyK7galYpfuk1OIP0="
     },
     "for-in": {
-      "version": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
       "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
       "dev": true
     },
     "for-own": {
-      "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "dependencies": {
         "for-in": {
-          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         }
       }
     },
     "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-      "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-      "dependencies": {
-        "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
-        },
-        "delayed-stream": {
-          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-          "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww="
-        },
-        "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-          "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk="
-        }
-      }
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
     },
     "formatio": {
-      "version": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true
     },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+      "dev": true
+    },
     "front-matter": {
-      "version": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.0.tgz",
       "integrity": "sha1-C9/0LLrSs1wHrHCFgReJdZ+YWMA=",
       "dev": true
     },
     "fs-exists-sync": {
-      "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
     "fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+      "integrity": "sha1-rwXKcCsLbfp96AOh96tHnsXCFSU=",
       "dev": true,
       "dependencies": {
-        "jsonfile": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
-          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true
         }
       }
@@ -2201,157 +2225,221 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.3.0.tgz",
       "integrity": "sha1-LhSKVEKH3wJYkxyrxYMGO07tIwM=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
+          "dev": true
+        }
+      }
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fstream": {
-      "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true
     },
     "ftp": {
-      "version": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "function-bind": {
-      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
     "gauge": {
-      "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-      "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true
     },
     "gaze": {
-      "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-      "dev": true,
-      "dependencies": {
-        "globule": {
-          "version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
-          "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
-          "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "generate-function": {
-      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
-      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true
     },
     "get-caller-file": {
-      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-object": {
-      "version": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
       "integrity": "sha1-2S/31RkMZFMM2gVD2sY6PUf+jAw=",
       "dev": true
     },
     "get-stdin": {
-      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4="
+    },
+    "get-uri": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.0.tgz",
+      "integrity": "sha1-cT5Hy8uuqzj4ivHN/IX6fwmwBzg=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
     },
     "get-value": {
-      "version": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
-      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "git-config-path": {
-      "version": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "dev": true
     },
     "git-repo-name": {
-      "version": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
       "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
       "dev": true
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "dev": true
     },
     "glob-base": {
-      "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true
     },
     "glob-parent": {
-      "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true
     },
     "global-modules": {
-      "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true
     },
     "global-prefix": {
-      "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dev": true
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "dependencies": {
-        "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         }
       }
     },
-    "globals": {
-      "version": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
-      "integrity": "sha1-Y+kDZYFx7C2fUbHTHeXiuNwB+4A=",
-      "dev": true
+    "globule": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        }
+      }
     },
     "gonzales-pe": {
-      "version": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
       "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
       "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -2361,300 +2449,190 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
     },
     "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
-      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "handlebars": {
-      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true
         }
       }
     },
     "handlebars-helpers": {
-      "version": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.6.2.tgz",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.6.2.tgz",
       "integrity": "sha1-CY6xKCX9rogz4zm2MykA+Wh8XaE=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "har-schema": {
-      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
       "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
     },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
     },
     "has": {
-      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true
     },
     "has-ansi": {
-      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-flag": {
-      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-unicode": {
-      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-values": {
-      "version": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
       "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
       "dev": true
     },
     "hash-base": {
-      "version": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true
     },
     "hash.js": {
-      "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
       "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
       "dev": true
     },
     "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
     },
     "helper-date": {
-      "version": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
       "integrity": "sha1-2HDKu6BB0ynMhW2yC7jElnTj7yg=",
-      "dev": true,
-      "dependencies": {
-        "moment": {
-          "version": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
-          "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "helper-markdown": {
-      "version": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.1.tgz",
-      "integrity": "sha1-N3xZJM2dNwkpEGoDQyXX9GhLvKw=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.2.tgz",
+      "integrity": "sha1-ONt/dxhJ4wrpXJL8AhuutT8uMEA=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         }
       }
     },
     "helper-md": {
-      "version": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.1.tgz",
-      "integrity": "sha1-Vdk3GEBeuh0oT28q7f/CX8+VSsY=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.2.tgz",
+      "integrity": "sha1-wfWdflW7riM2L9ig6XFgeuxp1B8=",
       "dev": true
     },
     "hmac-drbg": {
-      "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true
     },
     "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-path": {
-      "version": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz",
-      "integrity": "sha1-ns5Z/sPwMubRC1Q0/uJk30wt4y8=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
+      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
       "dev": true
     },
     "homedir-polyfill": {
-      "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true
     },
     "hosted-git-info": {
-      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-      "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
     },
     "html-angular-validate": {
-      "version": "github:jhermsmeier/html-angular-validate#1aeb1873edb267302fbd52340e41850c5b40b6f4",
+      "version": "github:jhermsmeier/html-angular-validate#2b1460b63b51be61023de1d02db8230464476a7d",
       "dev": true,
       "dependencies": {
-        "agent-base": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-          "dev": true
-        },
         "async": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true
-        },
-        "co": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
-          "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
-        "cookiejar": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
-          "dev": true
-        },
-        "formidable": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-          "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
-          "dev": true
-        },
-        "get-uri": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.0.tgz",
-          "integrity": "sha1-cT5Hy8uuqzj4ivHN/IX6fwmwBzg=",
-          "dev": true
-        },
-        "globule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-          "dev": true
-        },
-        "http-proxy-agent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
-          "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
-          "dev": true
-        },
-        "https-proxy-agent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-          "dev": true
-        },
-        "ip": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
-          "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-          "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
-          "dev": true
-        },
-        "methods": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-          "dev": true
-        },
-        "node.extend": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.0.tgz",
-          "integrity": "sha1-dSWih1Z36lNHhKXhCseJVhOWFN8=",
-          "dev": true
-        },
-        "pac-proxy-agent": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-1.1.0.tgz",
-          "integrity": "sha512-QBELCWyLYPgE2Gj+4wUEiMscHrQ8nRPBzYItQNOHWavwBt25ohZHQC4qnd5IszdVVrFbLsQ+dPkm6eqdjJAmwQ==",
-          "dev": true
-        },
-        "pac-resolver": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-2.0.0.tgz",
-          "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
-          "dev": true
-        },
-        "proxy-agent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.0.0.tgz",
-          "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        },
-        "socks-proxy-agent": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
-          "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
-          "dev": true
-        },
-        "superagent": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
-          "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
-          "dev": true
-        },
-        "superagent-proxy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.2.tgz",
-          "integrity": "sha1-ktNmBXj2GO1DqCz4yseZ/ik4ui0=",
-          "dev": true
-        },
-        "w3cjs": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/w3cjs/-/w3cjs-0.4.0.tgz",
-          "integrity": "sha1-EzYk4LhlYmfPanCF2NfGlLcPBI8=",
           "dev": true
         },
         "xmlbuilder": {
@@ -2666,39 +2644,59 @@
       }
     },
     "html-tag": {
-      "version": "https://registry.npmjs.org/html-tag/-/html-tag-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-0.2.1.tgz",
       "integrity": "sha1-r0jg3kdovRTonYXnPgZwQeIHRyI=",
       "dev": true
     },
     "htmlescape": {
-      "version": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
+    "http-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
+      "dev": true
+    },
     "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "https-browserify": {
-      "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "dev": true
+    },
     "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
     },
     "ieee754": {
-      "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
-      "integrity": "sha1-LhATIZxtZxKXPsVNmB7BnlV53pc="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
-      "version": "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz",
-      "integrity": "sha1-JujaBkS+C7TLOVFvbHnw4PT/5Iw=",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
       "dev": true
     },
     "immutable": {
-      "version": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
       "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
     },
     "import-lazy": {
@@ -2708,129 +2706,149 @@
       "dev": true
     },
     "imurmurhash": {
-      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
-      "version": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
-      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true
     },
     "index-of": {
-      "version": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
       "integrity": "sha1-OMHiNn6lXf+tO261kuwcwwkNfWU=",
       "dev": true
     },
     "indexof": {
-      "version": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
     "inline-source-map": {
-      "version": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true
     },
     "inquirer": {
-      "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
       "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
       "dependencies": {
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "inquirer-dynamic-list": {
-      "version": "https://registry.npmjs.org/inquirer-dynamic-list/-/inquirer-dynamic-list-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer-dynamic-list/-/inquirer-dynamic-list-1.0.0.tgz",
       "integrity": "sha1-x13pQj1yCoTRgQc6QKGO6kftC3g=",
       "dependencies": {
         "bluebird": {
-          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "insert-module-globals": {
-      "version": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "dependencies": {
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true
-        },
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "interpret": {
-      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-      "integrity": "sha1-1Xn7f2k7hYAElHrzn6DbSfeVYCw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
     "invert-kv": {
-      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ip": {
-      "version": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
+      "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
       "dev": true
     },
     "is": {
-      "version": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
       "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
       "dev": true
     },
     "is-absolute": {
-      "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true
     },
     "is-accessor-descriptor": {
-      "version": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true
     },
     "is-arrayish": {
-      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
-      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
     "is-ci": {
@@ -2840,84 +2858,92 @@
       "dev": true
     },
     "is-data-descriptor": {
-      "version": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true
     },
     "is-descriptor": {
-      "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.5.tgz",
       "integrity": "sha1-4/uLSrZfOjc3M4jhi0AdeMWMvqc=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "is-dotfile": {
-      "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-      "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-electron": {
-      "version": "https://registry.npmjs.org/is-electron/-/is-electron-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.0.0.tgz",
       "integrity": "sha1-yC01mWQPffkchOqu52vFZxPGrHk="
     },
     "is-electron-renderer": {
-      "version": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
       "integrity": "sha1-pGnQVvl1aXxYyYxgI+sKp5r4laI=",
       "dev": true
     },
     "is-equal-shallow": {
-      "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true
     },
     "is-even": {
-      "version": "https://registry.npmjs.org/is-even/-/is-even-0.1.1.tgz",
-      "integrity": "sha1-8Q+/ti2JP3Vdja6PuaOYu8jNXyo=",
-      "dev": true,
-      "dependencies": {
-        "is-number": {
-          "version": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
-          "integrity": "sha1-nYJAnzqKi+7PJJsbx9raSYKZZuQ=",
-          "dev": true
-        }
-      }
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-even/-/is-even-0.1.2.tgz",
+      "integrity": "sha1-4EMqc3ny0gtuu8LLEeab6q8xzWM=",
+      "dev": true
     },
     "is-extendable": {
-      "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
-      "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
-      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
     "is-glob": {
-      "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "dependencies": {
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
@@ -2930,7 +2956,8 @@
       "dev": true
     },
     "is-number": {
-      "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true
     },
@@ -2941,52 +2968,62 @@
       "dev": true
     },
     "is-odd": {
-      "version": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.1.tgz",
-      "integrity": "sha1-UVCPfTnq+wKC+7mJV7LR0o5yo+c=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.2.tgz",
+      "integrity": "sha1-vFc7XONx7yqtbm9JeZtyvvE5eKc=",
       "dev": true,
       "dependencies": {
         "is-number": {
-          "version": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
-          "integrity": "sha1-nYJAnzqKi+7PJJsbx9raSYKZZuQ=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true
         }
       }
     },
     "is-path-cwd": {
-      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true
     },
     "is-path-inside": {
-      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true
     },
     "is-phantom": {
-      "version": "https://registry.npmjs.org/is-phantom/-/is-phantom-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-phantom/-/is-phantom-1.0.1.tgz",
       "integrity": "sha1-SksVhpA74wSgyRo8l3+KU4KsQ6I="
     },
     "is-posix-bracket": {
-      "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
-      "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-promise": {
-      "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-property": {
-      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
@@ -2997,12 +3034,14 @@
       "dev": true
     },
     "is-relative": {
-      "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "dev": true
     },
     "is-resolvable": {
-      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true
     },
@@ -3013,34 +3052,41 @@
       "dev": true
     },
     "is-stream": {
-      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
-      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
-      "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "dev": true
     },
     "is-utf8": {
-      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-valid-glob": {
-      "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
       "dev": true
     },
     "is-windows": {
-      "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
       "dev": true
     },
     "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
@@ -3050,69 +3096,76 @@
       "dev": true
     },
     "isexe": {
-      "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
       "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
       "dev": true
     },
     "isomorphic-fetch": {
-      "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
     },
     "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "jodid25519": {
-      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
-    },
     "js-base64": {
-      "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
       "dev": true
     },
     "js-message": {
-      "version": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
       "integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU="
     },
     "js-queue": {
-      "version": "https://registry.npmjs.org/js-queue/-/js-queue-1.0.0.tgz",
-      "integrity": "sha1-urLiJiH+8rJKNLgM4CtyaUHDugA="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz",
+      "integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug="
     },
     "js-tokens": {
-      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-      "integrity": "sha1-FOVutoyPGpLEPVn1AU7CncIPKuE="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
     },
     "js-yaml": {
-      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA="
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY="
     },
     "jsbn": {
-      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "json-schema": {
-      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
     },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
-      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
@@ -3123,51 +3176,61 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true
     },
     "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
-      "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
-      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "JSONStream": {
-      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
       "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
       "dev": true
     },
     "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dependencies": {
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "kind-of": {
-      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true
     },
     "klaw": {
-      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true
     },
     "labeled-stream-splicer": {
-      "version": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
       "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
       "dev": true
     },
@@ -3178,38 +3241,38 @@
       "dev": true
     },
     "lazy-cache": {
-      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
     "lcid": {
-      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
     "levn": {
-      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true
     },
     "lexical-scope": {
-      "version": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true
     },
     "list-item": {
-      "version": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
       "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
       "dev": true
     },
     "load-json-file": {
-      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dependencies": {
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
-        }
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
     },
     "locate-path": {
       "version": "2.0.0",
@@ -3226,169 +3289,192 @@
       }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-      "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash-deep": {
-      "version": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-2.0.0.tgz",
       "integrity": "sha1-ypWPW82z1o0+w3rN8cWMHMvYhlw="
     },
     "lodash-es": {
-      "version": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.13.1.tgz",
-      "integrity": "sha1-Pao28j8J7eCSpviIM//eCPe4WTw="
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
+      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
     },
     "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "dependencies": {
-        "lodash.keys": {
-          "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.assign": {
-      "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz",
-      "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.capitalize": {
-      "version": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
     "lodash.clonedeep": {
-      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.create": {
-      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true
     },
     "lodash.filter": {
-      "version": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
       "dev": true
     },
     "lodash.findkey": {
-      "version": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
       "integrity": "sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg=",
       "dev": true
     },
     "lodash.foreach": {
-      "version": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
     "lodash.frompairs": {
-      "version": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
       "integrity": "sha1-vE5SB/onV8E25XNhTpZkUGsrG9I="
     },
     "lodash.includes": {
-      "version": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "dev": true
     },
     "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isempty": {
-      "version": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
       "dev": true
     },
     "lodash.kebabcase": {
-      "version": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz",
-      "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true
     },
     "lodash.mapvalues": {
-      "version": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.memoize": {
-      "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
       "dev": true
     },
     "lodash.partition": {
-      "version": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
       "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=",
       "dev": true
     },
-    "lodash.rest": {
-      "version": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz",
-      "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU="
-    },
     "lodash.some": {
-      "version": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.trim": {
-      "version": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
       "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc=",
       "dev": true
     },
     "logging-helpers": {
-      "version": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
       "integrity": "sha1-AObVMWwjdn7BLhIA5PEsXgM+frA=",
       "dev": true
     },
     "lolex": {
-      "version": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "longest": {
-      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
-      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-      "integrity": "sha1-aaZarT3lQs9O4PT+dOjjPHCcyw8="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "loud-rejection": {
-      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true
     },
@@ -3399,509 +3485,499 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-      "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
-      "dev": true
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
     },
     "lsmod": {
-      "version": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
       "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
     },
     "lzma-native": {
-      "version": "https://registry.npmjs.org/lzma-native/-/lzma-native-1.5.2.tgz",
-      "integrity": "sha1-22VqwTNggVW9Dm6yqWqxrw3TPSQ=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-2.0.2.tgz",
+      "integrity": "sha512-cM+1OnKRacBh98mw5RJ3PEmFxhl70lDFAL50+x/a+fxzSZryBF1asADf57zliAtGhCNVHYzrJAZX+8R77AGYGg==",
       "dependencies": {
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
+        "abbrev": {
+          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+        },
+        "ajv": {
+          "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+          "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
+          "dependencies": {
+            "co": {
+              "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+        },
+        "aproba": {
+          "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+          "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
+        },
+        "are-we-there-yet": {
+          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM="
+        },
+        "asn1": {
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        },
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "asynckit": {
+          "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "aws4": {
+          "version": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
+          "integrity": "sha1-054L7kEs7Q6O2Uoj4xTzE6lbn9E="
+        },
+        "balanced-match": {
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
+        },
+        "block-stream": {
+          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
+        },
+        "boom": {
+          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+        },
+        "brace-expansion": {
+          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+          "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE="
+        },
+        "buffer-shims": {
+          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+        },
+        "code-point-at": {
+          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+          "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
+        },
+        "combined-stream": {
+          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+        },
+        "concat-map": {
+          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "console-control-strings": {
+          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+        },
+        "core-util-is": {
+          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cryptiles": {
+          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+        },
+        "dashdash": {
+          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+          "integrity": "sha1-parm/Z2OFWYk6w3ZJZ6xK6JFOFo=",
+          "dependencies": {
+            "assert-plus": {
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+        },
+        "deep-extend": {
+          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+        },
+        "delayed-stream": {
+          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "delegates": {
+          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "ecc-jsbn": {
+          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "optional": true
+        },
+        "extend": {
+          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+        },
+        "extsprintf": {
+          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+        },
+        "forever-agent": {
+          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "fs.realpath": {
+          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fstream": {
+          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE="
+        },
+        "fstream-ignore": {
+          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
+        },
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+          "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw="
+        },
+        "har-schema": {
+          "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+        },
+        "has-unicode": {
+          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        },
+        "hawk": {
+          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+        },
+        "hoek": {
+          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+        },
+        "inflight": {
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+          "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo="
+        },
+        "inherits": {
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "ini": {
+          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+        },
+        "is-typedarray": {
+          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isstream": {
+          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "jodid25519": {
+          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
+        },
+        "json-stable-stringify": {
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+        },
+        "json-stringify-safe": {
+          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonify": {
+          "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
+        "jsprim": {
+          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+          "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE="
+        },
+        "lru-cache": {
+          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+          "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4="
+        },
+        "mime-db": {
+          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+          "integrity": "sha1-qyOmNy3J2G09yRIb0OvTgQWhkEo="
+        },
+        "mime-types": {
+          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+          "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc="
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
+        },
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mkdirp": {
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "nan": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+          "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
         },
         "node-pre-gyp": {
-          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
-          "integrity": "sha1-sL0TY1uvfRvnriM8FvvPMwms03w=",
+          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
+          "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
           "dependencies": {
-            "abbrev": {
-              "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
-            },
-            "ansi-regex": {
-              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-            },
-            "ansi-styles": {
-              "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-            },
-            "aproba": {
-              "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-              "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
-            },
-            "are-we-there-yet": {
-              "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM="
-            },
-            "asn1": {
-              "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-            },
-            "assert-plus": {
-              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-            },
-            "async": {
-              "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            },
-            "aws-sign2": {
-              "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-            },
-            "aws4": {
-              "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE="
-            },
-            "balanced-match": {
-              "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-              "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU="
-            },
-            "bl": {
-              "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
-                }
-              }
-            },
-            "block-stream": {
-              "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
-            },
-            "boom": {
-              "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
-            },
-            "brace-expansion": {
-              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-              "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY="
-            },
-            "buffer-shims": {
-              "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-            },
             "caseless": {
-              "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-            },
-            "chalk": {
-              "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
-            },
-            "code-point-at": {
-              "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-              "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
-            },
-            "combined-stream": {
-              "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
-            },
-            "commander": {
-              "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
-            },
-            "concat-map": {
-              "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-            },
-            "console-control-strings": {
-              "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-            },
-            "core-util-is": {
-              "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-            },
-            "cryptiles": {
-              "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
-            },
-            "dashdash": {
-              "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-              "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
-              }
-            },
-            "debug": {
-              "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
-            },
-            "deep-extend": {
-              "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
-            },
-            "delayed-stream": {
-              "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-            },
-            "delegates": {
-              "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-            },
-            "ecc-jsbn": {
-              "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-              "optional": true
-            },
-            "escape-string-regexp": {
-              "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-            },
-            "extend": {
-              "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
-            },
-            "extsprintf": {
-              "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-            },
-            "forever-agent": {
-              "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+              "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
             },
             "form-data": {
-              "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-              "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14="
-            },
-            "fs.realpath": {
-              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-            },
-            "fstream": {
-              "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-              "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI="
-            },
-            "fstream-ignore": {
-              "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
-            },
-            "gauge": {
-              "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-              "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY="
-            },
-            "generate-function": {
-              "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-            },
-            "generate-object-property": {
-              "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
-            },
-            "getpass": {
-              "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-              "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+              "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+              "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
               "dependencies": {
-                "assert-plus": {
-                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                "mime-types": {
+                  "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+                  "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4="
                 }
               }
             },
+            "gauge": {
+              "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+              "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk="
+            },
+            "glob": {
+              "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
+            },
+            "har-validator": {
+              "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+            },
+            "mime-db": {
+              "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+              "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
+            },
+            "npmlog": {
+              "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+              "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518="
+            },
+            "object-assign": {
+              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            },
+            "qs": {
+              "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+            },
+            "request": {
+              "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+            },
+            "rimraf": {
+              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ="
+            },
+            "semver": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+            },
+            "signal-exit": {
+              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            },
+            "tough-cookie": {
+              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+            },
+            "tunnel-agent": {
+              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+            },
+            "uuid": {
+              "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+            }
+          }
+        },
+        "nopt": {
+          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
+        },
+        "number-is-nan": {
+          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+        },
+        "oauth-sign": {
+          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+          "integrity": "sha1-GCQ5vbkTeL90YOdcZOpD5kSN7wY="
+        },
+        "once": {
+          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
+        },
+        "path-is-absolute": {
+          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+        },
+        "performance-now": {
+          "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        },
+        "process-nextick-args": {
+          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+          "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
+        },
+        "pseudomap": {
+          "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "punycode": {
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "rc": {
+          "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+          "dependencies": {
+            "minimist": {
+              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+          "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY="
+        },
+        "rimraf": {
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+          "dependencies": {
             "glob": {
               "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
               "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU="
             },
-            "graceful-fs": {
-              "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-              "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
-            },
-            "graceful-readlink": {
-              "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-            },
-            "har-validator": {
-              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
-            },
-            "has-ansi": {
-              "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
-            },
-            "has-color": {
-              "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-              "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-            },
-            "has-unicode": {
-              "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-            },
-            "hawk": {
-              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
-            },
-            "hoek": {
-              "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-            },
-            "http-signature": {
-              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
-            },
-            "inflight": {
-              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo="
-            },
-            "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-            },
-            "ini": {
-              "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
-            },
-            "is-fullwidth-code-point": {
-              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
-            },
-            "is-my-json-valid": {
-              "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-              "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc="
-            },
-            "is-property": {
-              "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-            },
-            "is-typedarray": {
-              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-            },
-            "isarray": {
-              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "isstream": {
-              "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-            },
-            "jodid25519": {
-              "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-              "optional": true
-            },
-            "jsbn": {
-              "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-              "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-              "optional": true
-            },
-            "json-schema": {
-              "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-              "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
-            },
-            "json-stringify-safe": {
-              "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-            },
-            "jsonpointer": {
-              "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-              "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk="
-            },
-            "jsprim": {
-              "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-              "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA="
-            },
-            "mime-db": {
-              "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-              "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
-            },
-            "mime-types": {
-              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw="
-            },
             "minimatch": {
               "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
               "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo="
-            },
-            "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-            },
-            "mkdirp": {
-              "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
-            },
-            "ms": {
-              "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-            },
-            "node-uuid": {
-              "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
-            },
-            "nopt": {
-              "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
-            },
-            "npmlog": {
-              "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-              "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM="
-            },
-            "number-is-nan": {
-              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-              "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
-            },
-            "oauth-sign": {
-              "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-            },
-            "object-assign": {
-              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-            },
-            "once": {
-              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
-            },
-            "path-is-absolute": {
-              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
-            },
-            "pinkie": {
-              "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-            },
-            "pinkie-promise": {
-              "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
-            },
-            "process-nextick-args": {
-              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-            },
-            "qs": {
-              "version": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
-              "integrity": "sha1-7B0WJrJCeNmfD99FSeUk4k7O6yY="
-            },
-            "rc": {
-              "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-              "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-              "dependencies": {
-                "minimist": {
-                  "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-              "integrity": "sha1-cLl5HG/LhIDbRL0VWg9rtY8XJGg="
-            },
-            "request": {
-              "version": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
-              "integrity": "sha1-DOOheVEmILEEQfFMguIcEsDdtOE="
-            },
-            "rimraf": {
-              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-              "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY="
-            },
-            "semver": {
-              "version": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-              "integrity": "sha1-KBmVuAwUSCCUFd28TPUMJpzvVcU="
-            },
-            "set-blocking": {
-              "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-            },
-            "signal-exit": {
-              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-              "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g="
-            },
-            "sntp": {
-              "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
-            },
-            "sshpk": {
-              "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-              "integrity": "sha1-iQzJ1hTcUpLlyxpUOwPJq6pcN04=",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-            },
-            "string-width": {
-              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
-            },
-            "stringstream": {
-              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-            },
-            "strip-ansi": {
-              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-            },
-            "strip-json-comments": {
-              "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
-            },
-            "supports-color": {
-              "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            },
-            "tar": {
-              "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
-            },
-            "tar-pack": {
-              "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
-              "integrity": "sha1-vIz5oi9YMnOfEvORDaweuXtJcIw="
-            },
-            "tough-cookie": {
-              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-              "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
-            },
-            "tunnel-agent": {
-              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-            },
-            "tweetnacl": {
-              "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-              "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
-              "optional": true
-            },
-            "uid-number": {
-              "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-            },
-            "util-deprecate": {
-              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-            },
-            "verror": {
-              "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
-            },
-            "wide-align": {
-              "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-              "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
-            },
-            "wrappy": {
-              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-            },
-            "xtend": {
-              "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
+        },
+        "safe-buffer": {
+          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+        },
+        "set-blocking": {
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "sntp": {
+          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+        },
+        "sshpk": {
+          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
+          "integrity": "sha1-rXtH3vymHIQV2WQkO2KwzmD7yjg="
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+          "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
+        },
+        "stringstream": {
+          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+        },
+        "strip-ansi": {
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+        },
+        "strip-json-comments": {
+          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+        },
+        "tar": {
+          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
+        },
+        "tar-pack": {
+          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+          "dependencies": {
+            "readable-stream": {
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA="
+            }
+          }
+        },
+        "tweetnacl": {
+          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+        },
+        "util-deprecate": {
+          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "verror": {
+          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+        },
+        "wide-align": {
+          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
+        },
+        "wrappy": {
+          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
+        },
+        "yallist": {
+          "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+          "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ="
         }
       }
     },
@@ -3918,55 +3994,77 @@
       "dev": true
     },
     "make-iterator": {
-      "version": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz",
       "integrity": "sha1-oZxmATK1SubWT4gewUBWx0bb6XI=",
       "dev": true
     },
     "map-obj": {
-      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "markdown": {
-      "version": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
       "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
       "dev": true,
       "dependencies": {
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
           "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
           "dev": true
         }
       }
     },
     "markdown-utils": {
-      "version": "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz",
       "integrity": "sha1-TFg6MeJR1psxOs6zgCpPXRsPHnY=",
       "dev": true
     },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y="
     },
     "meow": {
-      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "merge": {
-      "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
     "micromatch": {
-      "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true
     },
     "miller-rabin": {
-      "version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "dev": true
     },
@@ -3977,309 +4075,330 @@
       "dev": true
     },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
       "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
     },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimalistic-assert": {
-      "version": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
       "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
-      "version": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true
     },
     "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mixin-deep": {
-      "version": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
       "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
       "dev": true,
       "dependencies": {
         "for-in": {
-          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         }
       }
     },
     "mixpanel": {
-      "version": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.6.0.tgz",
       "integrity": "sha1-67sBGvASLcyDR5o6NdcVh4odeOI="
     },
     "mixpanel-browser": {
-      "version": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.11.0.tgz",
-      "integrity": "sha1-WRmpTbE+/x0TdRyvxgvGhf88jvI="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.11.1.tgz",
+      "integrity": "sha1-H266OO3MEkAT5IJcPzxCfbZ2VjM="
     },
     "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "dependencies": {
-        "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "mkpath": {
-      "version": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
       "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
       "dev": true
     },
     "mksnapshot": {
-      "version": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
       "integrity": "sha1-99CavKgGrYw3gNpwG7GHeNfOaaw=",
       "dev": true,
       "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+          "dev": true
+        },
         "assert-plus": {
-          "version": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
           "dev": true
         },
-        "async": {
-          "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
         "aws-sign2": {
-          "version": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
           "dev": true
         },
         "bluebird": {
-          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "caseless": {
-          "version": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
           "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
           "dev": true
         },
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
           "dev": true
         },
         "form-data": {
-          "version": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
           "dev": true
         },
-        "fs-extra": {
-          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
-          "integrity": "sha1-rwXKcCsLbfp96AOh96tHnsXCFSU=",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true
-        },
         "har-validator": {
-          "version": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
           "dev": true
         },
         "hawk": {
-          "version": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
           "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
           "dev": true
         },
         "http-signature": {
-          "version": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "dev": true
         },
         "mime-db": {
-          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
           "dev": true
         },
         "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "dev": true
         },
         "node-uuid": {
-          "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
           "dev": true
         },
         "oauth-sign": {
-          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
           "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
           "dev": true
         },
         "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
           "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
           "dev": true
         },
         "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "version": "2.55.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
           "dev": true
         },
         "tunnel-agent": {
-          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         }
       }
     },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
-      "integrity": "sha1-fcT0XlCIB1FxpoiWgU5q6et6heM=",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
           "dev": true
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true
         }
       }
     },
     "mochainon": {
-      "version": "https://registry.npmjs.org/mochainon/-/mochainon-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mochainon/-/mochainon-1.0.0.tgz",
       "integrity": "sha1-r6Po2kfA0Ox6eFdW8EudqkFhMbs=",
       "dev": true
     },
     "module-deps": {
-      "version": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "dependencies": {
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true
         },
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "moment": {
-      "version": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI="
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "moment-duration-format": {
-      "version": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz",
       "integrity": "sha1-VBdxtfh6BJzGVUBHXTrZZnN9aQg="
     },
     "mountutils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.2.0.tgz",
-      "integrity": "sha512-P64iNn/+w083X2jZIqYvYNTuJsey3MYLSBcDRZ1lecmYVS0r65w8eqyD0xFjfW++E7DqRkE7weFeWI+mppGI0w==",
-      "dependencies": {
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-        }
-      }
+      "integrity": "sha512-P64iNn/+w083X2jZIqYvYNTuJsey3MYLSBcDRZ1lecmYVS0r65w8eqyD0xFjfW++E7DqRkE7weFeWI+mppGI0w=="
     },
     "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
-      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
     },
     "nan": {
-      "version": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
-      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
     },
     "natives": {
-      "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
       "dev": true
     },
     "natural-compare": {
-      "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "netmask": {
-      "version": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
     },
     "ngcomponent": {
-      "version": "https://registry.npmjs.org/ngcomponent/-/ngcomponent-3.0.1.tgz",
-      "integrity": "sha1-Os62qfDxmg1pUo4GudzkkNxQIIQ=",
-      "dependencies": {
-        "lodash.assign": {
-          "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-        }
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ngcomponent/-/ngcomponent-3.0.1.tgz",
+      "integrity": "sha1-Os62qfDxmg1pUo4GudzkkNxQIIQ="
     },
     "nock": {
-      "version": "https://registry.npmjs.org/nock/-/nock-9.0.9.tgz",
-      "integrity": "sha1-ykzZIzUuIGrjx9ZZXP1/siMpnsA=",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": {
-          "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
-      }
-    },
-    "node-cmd": {
-      "version": "https://registry.npmjs.org/node-cmd/-/node-cmd-1.1.1.tgz",
-      "integrity": "sha1-nGFZ025rNbWexKtAhA0mqxSpgG0="
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.13.tgz",
+      "integrity": "sha1-0Lw570PTF5mB4isujqBp+RbFeBo=",
+      "dev": true
     },
     "node-emoji": {
       "version": "1.5.1",
@@ -4288,8 +4407,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
     },
     "node-forge": {
       "version": "0.7.1",
@@ -4298,78 +4418,87 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
-      "integrity": "sha1-qP5eYR0HnsFjSKPrlg544RyFJ0o=",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "dependencies": {
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         }
       }
     },
     "node-ipc": {
-      "version": "https://registry.npmjs.org/node-ipc/-/node-ipc-8.9.2.tgz",
-      "integrity": "sha1-HQEDWVXFpr0fC5MhdOoDMKud2XY="
+      "version": "8.10.3",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-8.10.3.tgz",
+      "integrity": "sha1-IjvUMa1/suQMVDT4peRVi+JWj70="
     },
     "node-sass": {
-      "version": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "dependencies": {
         "cross-spawn": {
-          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true
         },
-        "lodash.assign": {
-          "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         }
       }
     },
     "node-stream-zip": {
-      "version": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.4.tgz",
-      "integrity": "sha1-FaJMCUsBx3vp2PuswwwDTOwl13I="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.7.tgz",
+      "integrity": "sha1-uImTxhXT9hNM9e0ckT/uvNvlAw4="
+    },
+    "node.extend": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.0.tgz",
+      "integrity": "sha1-dSWih1Z36lNHhKXhCseJVhOWFN8=",
+      "dev": true
     },
     "nopt": {
-      "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true
     },
     "normalize-package-data": {
-      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8="
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
     },
     "normalize-path": {
-      "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-      "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true
     },
     "npm-run-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
     },
     "npmlog": {
-      "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-      "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
-      "dev": true,
-      "dependencies": {
-        "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true
-        }
-      }
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+      "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+      "dev": true
     },
     "npx": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/npx/-/npx-5.2.0.tgz",
-      "integrity": "sha512-I4qqDjY/OqHa6XB+hfQJoVHQc/N/B7vOSmv1noezTeryD/zTx5BCi86Zw+r9/Mf3rUkH6iJIqIG4b8nPF7MHAQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npx/-/npx-5.3.0.tgz",
+      "integrity": "sha512-o8V4NqQqmAF7knAyCLwkCw++ap049Pwql8gtQiO4lQgGSHpmxxeW9INa6M5SlPEYL/dg5hSuFDKpNO0ohiUlvQ==",
       "dev": true,
       "dependencies": {
         "ansi-align": {
@@ -7530,92 +7659,110 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
       "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "number-is-nan": {
-      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
-      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "object.omit": {
-      "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true
     },
     "omit-empty": {
-      "version": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
       "integrity": "sha1-KUo3gvLLIMdJfEEitiN8ncwMY6s=",
       "dev": true
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
     },
     "onetime": {
-      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "optimist": {
-      "version": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "dependencies": {
-        "minimist": {
-          "version": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
         "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
       }
     },
     "optionator": {
-      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true
     },
     "os-browserify": {
-      "version": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
-      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
-      "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+      "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ="
     },
     "os-tmpdir": {
-      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.1.0",
@@ -7629,6 +7776,26 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true
     },
+    "pac-proxy-agent": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-1.1.0.tgz",
+      "integrity": "sha512-QBELCWyLYPgE2Gj+4wUEiMscHrQ8nRPBzYItQNOHWavwBt25ohZHQC4qnd5IszdVVrFbLsQ+dPkm6eqdjJAmwQ==",
+      "dev": true
+    },
+    "pac-resolver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-2.0.0.tgz",
+      "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
+      "dev": true,
+      "dependencies": {
+        "co": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
+          "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
+          "dev": true
+        }
+      }
+    },
     "package-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
@@ -7636,27 +7803,32 @@
       "dev": true
     },
     "pako": {
-      "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parents": {
-      "version": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true
     },
     "parse-asn1": {
-      "version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true
     },
     "parse-author": {
-      "version": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
       "integrity": "sha1-XsFZAGKXe9nLOWLpFzuHWGQ39d8=",
       "dev": true
     },
     "parse-code-context": {
-      "version": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-0.1.3.tgz",
       "integrity": "sha1-sMr+ZcNLkWQ0EAAz6zNOnSgstGE=",
       "dev": true
     },
@@ -7667,129 +7839,130 @@
       "dev": true
     },
     "parse-git-config": {
-      "version": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
       "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "dev": true
     },
     "parse-github-url": {
-      "version": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
       "integrity": "sha1-du8B6/4LHpwPSTZylSzGpM2csmA=",
       "dev": true
     },
     "parse-glob": {
-      "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true
     },
     "parse-json": {
-      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
     "parse-passwd": {
-      "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "path-browserify": {
-      "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-exists": {
-      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
     },
     "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
-      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-platform": {
-      "version": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
       "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
     "path-type": {
-      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dependencies": {
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
-        }
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
     },
     "pbkdf2": {
-      "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
       "dev": true
     },
     "pend": {
-      "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
-      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
-      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
-      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
-      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
-    },
-    "pkg-conf": {
-      "version": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls="
     },
     "plist": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
       "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
-      "dev": true,
       "dependencies": {
-        "base64-js": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-          "dev": true
-        },
         "xmlbuilder": {
           "version": "8.2.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
-          "dev": true
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
         }
       }
     },
     "pluralize": {
-      "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "prelude-ls": {
-      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -7800,197 +7973,313 @@
       "dev": true
     },
     "preserve": {
-      "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-bytes": {
-      "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true
     },
     "process": {
-      "version": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
-      "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "progress-bar-formatter": {
-      "version": "https://registry.npmjs.org/progress-bar-formatter/-/progress-bar-formatter-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress-bar-formatter/-/progress-bar-formatter-2.0.1.tgz",
       "integrity": "sha1-DZfrsWRn4sIwg3NXIXa3w1UeVW4="
     },
     "progress-stream": {
-      "version": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c="
-    },
-    "project-name": {
-      "version": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
-      "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
-      "dev": true
-    },
-    "promise": {
-      "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
-    },
-    "prop-types": {
-      "version": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.9.tgz",
-      "integrity": "sha1-1Hju8OdhOWlC9wx453L3bovnR8k=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
       "dependencies": {
-        "js-tokens": {
-          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
-        },
-        "loose-envify": {
-          "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+        "through2": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+          "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8="
         }
       }
     },
+    "project-name": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+      "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "promise": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
+    },
+    "prop-types": {
+      "version": "15.5.10",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ="
+    },
     "propagate": {
-      "version": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
       "dev": true
     },
+    "proxy-agent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.0.0.tgz",
+      "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+          "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
+          "dev": true
+        }
+      }
+    },
     "pseudomap": {
-      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "public-encrypt": {
-      "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true
     },
     "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
-      "version": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
       "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
     },
     "querystring": {
-      "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
-      "version": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randomatic": {
-      "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-      "dev": true
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true
+        }
+      }
     },
     "randombytes": {
-      "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
-      "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew=",
-      "dev": true
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+          "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
+          "dev": true
+        }
+      }
     },
     "raven": {
-      "version": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
       "integrity": "sha1-lJwTTbAooZC3u/j3kKrlQbfAIL0=",
       "dependencies": {
         "uuid": {
-          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
           "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
         }
       }
     },
     "raven-js": {
-      "version": "https://registry.npmjs.org/raven-js/-/raven-js-3.14.1.tgz",
-      "integrity": "sha1-nDxfVwobkYtcMMX61mmC4X/jjjk="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.16.0.tgz",
+      "integrity": "sha1-p5naT90ExjlD9n3rk9qg7P4QHqs="
     },
     "raw-body": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
-      "dev": true
-    },
-    "rc": {
-      "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-      "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
-      "dev": true
-    },
-    "react": {
-      "version": "https://registry.npmjs.org/react/-/react-15.5.4.tgz",
-      "integrity": "sha1-+oPrAVBqsjfNwcjDsc6o3gEr8Ec="
-    },
-    "react-dom": {
-      "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz",
-      "integrity": "sha1-ugwoeG/VLtfk8hNf4CiNRirvk9o="
-    },
-    "react2angular": {
-      "version": "https://registry.npmjs.org/react2angular/-/react2angular-1.1.3.tgz",
-      "integrity": "sha1-nWn1J3mA1BrxpiWwTHikSXxkGJM="
-    },
-    "read-only-stream": {
-      "version": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
-      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-      "dev": true
-    },
-    "read-pkg": {
-      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
-    },
-    "read-pkg-up": {
-      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
-    },
-    "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-      "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
+      "dev": true,
       "dependencies": {
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        "iconv-lite": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+          "dev": true
         }
       }
     },
+    "rc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "react": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.5.4.tgz",
+      "integrity": "sha1-+oPrAVBqsjfNwcjDsc6o3gEr8Ec="
+    },
+    "react-dom": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz",
+      "integrity": "sha1-ugwoeG/VLtfk8hNf4CiNRirvk9o="
+    },
+    "react2angular": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react2angular/-/react2angular-1.1.3.tgz",
+      "integrity": "sha1-nWn1J3mA1BrxpiWwTHikSXxkGJM="
+    },
+    "read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+    },
     "readline2": {
-      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU="
     },
     "rechoir": {
-      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true
     },
     "redent": {
-      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true
     },
     "reduce-object": {
-      "version": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
       "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
       "dev": true
     },
     "redux": {
-      "version": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz",
-      "integrity": "sha1-RTN0XpcLZH7CYGaoOqMOnib6+EM="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
+      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0="
     },
     "redux-localstorage": {
-      "version": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz",
       "integrity": "sha1-+vbXGcWBOXKU2BFHP/zt7gZckzw="
     },
     "regex-cache": {
-      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true
     },
@@ -8007,195 +8296,260 @@
       "dev": true
     },
     "relative": {
-      "version": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
       "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         }
       }
     },
     "remarkable": {
-      "version": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
       "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
       "dev": true,
       "dependencies": {
         "argparse": {
-          "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true
         },
         "underscore.string": {
-          "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
           "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
           "dev": true
         }
       }
     },
     "remote-origin-url": {
-      "version": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.2.tgz",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.2.tgz",
       "integrity": "sha1-6N0uGItPLCFfASfnargbFPOOt0g=",
       "dev": true
     },
+    "remove-trailing-separator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "dev": true
+    },
     "repeat-element": {
-      "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
-      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
-      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true
     },
     "replace-ext": {
-      "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
+    "replace-in-file": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-2.5.0.tgz",
+      "integrity": "sha1-H2OIIlyKy02yiKgYk2XiZvmCTaQ=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true
+        }
+      }
+    },
     "repo-utils": {
-      "version": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
       "integrity": "sha1-SrZq80DLEfp+XPgFgekr6Xwb964=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "dependencies": {
-        "combined-stream": {
-          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
-        },
-        "delayed-stream": {
-          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        }
-      }
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
     },
     "require-directory": {
-      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
-      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-uncached": {
-      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true
     },
     "resin-cli-form": {
-      "version": "https://registry.npmjs.org/resin-cli-form/-/resin-cli-form-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/resin-cli-form/-/resin-cli-form-1.4.1.tgz",
       "integrity": "sha1-BhI0afWVsHM305mdb6p4ykZCawc=",
       "dependencies": {
         "bluebird": {
-          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "resin-cli-visuals": {
-      "version": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.3.1.tgz",
-      "integrity": "sha1-Gfc5cGtCKO1+MGcxPSO2CnZ4K7M=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.4.0.tgz",
+      "integrity": "sha1-IHq827K2JpitzA4e2cN8jFfUb0I=",
       "dependencies": {
         "bluebird": {
-          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "resin-corvus": {
-      "version": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.26.tgz",
-      "integrity": "sha1-N4LX/9JOYvW69miJlZNjTYYlorw=",
-      "dependencies": {
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
-      }
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.27.tgz",
+      "integrity": "sha1-PRdPSaJN8ku7Sgyoc+OCk0YNT34="
     },
     "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-      "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
       "dev": true
     },
     "resolve-dir": {
-      "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true
     },
     "resolve-from": {
-      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
-      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
     },
     "right-align": {
-      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "optional": true
     },
     "rimraf": {
-      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        }
+      }
     },
     "ripemd160": {
-      "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true
     },
     "run-async": {
-      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
     },
     "rx": {
-      "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rx-lite": {
-      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "samsam": {
-      "version": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
@@ -8206,129 +8560,133 @@
       "dev": true
     },
     "sass-graph": {
-      "version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "dependencies": {
-        "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         },
-        "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true
         },
         "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true
         },
         "yargs-parser": {
-          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true
         }
       }
     },
     "sass-lint": {
-      "version": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.10.2.tgz",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.10.2.tgz",
       "integrity": "sha1-glvWsNp53dNqQv+uW21ErEkiUCs=",
       "dev": true,
       "dependencies": {
         "cli-width": {
-          "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
           "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
           "dev": true
         },
-        "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
-        },
         "doctrine": {
-          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true
         },
         "eslint": {
-          "version": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true
         },
         "file-entry-cache": {
-          "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
           "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
           "dev": true
         },
         "fs-extra": {
-          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true
         },
-        "globule": {
-          "version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
-          "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
-          "dev": true,
-          "dependencies": {
-            "lodash": {
-              "version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
-              "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
-              "dev": true
-            }
-          }
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
         },
         "inquirer": {
-          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "json-stable-stringify": {
-          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true
-        },
         "shelljs": {
-          "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
           "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
           "dev": true
         },
         "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
         }
       }
     },
     "sax": {
-      "version": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
       "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg="
     },
     "scss-tokenizer": {
-      "version": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true
         }
       }
     },
     "seek-bzip": {
-      "version": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w="
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-      "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -8337,42 +8695,65 @@
       "dev": true
     },
     "set-blocking": {
-      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz",
-      "integrity": "sha1-zV5dk4BI3xrJLf6S4fFq3WVvXsU="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-getter": {
-      "version": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true
     },
     "setimmediate": {
-      "version": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "sha.js": {
-      "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
       "dev": true
     },
     "shasum": {
-      "version": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "json-stable-stringify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+          "dev": true
+        }
+      }
     },
     "shell-quote": {
-      "version": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true
     },
     "shelljs": {
-      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
-      "dev": true
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true
+        }
+      }
     },
     "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "single-line-log": {
       "version": "1.1.2",
@@ -8381,38 +8762,33 @@
       "dev": true
     },
     "sinon": {
-      "version": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true
     },
     "sinon-chai": {
-      "version": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
-      "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.11.0.tgz",
+      "integrity": "sha512-3kbzpr2q8N+M4CWkcym349ifwkXorsbw2YyVpEIvB3AKC/ebrLHXj3DySt8epKGA49zJBSgn1OvWHZ+O+aR0dA==",
       "dev": true
     },
     "ski": {
-      "version": "https://registry.npmjs.org/ski/-/ski-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ski/-/ski-1.0.0.tgz",
       "integrity": "sha1-FeSd/U8EQmDib8c8AUJlEYUhN7Y=",
       "dev": true
     },
     "slice-ansi": {
-      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "slice-stream2": {
-      "version": "https://registry.npmjs.org/slice-stream2/-/slice-stream2-2.0.1.tgz",
-      "integrity": "sha1-e9gO/BMjLsEVFLZlxLZBWv2mkbc=",
-      "dependencies": {
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/slice-stream2/-/slice-stream2-2.0.1.tgz",
+      "integrity": "sha1-e9gO/BMjLsEVFLZlxLZBWv2mkbc="
     },
     "slide": {
       "version": "1.1.6",
@@ -8421,21 +8797,39 @@
       "dev": true
     },
     "smart-buffer": {
-      "version": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
       "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
       "dev": true
     },
     "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
     },
     "socks": {
-      "version": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+      "dev": true,
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+          "dev": true
+        }
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
+      "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
       "dev": true
     },
     "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
@@ -8446,45 +8840,45 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
     },
-    "spdx-exceptions": {
-      "version": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-      "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
-    },
     "spdx-expression-parse": {
-      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-      "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
-      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
-      "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "speedometer": {
-      "version": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
       "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0="
     },
     "sprintf-js": {
-      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-      "integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dependencies": {
-        "asn1": {
-          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-        },
         "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "stack-trace": {
-      "version": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
     },
     "stat-mode": {
@@ -8494,77 +8888,160 @@
       "dev": true
     },
     "stdout-stream": {
-      "version": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "dev": true
-    },
-    "stream-browserify": {
-      "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "dev": true
-    },
-    "stream-chunker": {
-      "version": "https://registry.npmjs.org/stream-chunker/-/stream-chunker-1.2.8.tgz",
-      "integrity": "sha1-6zryyK7lJWzedvCh/qhjSDNtBPc=",
-      "dependencies": {
-        "through2": {
-          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
-      }
-    },
-    "stream-combiner2": {
-      "version": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "dev": true
-    },
-    "stream-http": {
-      "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
-      "integrity": "sha1-VGpRdBrVprB+njGwsQRBqRffUoo=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
           "dev": true
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
+    },
+    "stream-chunker": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/stream-chunker/-/stream-chunker-1.2.8.tgz",
+      "integrity": "sha1-6zryyK7lJWzedvCh/qhjSDNtBPc="
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
+    },
+    "stream-http": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true
         },
         "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "stream-splicer": {
-      "version": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
     },
     "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "string-template": {
-      "version": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
     "string-width": {
-      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-      "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
     },
     "string.prototype.codepointat": {
       "version": "0.2.0",
@@ -8573,93 +9050,151 @@
       "dev": true
     },
     "string.prototype.endswith": {
-      "version": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
       "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
       "dev": true
     },
     "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
-      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true
     },
     "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "striptags": {
-      "version": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
       "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI=",
       "dev": true
     },
     "subarg": {
-      "version": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "sudo-prompt": {
-      "version": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-6.1.0.tgz",
-      "integrity": "sha1-eBl8hN+PD7LgshjLIlTS4/w+3GM="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-6.2.1.tgz",
+      "integrity": "sha1-EHkhGsLPIfUjD/vrEk/8Is7kwrY="
     },
     "sumchecker": {
-      "version": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
       "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
       "dev": true
     },
+    "superagent": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
+      "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dev": true
+        }
+      }
+    },
+    "superagent-proxy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.2.tgz",
+      "integrity": "sha1-ktNmBXj2GO1DqCz4yseZ/ik4ui0=",
+      "dev": true
+    },
     "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
-    "symbol": {
-      "version": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c="
-    },
     "symbol-observable": {
-      "version": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
     },
     "syntax-error": {
-      "version": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
       "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
       "dev": true
     },
     "table": {
-      "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "dependencies": {
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true
         }
       }
     },
     "tar": {
-      "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true
     },
@@ -8681,34 +9216,75 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
       "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "execa": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+          "dev": true
+        },
+        "path-key": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
+          "dev": true
+        }
+      }
     },
     "text-table": {
-      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throttleit": {
-      "version": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
       "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
       "dev": true
     },
     "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+        },
+        "string_decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "thunkify": {
-      "version": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
       "dev": true
     },
@@ -8719,83 +9295,99 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true
     },
     "tmp": {
-      "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc="
     },
     "to-arraybuffer": {
-      "version": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-file": {
-      "version": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
       "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         },
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "to-gfm-code-block": {
-      "version": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
       "integrity": "sha1-JdBFpfrlUxielje1kJANpzLYqoI=",
       "dev": true
     },
     "to-object-path": {
-      "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true
     },
     "touch": {
-      "version": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
       "dev": true,
       "dependencies": {
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true
         }
       }
     },
     "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
     },
     "tracery": {
-      "version": "https://registry.npmjs.org/tracery/-/tracery-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tracery/-/tracery-1.0.3.tgz",
       "integrity": "sha1-PBMzxSq7IEvQGzHmUKJregHF9x0=",
       "dev": true
     },
     "trackjs": {
-      "version": "https://registry.npmjs.org/trackjs/-/trackjs-2.3.1.tgz",
-      "integrity": "sha1-IrdKW1MQTRjyFQgzJuCcaulnWYU="
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/trackjs/-/trackjs-2.8.2.tgz",
+      "integrity": "sha1-xhlkFNDQ4EnGyQO397QbWQDB/PI="
     },
     "traverse": {
-      "version": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "dev": true
     },
     "trim-newlines": {
-      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
@@ -8806,93 +9398,94 @@
       "dev": true
     },
     "tryit": {
-      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tty-browserify": {
-      "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
     },
     "tweetnacl": {
-      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
     "type-check": {
-      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true
     },
     "type-detect": {
-      "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "typedarray": {
-      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "ua-parser-js": {
-      "version": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
       "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
     },
     "udif": {
-      "version": "https://registry.npmjs.org/udif/-/udif-0.9.0.tgz",
-      "integrity": "sha1-rqCjIFcjvMQSAMcLkAlv2EyMYbk=",
-      "dependencies": {
-        "base64-js": {
-          "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
-          "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
-        },
-        "plist": {
-          "version": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
-          "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os="
-        },
-        "xmlbuilder": {
-          "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
-        }
-      }
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/udif/-/udif-0.9.0.tgz",
+      "integrity": "sha1-rqCjIFcjvMQSAMcLkAlv2EyMYbk="
     },
     "uglify-js": {
-      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.13.tgz",
-      "integrity": "sha1-0M3wLzxmFIT6xgG35yMge3NaN0w=",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "cliui": {
-          "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true
         },
         "window-size": {
-          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
-          "version": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
         },
         "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "optional": true
@@ -8900,32 +9493,38 @@
       }
     },
     "uglify-to-browserify": {
-      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "umd": {
-      "version": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.11.tgz",
-      "integrity": "sha1-IE9VVJzR3YAP3YNbhmdoMOdJLY8="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.4.tgz",
+      "integrity": "sha1-jITITVtMwo/B+fV3IDu9PLhgoWo="
     },
     "unc-path-regex": {
-      "version": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
-      "version": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "underscore.string": {
-      "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s="
     },
     "unique-string": {
@@ -8953,12 +9552,14 @@
       "dev": true
     },
     "update-json": {
-      "version": "https://registry.npmjs.org/update-json/-/update-json-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/update-json/-/update-json-1.0.0.tgz",
       "integrity": "sha1-f3HfLA3egBngR63bPEdKLQWPsGU=",
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
@@ -8971,12 +9572,14 @@
       "dev": true
     },
     "url": {
-      "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "dependencies": {
         "punycode": {
-          "version": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -8989,7 +9592,8 @@
       "dev": true
     },
     "user-home": {
-      "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true
     },
@@ -9000,20 +9604,27 @@
       "dev": true
     },
     "util": {
-      "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
     },
     "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "util-extend": {
-      "version": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
-    },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
       "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
     },
     "uuid-1345": {
@@ -9023,71 +9634,103 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
     },
     "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     },
     "versionist": {
-      "version": "https://registry.npmjs.org/versionist/-/versionist-2.8.1.tgz",
-      "integrity": "sha1-6iFvW4rn9Q/CTfAUm8uJ4DA9maM=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/versionist/-/versionist-2.10.0.tgz",
+      "integrity": "sha1-THYIHlWMg5d+TkGKE55dss5KZms=",
       "dev": true,
       "dependencies": {
+        "async": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+          "dev": true
+        },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
           "integrity": "sha1-kQe7SlBgUuwqAjFLxgYxPtK5IcE=",
           "dev": true
         },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true
         },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
         "touch": {
-          "version": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
           "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
           "dev": true
         }
       }
     },
     "vinyl": {
-      "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true
     },
     "vm-browserify": {
-      "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true
     },
+    "w3cjs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/w3cjs/-/w3cjs-0.4.0.tgz",
+      "integrity": "sha1-EzYk4LhlYmfPanCF2NfGlLcPBI8=",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true
+        }
+      }
+    },
     "wcwidth": {
-      "version": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g="
     },
     "whatwg-fetch": {
-      "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "which": {
-      "version": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-      "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
-      "dev": true
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
     },
     "which-module": {
-      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "wide-align": {
-      "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true
     },
     "widest-line": {
@@ -9097,24 +9740,29 @@
       "dev": true
     },
     "window-size": {
-      "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-      "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
-      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true
     },
@@ -9131,52 +9779,62 @@
       "dev": true
     },
     "xml2js": {
-      "version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
     },
     "xmlbuilder": {
-      "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
     },
     "xmldom": {
-      "version": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xregexp": {
-      "version": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
       "dev": true
     },
     "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
     },
     "y18n": {
-      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
-      "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8="
-    },
-    "yargs-parser": {
-      "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
-      "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "dependencies": {
-        "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
         }
       }
     },
+    "yargs-parser": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ="
+    },
     "yauzl": {
-      "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz",
-      "integrity": "sha1-QIlNRYe7ElUA0F30VHHNXhFKdvk="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+      "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI="
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3516,41 +3516,34 @@
       "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
     },
     "lzma-native": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-2.0.2.tgz",
-      "integrity": "sha512-cM+1OnKRacBh98mw5RJ3PEmFxhl70lDFAL50+x/a+fxzSZryBF1asADf57zliAtGhCNVHYzrJAZX+8R77AGYGg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-2.0.3.tgz",
+      "integrity": "sha512-xwHoJ/nTRzzCIwk1+uMN+oEgT1v3j+3u0/W8YE1bygbdHxW9DZV8aMkfC1oyAk5HImMYMyIGcinoLtk0NLKOMg==",
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8="
         },
         "ajv": {
-          "version": "4.11.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-          "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
-          "dependencies": {
-            "co": {
-              "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-            }
-          }
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
         },
         "ansi-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-          "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
         },
         "are-we-there-yet": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM="
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0="
         },
         "asn1": {
           "version": "0.2.3",
@@ -3573,14 +3566,20 @@
           "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
         },
         "aws4": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
-          "integrity": "sha1-054L7kEs7Q6O2Uoj4xTzE6lbn9E="
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
         },
         "balanced-match": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
@@ -3593,19 +3592,24 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
         },
         "brace-expansion": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-          "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE="
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
         },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "code-point-at": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-          "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -3633,9 +3637,9 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
         },
         "dashdash": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-          "integrity": "sha1-parm/Z2OFWYk6w3ZJZ6xK6JFOFo=",
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3645,14 +3649,14 @@
           }
         },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
         },
         "deep-extend": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -3671,9 +3675,9 @@
           "optional": true
         },
         "extend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -3684,6 +3688,11 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -3700,15 +3709,42 @@
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
         },
+        "gauge": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c="
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+        },
         "graceful-fs": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
-          "integrity": "sha1-kgM84RETxB4mKNYf36QLwQ3AFVw="
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "har-schema": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
           "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -3731,14 +3767,14 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
         },
         "inflight": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo="
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
         },
         "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.4",
@@ -3772,15 +3808,15 @@
           "optional": true
         },
         "jsbn": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "optional": true
         },
         "json-schema": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-stable-stringify": {
           "version": "1.0.1",
@@ -3798,29 +3834,31 @@
           "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsprim": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-          "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE="
-        },
-        "lru-cache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-          "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
         },
         "mime-db": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-          "integrity": "sha1-qyOmNy3J2G09yRIb0OvTgQWhkEo="
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
         },
         "mime-types": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-          "integrity": "sha1-uTx8tDYuFtQQcqflRTj7TUMHCDc="
+          "version": "2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
         },
         "minimatch": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
         },
         "minimist": {
           "version": "0.0.8",
@@ -3833,9 +3871,9 @@
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
           "version": "2.5.1",
@@ -3843,123 +3881,59 @@
           "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
         },
         "node-pre-gyp": {
-          "version": "0.6.33",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
-          "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
-          "dependencies": {
-            "caseless": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-            },
-            "form-data": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-              "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-              "dependencies": {
-                "mime-types": {
-                  "version": "2.1.14",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-                  "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4="
-                }
-              }
-            },
-            "gauge": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-              "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk="
-            },
-            "glob": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
-            },
-            "mime-db": {
-              "version": "1.26.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-              "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
-            },
-            "npmlog": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-              "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518="
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-            },
-            "qs": {
-              "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-            },
-            "request": {
-              "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
-            },
-            "rimraf": {
-              "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ="
-            },
-            "semver": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
-            },
-            "uuid": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-            }
-          }
+          "version": "0.6.36",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y="
         },
         "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00="
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA=="
         },
         "number-is-nan": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
-          "integrity": "sha1-GCQ5vbkTeL90YOdcZOpD5kSN7wY="
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "performance-now": {
           "version": "0.2.0",
@@ -3967,24 +3941,24 @@
           "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
         },
         "process-nextick-args": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-          "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
         "rc": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -3994,36 +3968,39 @@
           }
         },
         "readable-stream": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-          "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY="
+          "version": "2.2.11",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
         },
         "rimraf": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
-          "dependencies": {
-            "glob": {
-              "version": "7.0.5",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-              "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU="
-            },
-            "minimatch": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-              "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo="
-            }
-          }
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
         },
         "safe-buffer": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
         },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        },
         "set-blocking": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "sntp": {
           "version": "1.0.9",
@@ -4031,19 +4008,26 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
         },
         "sshpk": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
-          "integrity": "sha1-rXtH3vymHIQV2WQkO2KwzmD7yjg="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            }
+          }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
         },
         "string-width": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-          "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
         },
         "stringstream": {
           "version": "0.0.5",
@@ -4056,9 +4040,9 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "tar": {
           "version": "2.2.1",
@@ -4066,21 +4050,24 @@
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
         },
         "tar-pack": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA="
-            }
-          }
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ="
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
         },
         "tweetnacl": {
-          "version": "0.14.3",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "optional": true
         },
         "uid-number": {
@@ -4093,25 +4080,25 @@
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
+        "uuid": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        },
         "verror": {
           "version": "1.3.6",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
         },
         "wide-align": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w=="
         },
         "wrappy": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
-        },
-        "yallist": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-          "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,4575 +1,3905 @@
 {
   "name": "etcher",
   "version": "1.0.0",
+  "lockfileVersion": 1,
   "dependencies": {
     "@types/angular": {
-      "version": "1.6.17",
-      "from": "@types/angular@>=1.6.16 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.17.tgz"
+      "version": "https://registry.npmjs.org/@types/angular/-/angular-1.6.17.tgz",
+      "integrity": "sha1-W9WedzUJQ/+/+4u5jf5xisu27Sc="
     },
     "@types/jquery": {
-      "version": "2.0.43",
-      "from": "@types/jquery@*",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.43.tgz"
+      "version": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.43.tgz",
+      "integrity": "sha1-4w2XHVbc4ivw1i4CvUsop//boHY="
     },
     "@types/lodash": {
-      "version": "4.14.64",
-      "from": "@types/lodash@*",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.64.tgz"
+      "version": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.64.tgz",
+      "integrity": "sha1-l5zzo9SjaGcIQL+bPkSNwz/+hO4="
     },
     "@types/lodash.assign": {
-      "version": "4.2.2",
-      "from": "@types/lodash.assign@>=4.2.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash.assign/-/lodash.assign-4.2.2.tgz"
+      "version": "https://registry.npmjs.org/@types/lodash.assign/-/lodash.assign-4.2.2.tgz",
+      "integrity": "sha1-+dLT2xyGqG6Rg8ed+ZpGVayU2ck="
     },
     "@types/lodash.frompairs": {
-      "version": "4.0.2",
-      "from": "@types/lodash.frompairs@>=4.0.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash.frompairs/-/lodash.frompairs-4.0.2.tgz"
+      "version": "https://registry.npmjs.org/@types/lodash.frompairs/-/lodash.frompairs-4.0.2.tgz",
+      "integrity": "sha1-8E5OjpaGT8WSnRd1yRyTpqHJsKo="
     },
     "@types/lodash.mapvalues": {
-      "version": "4.6.2",
-      "from": "@types/lodash.mapvalues@>=4.6.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash.mapvalues/-/lodash.mapvalues-4.6.2.tgz"
+      "version": "https://registry.npmjs.org/@types/lodash.mapvalues/-/lodash.mapvalues-4.6.2.tgz",
+      "integrity": "sha1-Acvr3ltYjQvXMufvk/pX6nF6ZCA="
     },
     "@types/lodash.some": {
-      "version": "4.6.2",
-      "from": "@types/lodash.some@>=4.6.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz"
+      "version": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz",
+      "integrity": "sha1-0NFnq4NBfPTVdM30yqIY/7oyygA="
     },
     "@types/react": {
-      "version": "15.0.24",
-      "from": "@types/react@>=15.0.23 <16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.24.tgz"
+      "version": "https://registry.npmjs.org/@types/react/-/react-15.0.24.tgz",
+      "integrity": "sha1-inUpncN5Bt8yfBjKkYv5elXnEjs="
     },
     "@types/react-dom": {
-      "version": "15.5.0",
-      "from": "@types/react-dom@>=15.5.0 <16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.0.tgz"
+      "version": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.0.tgz",
+      "integrity": "sha1-f0+5YT1AURQXcyQve2tfGkazS9k="
     },
     "7zip-bin": {
       "version": "2.1.0",
-      "from": "7zip-bin@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.1.0.tgz",
+      "integrity": "sha512-jgBTCcJ0gQedE9o8Jw+H/Gyq//EnQxmVpha7CdprIwzRSC81Uj37inHvPzv6jaZgZwkCcfho52rAaIFBrdbO7w==",
       "dev": true
     },
-    "abbrev": {
+    "7zip-bin-linux": {
       "version": "1.1.0",
-      "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.1.0.tgz",
+      "integrity": "sha512-BfW7XsUWNV/j723el3gGbiNWdmvLrnTB9VD0BondfCinxCwz4RQ60W4c3UxRpfHn1Q4Cn1o/DxYFmLMgHTEKqg==",
+      "dev": true,
+      "optional": true
+    },
+    "7zip-bin-mac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
+      "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
+      "dev": true,
+      "optional": true
+    },
+    "7zip-bin-win": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.0.tgz",
+      "integrity": "sha512-7t8V+cGvZ0xUAuTLH1iDkrl+XVYWxlS3hHCvA6yELTcx2VwgMDNe4FdQlyKJRjO0PExn0sit8wD3PGaPKBpt2A==",
+      "dev": true,
+      "optional": true
+    },
+    "abbrev": {
+      "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
     "acorn": {
-      "version": "4.0.11",
-      "from": "acorn@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+      "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+      "integrity": "sha1-7c2jvZN+dVZBDULtWGD2c5nHlMA=",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "from": "acorn@>=3.0.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
-    "agent-base": {
-      "version": "1.0.2",
-      "from": "agent-base@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz",
-      "dev": true
-    },
     "ajv": {
-      "version": "4.11.5",
-      "from": "ajv@>=4.9.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+      "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
       "dependencies": {
         "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
         }
       }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "from": "ajv-keywords@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
-      "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "dev": true
-    },
-    "alter": {
-      "version": "0.2.0",
-      "from": "alter@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true
     },
     "amdefine": {
-      "version": "1.0.1",
-      "from": "amdefine@>=0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "angular": {
-      "version": "1.6.3",
-      "from": "angular@1.6.3",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.3.tgz"
+      "version": "https://registry.npmjs.org/angular/-/angular-1.6.3.tgz",
+      "integrity": "sha1-XTS3mSNOj6F8ajoU4CWHM5NfQ+c="
     },
     "angular-if-state": {
-      "version": "1.0.0",
-      "from": "angular-if-state@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/angular-if-state/-/angular-if-state-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/angular-if-state/-/angular-if-state-1.0.0.tgz",
+      "integrity": "sha1-NqQ4N88nHs73F/bJCw3/L76WTOQ=",
       "dependencies": {
         "angular-ui-router": {
-          "version": "0.3.2",
-          "from": "angular-ui-router@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.3.2.tgz"
+          "version": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.3.2.tgz",
+          "integrity": "sha1-wn4EljCcmSGNVlWYWxZKCWq1IKk="
         }
       }
     },
     "angular-middle-ellipses": {
-      "version": "1.0.0",
-      "from": "angular-middle-ellipses@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/angular-middle-ellipses/-/angular-middle-ellipses-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/angular-middle-ellipses/-/angular-middle-ellipses-1.0.0.tgz",
+      "integrity": "sha1-zb3ECkXOMihJU1foQDV/1AyqUks="
     },
     "angular-mocks": {
-      "version": "1.6.3",
-      "from": "angular-mocks@1.6.3",
-      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.3.tgz",
+      "version": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.3.tgz",
+      "integrity": "sha1-Evr8Dx4JA/FoZABLo3W/P7kQHvE=",
       "dev": true
     },
     "angular-moment": {
-      "version": "1.0.1",
-      "from": "angular-moment@1.0.1",
-      "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.0.1.tgz",
+      "integrity": "sha1-UJ0zJq6iP3giHP3bK2K/7eaEHTE="
     },
     "angular-seconds-to-date": {
-      "version": "1.0.0",
-      "from": "angular-seconds-to-date@latest",
-      "resolved": "https://registry.npmjs.org/angular-seconds-to-date/-/angular-seconds-to-date-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/angular-seconds-to-date/-/angular-seconds-to-date-1.0.0.tgz",
+      "integrity": "sha1-7eN/jrRLZXxo2XRamkBulqbefR8="
     },
     "angular-ui-bootstrap": {
-      "version": "2.5.0",
-      "from": "angular-ui-bootstrap@>=2.5.0 <2.6.0",
-      "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz"
+      "version": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz",
+      "integrity": "sha1-L6zvuRU4ZlXcX0QVAlgDJRcjbQE="
     },
     "angular-ui-router": {
-      "version": "0.4.2",
-      "from": "angular-ui-router@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.2.tgz"
+      "version": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.2.tgz",
+      "integrity": "sha1-tq7Rymmmg8guOZKJjqvUuhWGhgg="
     },
     "ansi-align": {
       "version": "2.0.0",
-      "from": "ansi-align@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@^2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true
         }
       }
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
-      "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "any-promise": {
-      "version": "1.3.0",
-      "from": "any-promise@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
+      "version": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "apple-data-compression": {
-      "version": "0.1.0",
-      "from": "apple-data-compression@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.1.0.tgz"
+      "version": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.1.0.tgz",
+      "integrity": "sha1-v9ahaDXk+LDnbCNzRbJBqnf13y8="
     },
     "aproba": {
-      "version": "1.1.1",
-      "from": "aproba@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+      "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
       "dev": true
     },
     "arch": {
-      "version": "2.1.0",
-      "from": "arch@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz"
+      "version": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
+      "integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
     },
     "are-we-there-yet": {
-      "version": "1.1.2",
-      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+      "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
       "dev": true
     },
     "argparse": {
-      "version": "1.0.7",
-      "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
+      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+      "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE="
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true
     },
     "arr-filter": {
-      "version": "1.1.2",
-      "from": "arr-filter@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "dependencies": {
         "make-iterator": {
-          "version": "1.0.0",
-          "from": "make-iterator@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
+          "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
           "dev": true
         }
       }
     },
     "arr-flatten": {
-      "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
       "dev": true
     },
     "array-filter": {
-      "version": "0.0.1",
-      "from": "array-filter@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
     "array-find-index": {
-      "version": "1.0.2",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-map": {
-      "version": "0.0.0",
-      "from": "array-map@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
       "dev": true
     },
     "array-reduce": {
-      "version": "0.0.0",
-      "from": "array-reduce@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
     "array-slice": {
-      "version": "0.2.3",
-      "from": "array-slice@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true
     },
     "array-sort": {
-      "version": "0.1.2",
-      "from": "array-sort@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.2.tgz",
+      "integrity": "sha1-rqb8klPzP65+jDWwIASzga0NZDM=",
       "dev": true,
       "dependencies": {
         "kind-of": {
-          "version": "2.0.1",
-          "from": "kind-of@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true
         }
       }
     },
     "array-union": {
-      "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true
     },
     "array-uniq": {
-      "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
-      "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arrify": {
-      "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
-      "version": "2.0.5",
-      "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+      "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
     },
     "asar": {
-      "version": "0.10.0",
-      "from": "asar@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/asar/-/asar-0.10.0.tgz",
+      "version": "https://registry.npmjs.org/asar/-/asar-0.10.0.tgz",
+      "integrity": "sha1-JK+b8RuQKVQSX+N4Hn9ZKmYR0mc=",
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "glob": {
-          "version": "6.0.4",
-          "from": "glob@>=6.0.4 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true
         }
       }
     },
     "asar-integrity": {
       "version": "0.1.1",
-      "from": "asar-integrity@0.1.1",
       "resolved": "https://registry.npmjs.org/asar-integrity/-/asar-integrity-0.1.1.tgz",
+      "integrity": "sha512-Nt9p2sWWNFkgqaioFCjsjTQTBAu0YFy2UyW0cWqNr1UBs9vV0j1kG0GI3r1lEJ6XxV4jiz1/AwCJnCDj5DLJUg==",
       "dev": true
     },
     "asn1": {
-      "version": "0.1.11",
-      "from": "asn1@0.1.11",
-      "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "version": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
       "dev": true
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "from": "asn1.js@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "dev": true
     },
     "assert": {
-      "version": "1.4.1",
-      "from": "assert@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "from": "assert-plus@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "dev": true
-    },
-    "ast-traverse": {
-      "version": "0.1.1",
-      "from": "ast-traverse@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.6",
-      "from": "ast-types@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "version": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
       "dev": true
     },
     "astw": {
-      "version": "2.2.0",
-      "from": "astw@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true
     },
     "async": {
-      "version": "2.0.0",
-      "from": "async@>=2.0.0-rc.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
+      "integrity": "sha1-0JAK04WvE4BFQKEJxCFm4657K50=",
       "dev": true
     },
     "async-foreach": {
-      "version": "0.1.3",
-      "from": "async-foreach@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "autolinker": {
-      "version": "0.15.3",
-      "from": "autolinker@>=0.15.0 <0.16.0",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "version": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
       "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
-      "version": "1.6.0",
-      "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "from": "babel-code-frame@>=6.16.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
       "dev": true,
       "dependencies": {
         "js-tokens": {
-          "version": "3.0.1",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
           "dev": true
         }
       }
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
       "dev": true
     },
     "base64-js": {
-      "version": "0.0.8",
-      "from": "base64-js@0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+      "version": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true
     },
     "binary": {
-      "version": "0.3.0",
-      "from": "binary@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true
     },
     "bindings": {
-      "version": "1.2.1",
-      "from": "bindings@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+      "version": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
     "bl": {
-      "version": "0.9.5",
-      "from": "bl@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true
         }
       }
     },
     "block-stream": {
-      "version": "0.0.9",
-      "from": "block-stream@*",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true
     },
     "bloodline": {
-      "version": "1.0.1",
-      "from": "bloodline@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bloodline/-/bloodline-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/bloodline/-/bloodline-1.0.1.tgz",
+      "integrity": "sha1-E/kwNaTtPG0pUwgkkkWg7XZ7NeI="
     },
     "bluebird": {
-      "version": "3.4.1",
-      "from": "bluebird@>=3.0.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
+      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
+      "integrity": "sha1-tzHd9I4t077awudeEhWhG8uR+gc="
     },
     "bluebird-lst": {
       "version": "1.0.2",
-      "from": "bluebird-lst@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.2.tgz",
+      "integrity": "sha1-x7JhdrbI+kWL5wPesGRKKPZKR1s=",
       "dev": true,
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@>=3.5.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
           "dev": true
         }
       }
     },
     "bluebird-retry": {
-      "version": "0.10.1",
-      "from": "bluebird-retry@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.10.1.tgz"
+      "version": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.10.1.tgz",
+      "integrity": "sha1-zfdrAdSm3U/sTiyENgqKCQB/Z9o="
     },
     "bmapflash": {
-      "version": "1.2.1",
-      "from": "bmapflash@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bmapflash/-/bmapflash-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/bmapflash/-/bmapflash-1.2.1.tgz",
+      "integrity": "sha1-O96v+FBrBBj+4G5FbloIxc9xvLY=",
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@>=4.14.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
         },
         "xml2js": {
-          "version": "0.4.17",
-          "from": "xml2js@>=0.4.17 <0.5.0",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz"
+          "version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+          "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "bn.js": {
-      "version": "4.11.6",
-      "from": "bn.js@>=4.1.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "version": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
     },
     "bootstrap-sass": {
-      "version": "3.3.6",
-      "from": "bootstrap-sass@>=3.3.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.6.tgz"
+      "version": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.6.tgz",
+      "integrity": "sha1-NjsNMA6GjT5wE0wadCuxcohET9E="
     },
     "boxen": {
       "version": "1.1.0",
-      "from": "boxen@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+      "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
       "dev": true,
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@^2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true
         }
       }
     },
     "brace-expansion": {
-      "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
       "dev": true
     },
     "braces": {
-      "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "dev": true
-    },
-    "breakable": {
-      "version": "1.0.0",
-      "from": "breakable@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true
     },
     "brorand": {
-      "version": "1.1.0",
-      "from": "brorand@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-pack": {
-      "version": "6.0.2",
-      "from": "browser-pack@>=6.0.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+      "version": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+      "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "browser-resolve": {
-      "version": "1.11.2",
-      "from": "browser-resolve@>=1.11.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "version": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
       "dev": true,
       "dependencies": {
         "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "from": "browser-stdout@1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "browserify": {
-      "version": "14.3.0",
-      "from": "jviotti/node-browserify#dynamic-dirname-filename",
-      "resolved": "git://github.com/jviotti/node-browserify.git#14691ac9257063000e4aa216073cdad28b9d04e1",
+      "version": "git://github.com/jviotti/node-browserify.git#14691ac9257063000e4aa216073cdad28b9d04e1",
+      "integrity": "sha1-XF/jMVrxa5Oggni58N2FixQUonY=",
       "dev": true,
       "dependencies": {
         "base64-js": {
-          "version": "1.2.0",
-          "from": "base64-js@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
           "dev": true
         },
         "buffer": {
-          "version": "5.0.6",
-          "from": "buffer@>=5.0.2 <6.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+          "version": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+          "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
           "dev": true
         },
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "browserify-aes": {
-      "version": "1.0.6",
-      "from": "browserify-aes@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
       "dev": true
     },
     "browserify-cipher": {
-      "version": "1.0.0",
-      "from": "browserify-cipher@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true
     },
     "browserify-des": {
-      "version": "1.0.0",
-      "from": "browserify-des@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "from": "browserify-rsa@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "from": "browserify-sign@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "from": "browserify-zlib@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true
     },
     "buffer": {
-      "version": "3.6.0",
-      "from": "buffer@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "version": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
     "buffer-crc32": {
-      "version": "0.2.5",
-      "from": "buffer-crc32@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
+      "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
+      "integrity": "sha1-2wA6wmceYuvW7OeOosLhtAVzbpE="
     },
     "buffer-shims": {
-      "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "buffer-xor": {
-      "version": "1.0.3",
-      "from": "buffer-xor@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "buffers": {
-      "version": "0.1.1",
-      "from": "buffers@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "builtin-status-codes": {
-      "version": "3.0.0",
-      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "version": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
       "dev": true
     },
     "cached-path-relative": {
-      "version": "1.0.1",
-      "from": "cached-path-relative@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
       "dev": true
     },
     "caller-path": {
-      "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true
     },
     "callsites": {
-      "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
-      "version": "3.0.0",
-      "from": "camelcase@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+      "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "camelcase-keys": {
-      "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "from": "camelcase@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
       }
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
     },
     "caseless": {
-      "version": "0.12.0",
-      "from": "caseless@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
-      "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "dev": true
+      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true
     },
     "chai": {
-      "version": "3.5.0",
-      "from": "chai@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true
     },
     "chai-as-promised": {
-      "version": "5.3.0",
-      "from": "chai-as-promised@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
+      "version": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
+      "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
       "dev": true
     },
     "chai-datetime": {
-      "version": "1.4.1",
-      "from": "chai-datetime@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
+      "integrity": "sha1-M3n8GNng0A8u1GWZh1JNYhHGQqg=",
       "dev": true
     },
     "chai-interface": {
-      "version": "2.0.3",
-      "from": "chai-interface@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/chai-interface/-/chai-interface-2.0.3.tgz",
+      "version": "https://registry.npmjs.org/chai-interface/-/chai-interface-2.0.3.tgz",
+      "integrity": "sha1-9SMW0k1kHMz2gKHGe87hgZCVv2c=",
       "dev": true
     },
     "chai-string": {
-      "version": "1.3.0",
-      "from": "chai-string@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/chai-string/-/chai-string-1.3.0.tgz",
+      "integrity": "sha1-32E58pQ5GxA1vlYG9gqEOzpQQec=",
       "dev": true
     },
     "chai-things": {
-      "version": "0.2.0",
-      "from": "chai-things@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+      "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
       "dev": true
     },
     "chainsaw": {
-      "version": "0.1.0",
-      "from": "chainsaw@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "from": "chalk@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "chromium-pickle-js": {
-      "version": "0.1.0",
-      "from": "chromium-pickle-js@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
+      "integrity": "sha1-HUixB9ghJqLz4hHC6iX4A7pVGyE=",
       "dev": true
     },
     "ci-info": {
       "version": "1.0.0",
-      "from": "ci-info@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
       "dev": true
     },
     "cipher-base": {
-      "version": "1.0.3",
-      "from": "cipher-base@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
       "dev": true
     },
     "circular-json": {
-      "version": "0.3.1",
-      "from": "circular-json@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
       "dev": true
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "from": "cli-boxes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
     },
     "cli-spinner": {
-      "version": "0.2.6",
-      "from": "cli-spinner@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz"
+      "version": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz",
+      "integrity": "sha1-illwMyTpOpCPbmAeTnT1uFs3Hlw="
     },
     "cli-width": {
-      "version": "1.1.1",
-      "from": "cli-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
+      "version": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0="
     },
     "cliui": {
-      "version": "3.2.0",
-      "from": "cliui@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+      "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
     },
     "clone": {
-      "version": "1.0.2",
-      "from": "clone@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
     },
     "clone-stats": {
-      "version": "0.0.1",
-      "from": "clone-stats@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "co": {
-      "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-context": {
-      "version": "0.5.3",
-      "from": "code-context@>=0.5.3 <0.6.0",
-      "resolved": "https://registry.npmjs.org/code-context/-/code-context-0.5.3.tgz",
+      "version": "https://registry.npmjs.org/code-context/-/code-context-0.5.3.tgz",
+      "integrity": "sha1-42jHvSR9OscRANkbX9AuTmb6kCI=",
       "dev": true
     },
     "code-point-at": {
-      "version": "1.0.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+      "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
     },
     "color-convert": {
       "version": "0.5.3",
-      "from": "color-convert@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
       "dev": true
     },
     "colors": {
-      "version": "1.1.2",
-      "from": "colors@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+      "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "columnify": {
-      "version": "1.5.4",
-      "from": "columnify@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz"
+      "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs="
     },
     "combine-source-map": {
-      "version": "0.7.2",
-      "from": "combine-source-map@>=0.7.1 <0.8.0",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+      "version": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+      "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
       "dev": true
     },
     "combined-stream": {
-      "version": "0.0.7",
-      "from": "combined-stream@>=0.0.5 <0.1.0",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "version": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
       "dev": true
     },
     "command-join": {
-      "version": "2.0.0",
-      "from": "command-join@latest",
-      "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
+      "integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
     },
     "commander": {
-      "version": "2.8.1",
-      "from": "commander@>=2.8.1 <2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
-    },
-    "commoner": {
-      "version": "0.10.8",
-      "from": "commoner@>=0.10.3 <0.11.0",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "dev": true,
-      "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@^2.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dev": true
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "from": "esprima@~3.1.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.15 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dev": true
-        },
-        "recast": {
-          "version": "0.11.23",
-          "from": "recast@>=0.11.17 <0.12.0",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-          "dev": true
-        }
-      }
+      "version": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ="
     },
     "compare-version": {
       "version": "0.1.2",
-      "from": "compare-version@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-      "dev": true
-    },
-    "component-emitter": {
-      "version": "1.1.2",
-      "from": "component-emitter@1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+      "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
       "dev": true
     },
     "concat-map": {
-      "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "1.5.2",
-      "from": "concat-stream@>=1.5.1 <1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true
         }
       }
     },
     "configstore": {
       "version": "3.1.0",
-      "from": "configstore@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+      "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
       "dev": true
     },
     "connective": {
-      "version": "1.0.0",
-      "from": "connective@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/connective/-/connective-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/connective/-/connective-1.0.0.tgz",
+      "integrity": "sha1-F9XdQ21BbH3OMJ3M4z2x7gWUseg=",
       "dev": true
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true
     },
     "console-control-strings": {
-      "version": "1.1.0",
-      "from": "console-control-strings@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
-      "version": "1.0.0",
-      "from": "constants-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.1.3",
-      "from": "convert-source-map@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
     },
     "cookie": {
-      "version": "0.3.1",
-      "from": "cookie@0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-    },
-    "cookiejar": {
-      "version": "2.0.1",
-      "from": "cookiejar@2.0.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
-      "dev": true
+      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "crc": {
-      "version": "3.4.4",
-      "from": "crc@>=3.4.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
+      "version": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
     },
     "crc32-stream": {
-      "version": "1.0.1",
-      "from": "crc32-stream@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.1.tgz",
+      "integrity": "sha1-zixdw72P+zgw+ctH9UAiLGPJD6s="
     },
     "create-ecdh": {
-      "version": "4.0.0",
-      "from": "create-ecdh@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true
     },
     "create-error-class": {
       "version": "3.0.2",
-      "from": "create-error-class@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true
     },
     "create-frame": {
-      "version": "0.1.4",
-      "from": "create-frame@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/create-frame/-/create-frame-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/create-frame/-/create-frame-0.1.4.tgz",
+      "integrity": "sha1-wJzZiK0lX0O6T7GjvVB7FebSbDw=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "create-hash": {
-      "version": "1.1.3",
-      "from": "create-hash@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true
     },
     "create-hmac": {
-      "version": "1.1.6",
-      "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true
     },
     "cross-spawn": {
       "version": "4.0.2",
-      "from": "cross-spawn@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true
     },
     "cross-spawn-async": {
       "version": "2.2.5",
-      "from": "cross-spawn-async@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
     },
     "crypto-browserify": {
-      "version": "3.11.0",
-      "from": "crypto-browserify@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+      "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+      "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
       "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "from": "crypto-random-string@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
     "ctype": {
-      "version": "0.5.3",
-      "from": "ctype@0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "version": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "dev": true
     },
     "cuint": {
-      "version": "0.2.2",
-      "from": "cuint@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "version": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
       "dev": true
     },
     "currently-unhandled": {
-      "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true
     },
     "cwd": {
-      "version": "0.9.1",
-      "from": "cwd@>=0.9.1 <0.10.0",
-      "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
+      "version": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
+      "integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
       "dev": true
     },
     "d": {
-      "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+      "version": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
     },
     "dashdash": {
-      "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "data-uri-to-buffer": {
-      "version": "0.0.4",
-      "from": "data-uri-to-buffer@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz",
+      "integrity": "sha1-RuE6udqOMJdFyNAc5UchPr2y/j8=",
       "dev": true
     },
     "date-now": {
-      "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "date.js": {
-      "version": "0.3.1",
-      "from": "date.js@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+      "version": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
+      "integrity": "sha1-OefHx3rcdl0Qvs9JbKzTkTMtfMg=",
       "dev": true,
       "dependencies": {
         "debug": {
-          "version": "0.7.4",
-          "from": "debug@~0.7.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         }
       }
     },
     "debug": {
-      "version": "2.6.0",
-      "from": "debug@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz"
+      "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs="
     },
     "decamelize": {
-      "version": "1.2.0",
-      "from": "decamelize@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decompress-zip": {
-      "version": "0.1.0",
-      "from": "decompress-zip@0.1.0",
-      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+      "integrity": "sha1-vOYMEWZPLWYPykvPY0r23l1sFMc=",
       "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true
         }
       }
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "dependencies": {
         "type-detect": {
-          "version": "0.1.1",
-          "from": "type-detect@0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
       }
     },
     "deep-extend": {
-      "version": "0.4.1",
-      "from": "deep-extend@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+      "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
       "dev": true
     },
     "deep-is": {
-      "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "deep-map-keys": {
-      "version": "1.2.0",
-      "from": "deep-map-keys@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/deep-map-keys/-/deep-map-keys-1.2.0.tgz"
+      "version": "https://registry.npmjs.org/deep-map-keys/-/deep-map-keys-1.2.0.tgz",
+      "integrity": "sha1-Q0GLgoykPSYajod7SSfknQxHjNk="
     },
     "defaults": {
-      "version": "1.0.3",
-      "from": "defaults@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
+      "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730="
     },
     "define-property": {
-      "version": "0.2.5",
-      "from": "define-property@>=0.2.5 <0.3.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "version": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+      "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true
     },
     "defined": {
-      "version": "1.0.0",
-      "from": "defined@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
-    "defs": {
-      "version": "1.1.1",
-      "from": "defs@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "dev": true
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "from": "window-size@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.27.0",
-          "from": "yargs@>=3.27.0 <3.28.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-          "dev": true
-        }
-      }
-    },
     "degenerator": {
-      "version": "1.0.4",
-      "from": "degenerator@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "dev": true,
       "dependencies": {
         "esprima": {
-          "version": "3.1.3",
-          "from": "esprima@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         }
       }
     },
     "del": {
-      "version": "2.2.2",
-      "from": "del@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "dependencies": {
         "globby": {
-          "version": "5.0.0",
-          "from": "globby@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true
         }
       }
     },
     "delayed-stream": {
-      "version": "0.0.5",
-      "from": "delayed-stream@0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
       "dev": true
     },
     "delegates": {
-      "version": "1.0.0",
-      "from": "delegates@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "deps-sort": {
-      "version": "2.0.0",
-      "from": "deps-sort@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "des.js": {
-      "version": "1.0.0",
-      "from": "des.js@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true
     },
     "detect-node": {
-      "version": "2.0.3",
-      "from": "detect-node@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz"
+      "version": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
     },
     "detect-process": {
-      "version": "1.0.4",
-      "from": "detect-process@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/detect-process/-/detect-process-1.0.4.tgz"
+      "version": "https://registry.npmjs.org/detect-process/-/detect-process-1.0.4.tgz",
+      "integrity": "sha1-Bmeklc2JVCKYdzsW9EPCh9kNVjo="
     },
     "detective": {
-      "version": "4.5.0",
-      "from": "detective@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "version": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
       "dev": true
     },
     "dev-null-stream": {
-      "version": "0.0.1",
-      "from": "dev-null-stream@0.0.1",
-      "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz"
+      "version": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz",
+      "integrity": "sha1-oqLie025mSjW2NRNXF9++9TLQ3I="
     },
     "diff": {
-      "version": "1.4.0",
-      "from": "diff@1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
     "diffie-hellman": {
-      "version": "5.0.2",
-      "from": "diffie-hellman@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0",
-      "from": "doctrine@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@^1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "from": "domain-browser@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "version": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
     "dot-prop": {
       "version": "4.1.1",
-      "from": "dot-prop@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
       "dev": true
     },
     "drivelist": {
       "version": "5.0.22",
-      "from": "drivelist@5.0.22",
       "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.22.tgz",
+      "integrity": "sha1-ZAKaFtUwtIXXwrP3SBScm8bocfA=",
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@>=3.5.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.16.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
     "duplexer2": {
-      "version": "0.1.4",
-      "from": "duplexer2@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
-      "from": "duplexer3@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true
     },
     "electron": {
-      "version": "1.6.6",
-      "from": "electron@1.6.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.6.tgz",
+      "version": "https://registry.npmjs.org/electron/-/electron-1.6.6.tgz",
+      "integrity": "sha1-F9+M33PsLATPrXq7QTV5uLja/Cg=",
       "dev": true,
       "dependencies": {
         "electron-download": {
-          "version": "3.3.0",
-          "from": "electron-download@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
+          "version": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
+          "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
           "dev": true
         },
         "fs-extra": {
-          "version": "0.30.0",
-          "from": "fs-extra@>=0.30.0 <0.31.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true
         },
         "nugget": {
-          "version": "2.0.1",
-          "from": "nugget@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+          "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
           "dev": true
         },
         "semver": {
-          "version": "5.3.0",
-          "from": "semver@>=5.3.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "single-line-log": {
-          "version": "1.1.2",
-          "from": "single-line-log@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+          "version": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+          "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
           "dev": true
         }
       }
     },
     "electron-builder": {
       "version": "18.6.2",
-      "from": "electron-builder@18.6.2",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-18.6.2.tgz",
+      "integrity": "sha512-CBr1dEuNSMls6U3zgESF4xUqAu4In4CNsEB13XUmt4CGawtMJX1UH9YIDLABuzLGjOMjFAHpE0HC5RJskRFRjQ==",
       "dev": true,
       "dependencies": {
         "ajv": {
           "version": "5.1.5",
-          "from": "ajv@>=5.1.5 <6.0.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.5.tgz",
+          "integrity": "sha1-hzSTG2AfANT+73xlc4130bZdH2g=",
           "dev": true
         },
         "ajv-keywords": {
           "version": "2.1.0",
-          "from": "ajv-keywords@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.7",
-          "from": "brace-expansion@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "chromium-pickle-js": {
           "version": "0.2.0",
-          "from": "chromium-pickle-js@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+          "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
           "dev": true
         },
         "debug": {
           "version": "2.6.8",
-          "from": "debug@2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "dev": true
-        },
-        "electron-builder-core": {
-          "version": "18.4.0",
-          "from": "electron-builder-core@18.4.0",
-          "resolved": "https://registry.npmjs.org/electron-builder-core/-/electron-builder-core-18.4.0.tgz",
-          "dev": true
-        },
-        "electron-builder-http": {
-          "version": "18.6.0",
-          "from": "electron-builder-http@18.6.0",
-          "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.6.0.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
         },
         "esprima": {
           "version": "3.1.3",
-          "from": "esprima@>=3.1.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "from": "execa@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "from": "get-stream@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.4.2",
-          "from": "hosted-git-info@>=2.4.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "js-yaml": {
           "version": "3.8.4",
-          "from": "js-yaml@>=3.8.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+          "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
           "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "from": "load-json-file@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.8",
-          "from": "normalize-package-data@>=2.3.8 <3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "from": "npm-run-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "from": "path-key@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "from": "path-type@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
-          "from": "read-pkg@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "from": "read-pkg-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@>=5.3.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "which-module": {
           "version": "2.0.0",
-          "from": "which-module@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "yargs": {
-          "version": "8.0.1",
-          "from": "yargs@>=8.0.1 <9.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "from": "yargs-parser@>=7.0.0 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true
+        }
+      }
+    },
+    "electron-builder-core": {
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-core/-/electron-builder-core-18.4.0.tgz",
+      "integrity": "sha512-nVDcWZnmBqzaoa9uOZA9qV8ByNhX0yBGPNxKnSxrJR13ruru2HFPzpaGEQnxmnYWFNOewsoehKaiH/dc1rYo1Q==",
+      "dev": true
+    },
+    "electron-builder-http": {
+      "version": "18.6.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.6.0.tgz",
+      "integrity": "sha512-/kNnHN2gslrbZdT+K8hF8tNnfn/QTvJvj/lGudXFVvbn0PPgQ6Nb/bwAh67v0DSyJE1XMgzsbn5qSShrY19gyA==",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
     },
     "electron-builder-util": {
       "version": "18.6.0",
-      "from": "electron-builder-util@18.6.0",
       "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-18.6.0.tgz",
+      "integrity": "sha512-8Kmfl5lpIhh1jFF2ZTnWIKs3jWsu7zoy0fhuZQn9srxPPbTG3ZD/uGnkEenH5QsNu5FGPtF+JmTMerJBH8No8A==",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "dev": true
-        },
-        "electron-builder-http": {
-          "version": "18.6.0",
-          "from": "electron-builder-http@~18.6.0",
-          "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.6.0.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
     },
     "electron-download-tf": {
       "version": "4.3.1",
-      "from": "electron-download-tf@4.3.1",
       "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
+      "integrity": "sha1-eTDySgjjZp6q04pffyiKEEYcr3I=",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "rc": {
           "version": "1.2.1",
-          "from": "rc@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@^5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "sumchecker": {
           "version": "2.0.2",
-          "from": "sumchecker@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+          "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
           "dev": true
         }
       }
     },
     "electron-is-running-in-asar": {
-      "version": "1.0.0",
-      "from": "electron-is-running-in-asar@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-is-running-in-asar/-/electron-is-running-in-asar-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/electron-is-running-in-asar/-/electron-is-running-in-asar-1.0.0.tgz",
+      "integrity": "sha1-9ufRapejP+R99S4/lUazcBfx+so="
     },
     "electron-mocha": {
-      "version": "3.3.0",
-      "from": "electron-mocha@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-3.3.0.tgz",
+      "version": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-3.3.0.tgz",
+      "integrity": "sha1-09Yzepmedmw7eCqWOF+DrsUW038=",
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@^2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "fs-extra": {
-          "version": "1.0.0",
-          "from": "fs-extra@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true
         }
       }
     },
     "electron-osx-sign": {
       "version": "0.4.6",
-      "from": "electron-osx-sign@0.4.6",
       "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.6.tgz",
+      "integrity": "sha1-I5ji18q1wdjD7quxzUkDdlKOw5o=",
       "dev": true,
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@^3.4.7",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
           "dev": true
         },
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
     },
     "electron-publish": {
       "version": "18.6.0",
-      "from": "electron-publish@18.6.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-18.6.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "from": "debug@2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "dev": true
-        },
-        "electron-builder-http": {
-          "version": "18.6.0",
-          "from": "electron-builder-http@~18.6.0",
-          "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.6.0.tgz",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "dev": true
-        }
-      }
+      "integrity": "sha512-gCl+Jn/0Qqk1XZT1Hr76eyzX2nL7BdN5ilo9/XKJjP+yqOVagJx/Y5kisX5kAfP+a+esGESuQ/1n6STnQH4zBw==",
+      "dev": true
     },
     "electron-window": {
-      "version": "0.8.1",
-      "from": "electron-window@>=0.8.0 <0.9.0",
-      "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
+      "version": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
+      "integrity": "sha1-FsoYfrSHCwZ5J0/IKZxZYOarLF4=",
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.0",
-      "from": "elliptic@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "from": "encoding@>=0.1.11 <0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+      "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
     },
     "ent": {
-      "version": "2.2.0",
-      "from": "ent@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "version": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
     "env-paths": {
       "version": "1.0.0",
-      "from": "env-paths@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
       "dev": true
     },
     "error": {
-      "version": "7.0.2",
-      "from": "error@>=7.0.2 <8.0.0",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "version": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dependencies": {
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "error-ex": {
-      "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk="
     },
     "es5-ext": {
-      "version": "0.10.12",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc="
     },
     "es6-iterator": {
-      "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w="
     },
     "es6-map": {
-      "version": "0.1.5",
-      "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "dependencies": {
         "d": {
-          "version": "1.0.0",
-          "from": "d@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.14",
-          "from": "es5-ext@>=0.10.14 <0.11.0",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+          "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
           "dev": true
         },
         "es6-iterator": {
-          "version": "2.0.1",
-          "from": "es6-iterator@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
           "dev": true
         },
         "es6-symbol": {
-          "version": "3.1.1",
-          "from": "es6-symbol@>=3.1.1 <3.2.0",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true
         }
       }
     },
     "es6-promise": {
-      "version": "4.1.0",
-      "from": "es6-promise@>=4.0.5 <5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
+      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
+      "integrity": "sha1-3aA8qPn4m8WX5omEKSnee6jOvfA=",
       "dev": true
     },
     "es6-set": {
-      "version": "0.1.5",
-      "from": "es6-set@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "dependencies": {
         "d": {
-          "version": "1.0.0",
-          "from": "d@1",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.14",
-          "from": "es5-ext@~0.10.14",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+          "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
           "dev": true
         },
         "es6-iterator": {
-          "version": "2.0.1",
-          "from": "es6-iterator@~2.0.1",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+          "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
           "dev": true
         },
         "es6-symbol": {
-          "version": "3.1.1",
-          "from": "es6-symbol@3.1.1",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true
         }
       }
     },
     "es6-symbol": {
-      "version": "3.1.0",
-      "from": "es6-symbol@>=3.1.0 <3.2.0",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o="
     },
     "es6-weak-map": {
-      "version": "2.0.1",
-      "from": "es6-weak-map@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
+      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+      "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE="
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.8.1",
-      "from": "escodegen@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "dependencies": {
         "estraverse": {
-          "version": "1.9.3",
-          "from": "estraverse@>=1.9.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
           "dev": true
         },
         "source-map": {
-          "version": "0.2.0",
-          "from": "source-map@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
           "optional": true
         }
       }
     },
     "escope": {
-      "version": "3.6.0",
-      "from": "escope@>=3.6.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true
     },
     "eslint": {
-      "version": "3.18.0",
-      "from": "eslint@>=3.16.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.18.0.tgz",
+      "version": "https://registry.npmjs.org/eslint/-/eslint-3.18.0.tgz",
+      "integrity": "sha1-ZH6YXErnFQLSCsYsEJ9m1RBMiks=",
       "dev": true,
       "dependencies": {
         "cli-width": {
-          "version": "2.1.0",
-          "from": "cli-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
           "dev": true
         },
         "inquirer": {
-          "version": "0.12.0",
-          "from": "inquirer@>=0.12.0 <0.13.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true
         },
         "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true
         },
         "strip-bom": {
-          "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
       }
     },
     "eslint-plugin-lodash": {
-      "version": "2.3.6",
-      "from": "eslint-plugin-lodash@>=2.3.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.3.6.tgz",
+      "version": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.3.6.tgz",
+      "integrity": "sha1-BUJBfEQqVxjpmvcahB2eRI5ONxc=",
       "dev": true
     },
     "espree": {
-      "version": "3.4.0",
-      "from": "espree@>=3.4.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
+      "version": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
+      "integrity": "sha1-QWVvpWKOBCh4Al70Z+ePEly4bh0=",
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "4.0.4",
-          "from": "acorn@4.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+          "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+          "integrity": "sha1-F6jWp6bE71OLgU7Jq6wneSk78wo=",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "2.7.2",
-      "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+      "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+      "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk="
     },
     "esquery": {
-      "version": "1.0.0",
-      "from": "esquery@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
       "dependencies": {
         "estraverse": {
-          "version": "4.1.1",
-          "from": "estraverse@>=4.1.0 <4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
           "dev": true
         }
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etcher-image-write": {
-      "version": "9.1.3",
-      "from": "etcher-image-write@9.1.3",
-      "resolved": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.3.tgz",
+      "version": "https://registry.npmjs.org/etcher-image-write/-/etcher-image-write-9.1.3.tgz",
+      "integrity": "sha1-2TOTH3ZsbmFUD9Prj01kJz2nYJw=",
       "dependencies": {
         "bluebird": {
-          "version": "3.5.0",
-          "from": "bluebird@>=3.4.7 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+          "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
         },
         "debug": {
-          "version": "2.6.6",
-          "from": "debug@>=2.6.6 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz"
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
+          "integrity": "sha1-qfpvvpykPPHnn3O3XAGJy7fW21o="
         },
         "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
         "ms": {
-          "version": "0.7.3",
-          "from": "ms@0.7.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         },
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "event-emitter": {
-      "version": "0.3.5",
-      "from": "event-emitter@>=0.3.5 <0.4.0",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "dependencies": {
         "d": {
-          "version": "1.0.0",
-          "from": "d@1",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true
         },
         "es5-ext": {
-          "version": "0.10.14",
-          "from": "es5-ext@~0.10.14",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+          "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+          "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
           "dev": true
         }
       }
     },
     "event-pubsub": {
-      "version": "4.2.3",
-      "from": "event-pubsub@4.2.3",
-      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.2.3.tgz"
+      "version": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.2.3.tgz",
+      "integrity": "sha1-DTFC9HrH4No4zcOEAtl+JRC8Xsw="
     },
     "events": {
-      "version": "1.1.1",
-      "from": "events@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "evp_bytestokey": {
-      "version": "1.0.0",
-      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+      "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
       "dev": true
     },
     "execa": {
       "version": "0.4.0",
-      "from": "execa@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
       "dev": true
     },
     "exit-hook": {
-      "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true
     },
     "expand-range": {
-      "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true
     },
     "expand-tilde": {
-      "version": "1.2.2",
-      "from": "expand-tilde@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "dev": true
     },
     "extend": {
-      "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+      "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
     },
     "extend-shallow": {
-      "version": "2.0.1",
-      "from": "extend-shallow@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true
     },
     "extglob": {
-      "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true
     },
     "extract-zip": {
-      "version": "1.6.0",
-      "from": "extract-zip@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.0.tgz",
+      "integrity": "sha1-f0AMlgfqhm7Kt6ptVPuXjusRYho=",
       "dev": true,
       "dependencies": {
         "concat-stream": {
-          "version": "1.5.0",
-          "from": "concat-stream@1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
           "dev": true
         },
         "debug": {
-          "version": "0.7.4",
-          "from": "debug@0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@~2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true
         },
         "yauzl": {
-          "version": "2.4.1",
-          "from": "yauzl@2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true
         }
       }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
     },
     "fast-levenshtein": {
-      "version": "2.0.6",
-      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.12",
-      "from": "fbjs@>=0.8.9 <0.9.0",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+      "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
       "dependencies": {
         "core-js": {
-          "version": "1.2.7",
-          "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+          "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "from": "fd-slicer@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU="
     },
     "figures": {
-      "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
+      "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
     },
     "file-contents": {
-      "version": "0.2.4",
-      "from": "file-contents@>=0.2.4 <0.3.0",
-      "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
+      "version": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
+      "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         },
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "from": "file-entry-cache@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true
     },
     "file-exists": {
-      "version": "1.0.0",
-      "from": "file-exists@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/file-exists/-/file-exists-1.0.0.tgz",
+      "integrity": "sha1-5tJptWVnuJIlgTmOmQ3XB49y1hY=",
       "dev": true
     },
     "file-name": {
-      "version": "0.1.0",
-      "from": "file-name@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
+      "integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc=",
       "dev": true
     },
     "file-stat": {
-      "version": "0.1.3",
-      "from": "file-stat@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
+      "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         },
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@~4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "file-type": {
-      "version": "4.1.0",
-      "from": "file-type@latest",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.1.0.tgz"
+      "version": "https://registry.npmjs.org/file-type/-/file-type-4.1.0.tgz",
+      "integrity": "sha1-aQtwKTcV1/05aX4496EI66slUbk="
     },
     "file-uri-to-path": {
-      "version": "0.0.2",
-      "from": "file-uri-to-path@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz",
+      "integrity": "sha1-N83RtbkFQEs/BeGyNkW+aU/3D4I=",
       "dev": true
     },
     "filename-regex": {
-      "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
       "dev": true
     },
     "filendir": {
-      "version": "1.0.0",
-      "from": "filendir@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/filendir/-/filendir-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/filendir/-/filendir-1.0.0.tgz",
+      "integrity": "sha1-dFtEWvzElwpM2wD9lTnHftlCrfY=",
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         }
       }
     },
     "find-file-up": {
-      "version": "0.1.3",
-      "from": "find-file-up@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+      "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
       "dev": true
     },
     "find-pkg": {
-      "version": "0.1.2",
-      "from": "find-pkg@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+      "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
       "dev": true
     },
     "find-up": {
-      "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
     },
     "flat": {
-      "version": "2.0.1",
-      "from": "flat@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz"
+      "version": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
+      "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8="
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "from": "flat-cache@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true
     },
     "flexboxgrid": {
-      "version": "6.3.0",
-      "from": "flexboxgrid@>=6.3.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/flexboxgrid/-/flexboxgrid-6.3.0.tgz"
+      "version": "https://registry.npmjs.org/flexboxgrid/-/flexboxgrid-6.3.0.tgz",
+      "integrity": "sha1-jclF7717EpWkKb8mpXQfS7iCXSw="
     },
     "for-in": {
-      "version": "0.1.8",
-      "from": "for-in@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "version": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
       "dev": true
     },
     "for-own": {
-      "version": "0.1.5",
-      "from": "for-own@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "dependencies": {
         "for-in": {
-          "version": "1.0.2",
-          "from": "for-in@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         }
       }
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "from": "forever-agent@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.1.2",
-      "from": "form-data@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+      "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
       "dependencies": {
         "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@^1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
         },
         "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@~1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "mime-db": {
-          "version": "1.24.0",
-          "from": "mime-db@>=1.24.0 <1.25.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+          "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww="
         },
         "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@>=2.1.12 <3.0.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+          "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk="
         }
       }
     },
     "formatio": {
-      "version": "1.1.1",
-      "from": "formatio@1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "dev": true
-    },
-    "formidable": {
-      "version": "1.0.14",
-      "from": "formidable@1.0.14",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+      "version": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true
     },
     "front-matter": {
-      "version": "2.1.0",
-      "from": "front-matter@2.1.0",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.0.tgz",
+      "integrity": "sha1-C9/0LLrSs1wHrHCFgReJdZ+YWMA=",
       "dev": true
     },
     "fs-exists-sync": {
-      "version": "0.1.0",
-      "from": "fs-exists-sync@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
     },
     "fs-extra": {
       "version": "3.0.1",
-      "from": "fs-extra@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
       "dev": true,
       "dependencies": {
         "jsonfile": {
           "version": "3.0.0",
-          "from": "jsonfile@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
+          "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
           "dev": true
         }
       }
     },
     "fs-extra-p": {
       "version": "4.3.0",
-      "from": "fs-extra-p@>=4.3.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.3.0.tgz",
+      "integrity": "sha1-LhSKVEKH3wJYkxyrxYMGO07tIwM=",
       "dev": true
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fstream": {
-      "version": "1.0.11",
-      "from": "fstream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true
     },
     "ftp": {
-      "version": "0.3.10",
-      "from": "ftp@>=0.3.5 <0.4.0",
-      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "version": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true
         }
       }
     },
     "function-bind": {
-      "version": "1.1.0",
-      "from": "function-bind@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
     "gauge": {
-      "version": "2.7.3",
-      "from": "gauge@>=2.7.1 <2.8.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+      "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+      "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
       "dev": true
     },
     "gaze": {
-      "version": "1.1.2",
-      "from": "gaze@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "dependencies": {
         "globule": {
-          "version": "1.1.0",
-          "from": "globule@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+          "version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+          "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
           "dev": true
         },
         "lodash": {
-          "version": "4.16.6",
-          "from": "lodash@>=4.16.4 <4.17.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+          "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
           "dev": true
         }
       }
     },
     "generate-function": {
-      "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
-      "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
     "get-object": {
-      "version": "0.2.0",
-      "from": "get-object@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
+      "integrity": "sha1-2S/31RkMZFMM2gVD2sY6PUf+jAw=",
       "dev": true
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
-      "from": "get-stream@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "dev": true
-    },
-    "get-uri": {
-      "version": "0.1.4",
-      "from": "get-uri@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-0.1.4.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
     "get-value": {
-      "version": "2.0.6",
-      "from": "get-value@>=2.0.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "version": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
-      "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "git-config-path": {
-      "version": "1.0.1",
-      "from": "git-config-path@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "dev": true
     },
     "git-repo-name": {
-      "version": "0.6.0",
-      "from": "git-repo-name@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+      "version": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+      "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
       "dev": true
     },
     "glob": {
-      "version": "7.1.1",
-      "from": "glob@>=7.1.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true
     },
     "glob-base": {
-      "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true
     },
     "global-modules": {
-      "version": "0.2.3",
-      "from": "global-modules@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true
     },
     "global-prefix": {
-      "version": "0.1.5",
-      "from": "global-prefix@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "dev": true,
       "dependencies": {
         "which": {
-          "version": "1.2.12",
-          "from": "which@>=1.2.12 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+          "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
           "dev": true
         }
       }
     },
     "globals": {
-      "version": "9.16.0",
-      "from": "globals@>=9.14.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
+      "version": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
+      "integrity": "sha1-Y+kDZYFx7C2fUbHTHeXiuNwB+4A=",
       "dev": true
     },
-    "globule": {
-      "version": "0.2.0",
-      "from": "globule@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "from": "glob@>=3.2.7 <3.3.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "dev": true,
-          "dependencies": {
-            "minimatch": {
-              "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "dev": true
-        }
-      }
-    },
     "gonzales-pe": {
-      "version": "3.4.7",
-      "from": "gonzales-pe@3.4.7",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
+      "version": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
+      "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
       "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "1.1.3",
-          "from": "minimist@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
       }
     },
     "got": {
       "version": "6.7.1",
-      "from": "got@>=6.7.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "graceful-readlink": {
-      "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
-      "version": "1.9.2",
-      "from": "growl@1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.6",
-      "from": "handlebars@>=4.0.5 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@^1.4.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.4 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true
         }
       }
     },
     "handlebars-helpers": {
-      "version": "0.6.2",
-      "from": "handlebars-helpers@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.6.2.tgz",
+      "version": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.6.2.tgz",
+      "integrity": "sha1-CY6xKCX9rogz4zm2MykA+Wh8XaE=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "har-schema": {
-      "version": "1.0.5",
-      "from": "har-schema@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
     },
     "har-validator": {
-      "version": "4.2.1",
-      "from": "har-validator@>=4.2.1 <4.3.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
     },
     "has": {
-      "version": "1.0.1",
-      "from": "has@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-flag": {
-      "version": "1.0.0",
-      "from": "has-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-unicode": {
-      "version": "2.0.1",
-      "from": "has-unicode@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-values": {
-      "version": "0.1.4",
-      "from": "has-values@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+      "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
       "dev": true
     },
     "hash-base": {
-      "version": "2.0.2",
-      "from": "hash-base@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "version": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true
     },
     "hash.js": {
-      "version": "1.0.3",
-      "from": "hash.js@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
       "dev": true
     },
     "hawk": {
-      "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
     },
     "helper-date": {
-      "version": "0.2.3",
-      "from": "helper-date@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
+      "integrity": "sha1-2HDKu6BB0ynMhW2yC7jElnTj7yg=",
       "dev": true,
       "dependencies": {
         "moment": {
-          "version": "2.17.1",
-          "from": "moment@>=2.17.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
+          "version": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
+          "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI=",
           "dev": true
         }
       }
     },
     "helper-markdown": {
-      "version": "0.2.1",
-      "from": "helper-markdown@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.1.tgz",
+      "integrity": "sha1-N3xZJM2dNwkpEGoDQyXX9GhLvKw=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         }
       }
     },
     "helper-md": {
-      "version": "0.2.1",
-      "from": "helper-md@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.1.tgz",
+      "integrity": "sha1-Vdk3GEBeuh0oT28q7f/CX8+VSsY=",
       "dev": true
     },
     "hmac-drbg": {
-      "version": "1.0.1",
-      "from": "hmac-drbg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true
     },
     "hoek": {
-      "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-path": {
-      "version": "1.0.3",
-      "from": "home-path@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/home-path/-/home-path-1.0.3.tgz",
+      "integrity": "sha1-ns5Z/sPwMubRC1Q0/uJk30wt4y8=",
       "dev": true
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "from": "homedir-polyfill@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.1.5",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+      "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
     },
     "html-angular-validate": {
-      "version": "0.1.9",
-      "from": "html-angular-validate@>=0.1.9 <0.2.0",
-      "resolved": "https://registry.npmjs.org/html-angular-validate/-/html-angular-validate-0.1.9.tgz",
+      "version": "github:jhermsmeier/html-angular-validate#1aeb1873edb267302fbd52340e41850c5b40b6f4",
       "dev": true,
       "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "dev": true
+        },
         "async": {
-          "version": "1.5.2",
-          "from": "async@~1.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+          "dev": true
+        },
+        "co": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
+          "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
+        "cookiejar": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+          "dev": true
+        },
+        "formidable": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+          "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
+          "dev": true
+        },
+        "get-uri": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.0.tgz",
+          "integrity": "sha1-cT5Hy8uuqzj4ivHN/IX6fwmwBzg=",
+          "dev": true
+        },
+        "globule": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
+          "dev": true
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "dev": true
+        },
+        "ip": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
+          "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+          "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
+          "dev": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        },
+        "node.extend": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.0.tgz",
+          "integrity": "sha1-dSWih1Z36lNHhKXhCseJVhOWFN8=",
+          "dev": true
+        },
+        "pac-proxy-agent": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-1.1.0.tgz",
+          "integrity": "sha512-QBELCWyLYPgE2Gj+4wUEiMscHrQ8nRPBzYItQNOHWavwBt25ohZHQC4qnd5IszdVVrFbLsQ+dPkm6eqdjJAmwQ==",
+          "dev": true
+        },
+        "pac-resolver": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-2.0.0.tgz",
+          "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
+          "dev": true
+        },
+        "proxy-agent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.0.0.tgz",
+          "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        },
+        "socks-proxy-agent": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
+          "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
+          "dev": true
+        },
+        "superagent": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
+          "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
+          "dev": true
+        },
+        "superagent-proxy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.2.tgz",
+          "integrity": "sha1-ktNmBXj2GO1DqCz4yseZ/ik4ui0=",
+          "dev": true
+        },
+        "w3cjs": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/w3cjs/-/w3cjs-0.4.0.tgz",
+          "integrity": "sha1-EzYk4LhlYmfPanCF2NfGlLcPBI8=",
           "dev": true
         },
         "xmlbuilder": {
-          "version": "8.2.2",
-          "from": "xmlbuilder@>=8.2.2 <8.3.0",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.0.tgz",
+          "integrity": "sha1-qTEbP4UJNFcAxJqPeb4GvMWYjRg=",
           "dev": true
         }
       }
     },
     "html-tag": {
-      "version": "0.2.1",
-      "from": "html-tag@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/html-tag/-/html-tag-0.2.1.tgz",
+      "integrity": "sha1-r0jg3kdovRTonYXnPgZwQeIHRyI=",
       "dev": true
     },
     "htmlescape": {
-      "version": "1.1.1",
-      "from": "htmlescape@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-      "dev": true
-    },
-    "http-proxy-agent": {
-      "version": "0.2.7",
-      "from": "http-proxy-agent@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-0.2.7.tgz",
+      "version": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
     "http-signature": {
-      "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
     },
     "https-browserify": {
-      "version": "1.0.0",
-      "from": "https-browserify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "0.3.6",
-      "from": "https-proxy-agent@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
+      "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.15",
-      "from": "iconv-lite@>=0.4.5 <0.5.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
     },
     "ieee754": {
-      "version": "1.1.6",
-      "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+      "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+      "integrity": "sha1-LhATIZxtZxKXPsVNmB7BnlV53pc="
     },
     "ignore": {
-      "version": "3.2.6",
-      "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz",
+      "version": "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz",
+      "integrity": "sha1-JujaBkS+C7TLOVFvbHnw4PT/5Iw=",
       "dev": true
     },
     "immutable": {
-      "version": "3.8.1",
-      "from": "immutable@>=3.8.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
+      "version": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+      "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
     },
     "import-lazy": {
       "version": "2.1.0",
-      "from": "import-lazy@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
-      "version": "2.0.0",
-      "from": "in-publish@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
-      "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true
     },
     "index-of": {
-      "version": "0.2.0",
-      "from": "index-of@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
+      "integrity": "sha1-OMHiNn6lXf+tO261kuwcwwkNfWU=",
       "dev": true
     },
     "indexof": {
-      "version": "0.0.1",
-      "from": "indexof@0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true
     },
     "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "ini": {
-      "version": "1.3.4",
-      "from": "ini@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
     "inline-source-map": {
-      "version": "0.6.2",
-      "from": "inline-source-map@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "version": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true
     },
     "inquirer": {
-      "version": "0.11.4",
-      "from": "inquirer@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+      "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+      "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
       "dependencies": {
         "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.3.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "inquirer-dynamic-list": {
-      "version": "1.0.0",
-      "from": "inquirer-dynamic-list@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer-dynamic-list/-/inquirer-dynamic-list-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/inquirer-dynamic-list/-/inquirer-dynamic-list-1.0.0.tgz",
+      "integrity": "sha1-x13pQj1yCoTRgQc6QKGO6kftC3g=",
       "dependencies": {
         "bluebird": {
-          "version": "2.11.0",
-          "from": "bluebird@^2.10.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "insert-module-globals": {
-      "version": "7.0.1",
-      "from": "insert-module-globals@>=7.0.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+      "version": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "interpret": {
-      "version": "1.0.1",
-      "from": "interpret@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+      "integrity": "sha1-1Xn7f2k7hYAElHrzn6DbSfeVYCw=",
       "dev": true
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ip": {
-      "version": "1.1.5",
-      "from": "ip@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "version": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "is": {
-      "version": "3.2.1",
-      "from": "is@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "version": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
       "dev": true
     },
     "is-absolute": {
-      "version": "0.2.6",
-      "from": "is-absolute@>=0.2.6 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true
     },
     "is-accessor-descriptor": {
-      "version": "0.1.6",
-      "from": "is-accessor-descriptor@>=0.1.6 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "version": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "1.1.4",
-      "from": "is-buffer@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
     },
     "is-builtin-module": {
-      "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
     },
     "is-ci": {
       "version": "1.0.10",
-      "from": "is-ci@>=1.0.10 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true
     },
     "is-data-descriptor": {
-      "version": "0.1.4",
-      "from": "is-data-descriptor@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true
     },
     "is-descriptor": {
-      "version": "0.1.5",
-      "from": "is-descriptor@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.5.tgz",
+      "version": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.5.tgz",
+      "integrity": "sha1-4/uLSrZfOjc3M4jhi0AdeMWMvqc=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "is-dotfile": {
-      "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
       "dev": true
     },
     "is-electron": {
-      "version": "2.0.0",
-      "from": "is-electron@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/is-electron/-/is-electron-2.0.0.tgz",
+      "integrity": "sha1-yC01mWQPffkchOqu52vFZxPGrHk="
     },
     "is-electron-renderer": {
-      "version": "2.0.1",
-      "from": "is-electron-renderer@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
+      "integrity": "sha1-pGnQVvl1aXxYyYxgI+sKp5r4laI=",
       "dev": true
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true
     },
     "is-even": {
-      "version": "0.1.1",
-      "from": "is-even@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-even/-/is-even-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-even/-/is-even-0.1.1.tgz",
+      "integrity": "sha1-8Q+/ti2JP3Vdja6PuaOYu8jNXyo=",
       "dev": true,
       "dependencies": {
         "is-number": {
-          "version": "1.1.2",
-          "from": "is-number@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+          "version": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+          "integrity": "sha1-nYJAnzqKi+7PJJsbx9raSYKZZuQ=",
           "dev": true
         }
       }
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "from": "is-extendable@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
     },
     "is-glob": {
-      "version": "2.0.1",
-      "from": "is-glob@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "from": "is-my-json-valid@>=2.13.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "dependencies": {
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "is-npm": {
       "version": "1.0.0",
-      "from": "is-npm@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
-      "from": "is-obj@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-odd": {
-      "version": "0.1.1",
-      "from": "is-odd@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.1.tgz",
+      "integrity": "sha1-UVCPfTnq+wKC+7mJV7LR0o5yo+c=",
       "dev": true,
       "dependencies": {
         "is-number": {
-          "version": "1.1.2",
-          "from": "is-number@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+          "version": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+          "integrity": "sha1-nYJAnzqKi+7PJJsbx9raSYKZZuQ=",
           "dev": true
         }
       }
     },
     "is-path-cwd": {
-      "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true
     },
     "is-phantom": {
-      "version": "1.0.1",
-      "from": "is-phantom@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-phantom/-/is-phantom-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/is-phantom/-/is-phantom-1.0.1.tgz",
+      "integrity": "sha1-SksVhpA74wSgyRo8l3+KU4KsQ6I="
     },
     "is-posix-bracket": {
-      "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-promise": {
-      "version": "2.1.0",
-      "from": "is-promise@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+      "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-property": {
-      "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "is-redirect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-relative": {
-      "version": "0.2.1",
-      "from": "is-relative@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
-      "from": "is-retry-allowed@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
       "dev": true
     },
     "is-stream": {
-      "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
-      "version": "0.1.2",
-      "from": "is-unc-path@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "dev": true
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-valid-glob": {
-      "version": "0.3.0",
-      "from": "is-valid-glob@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
       "dev": true
     },
     "is-windows": {
-      "version": "0.2.0",
-      "from": "is-windows@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
       "dev": true
     },
     "isarray": {
-      "version": "0.0.1",
-      "from": "isarray@0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
       "version": "3.0.2",
-      "from": "isbinaryfile@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+      "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
       "dev": true
     },
     "isexe": {
-      "version": "1.1.2",
-      "from": "isexe@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
       "dev": true
     },
     "isobject": {
-      "version": "0.2.0",
-      "from": "isobject@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
+      "integrity": "sha1-o0MhkvObkQtfAsyYlIeDbscKqF4=",
       "dev": true
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
+      "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
     },
     "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jodid25519": {
-      "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "optional": true
     },
     "js-base64": {
-      "version": "2.1.9",
-      "from": "js-base64@>=2.1.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
       "dev": true
     },
     "js-message": {
-      "version": "1.0.5",
-      "from": "js-message@>=1.0.5",
-      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz"
+      "version": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
+      "integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU="
     },
     "js-queue": {
-      "version": "1.0.0",
-      "from": "js-queue@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/js-queue/-/js-queue-1.0.0.tgz",
+      "integrity": "sha1-urLiJiH+8rJKNLgM4CtyaUHDugA="
     },
     "js-tokens": {
-      "version": "1.0.3",
-      "from": "js-tokens@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
+      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
+      "integrity": "sha1-FOVutoyPGpLEPVn1AU7CncIPKuE="
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "from": "js-yaml@>=3.4.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
+      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA="
     },
     "jsbn": {
-      "version": "0.1.1",
-      "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-stable-stringify": {
-      "version": "0.0.1",
-      "from": "json-stable-stringify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
-      "version": "3.3.2",
-      "from": "json3@3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "from": "json5@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "from": "jsonfile@>=2.3.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true
     },
     "jsonify": {
-      "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
-      "version": "1.3.1",
-      "from": "jsonparse@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "from": "jsonpointer@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "JSONStream": {
-      "version": "1.3.1",
-      "from": "JSONStream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
     "kind-of": {
-      "version": "3.1.0",
-      "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "dev": true
     },
     "klaw": {
-      "version": "1.3.1",
-      "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true
     },
     "labeled-stream-splicer": {
-      "version": "2.0.0",
-      "from": "labeled-stream-splicer@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
       "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
-      "from": "latest-version@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true
     },
     "lazy-cache": {
-      "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
     "lcid": {
-      "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
     },
     "levn": {
-      "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true
     },
     "lexical-scope": {
-      "version": "1.2.0",
-      "from": "lexical-scope@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true
     },
     "list-item": {
-      "version": "1.1.1",
-      "from": "list-item@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
       "dev": true
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "from": "load-json-file@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.4",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
+          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
         }
       }
     },
     "locate-path": {
       "version": "2.0.0",
-      "from": "locate-path@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@^3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
     },
     "lodash": {
-      "version": "4.13.1",
-      "from": "lodash@>=4.5.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+      "version": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+      "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
     },
     "lodash-deep": {
-      "version": "2.0.0",
-      "from": "lodash-deep@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-2.0.0.tgz",
+      "integrity": "sha1-ypWPW82z1o0+w3rN8cWMHMvYhlw="
     },
     "lodash-es": {
-      "version": "4.13.1",
-      "from": "lodash-es@>=4.2.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.13.1.tgz"
+      "version": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.13.1.tgz",
+      "integrity": "sha1-Pao28j8J7eCSpviIM//eCPe4WTw="
     },
     "lodash._baseassign": {
-      "version": "3.2.0",
-      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "dependencies": {
         "lodash.keys": {
-          "version": "3.1.2",
-          "from": "lodash.keys@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "dev": true
         }
       }
     },
     "lodash._basecopy": {
-      "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "3.0.3",
-      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.assign": {
-      "version": "4.0.9",
-      "from": "lodash.assign@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
+      "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz",
+      "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M="
     },
     "lodash.capitalize": {
-      "version": "4.2.1",
-      "from": "lodash.capitalize@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
     "lodash.clonedeep": {
-      "version": "4.5.0",
-      "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.create": {
-      "version": "3.1.1",
-      "from": "lodash.create@3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true
     },
     "lodash.filter": {
-      "version": "4.6.0",
-      "from": "lodash.filter@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
       "dev": true
     },
     "lodash.findkey": {
-      "version": "4.6.0",
-      "from": "lodash.findkey@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
+      "integrity": "sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg=",
       "dev": true
     },
     "lodash.foreach": {
-      "version": "4.5.0",
-      "from": "lodash.foreach@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
     "lodash.frompairs": {
-      "version": "4.0.1",
-      "from": "lodash.frompairs@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz"
+      "version": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz",
+      "integrity": "sha1-vE5SB/onV8E25XNhTpZkUGsrG9I="
     },
     "lodash.includes": {
-      "version": "4.3.0",
-      "from": "lodash.includes@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "dev": true
     },
     "lodash.isarguments": {
-      "version": "3.1.0",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isempty": {
-      "version": "4.4.0",
-      "from": "lodash.isempty@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
       "dev": true
     },
     "lodash.kebabcase": {
-      "version": "4.1.1",
-      "from": "lodash.kebabcase@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.keys": {
-      "version": "4.0.7",
-      "from": "lodash.keys@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
+      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz",
+      "integrity": "sha1-MOGzvZjlTWoGEZkYEmhba8R8tjs="
     },
     "lodash.mapvalues": {
-      "version": "4.6.0",
-      "from": "lodash.mapvalues@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz"
+      "version": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.memoize": {
-      "version": "3.0.4",
-      "from": "lodash.memoize@>=3.0.3 <3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "from": "lodash.mergewith@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
       "dev": true
     },
     "lodash.partition": {
-      "version": "4.6.0",
-      "from": "lodash.partition@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "version": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q=",
       "dev": true
     },
     "lodash.rest": {
-      "version": "4.0.3",
-      "from": "lodash.rest@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
+      "version": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz",
+      "integrity": "sha1-TBwyxAAoCHJQ+r9w1C4BUVSPSMU="
     },
     "lodash.some": {
-      "version": "4.6.0",
-      "from": "lodash.some@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
+      "version": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "lodash.trim": {
-      "version": "4.5.1",
-      "from": "lodash.trim@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "version": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc=",
       "dev": true
     },
     "logging-helpers": {
-      "version": "0.4.0",
-      "from": "logging-helpers@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
+      "integrity": "sha1-AObVMWwjdn7BLhIA5PEsXgM+frA=",
       "dev": true
     },
     "lolex": {
-      "version": "1.3.2",
-      "from": "lolex@1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "version": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "longest": {
-      "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.2.0",
-      "from": "loose-envify@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
+      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
+      "integrity": "sha1-aaZarT3lQs9O4PT+dOjjPHCcyw8="
     },
     "loud-rejection": {
-      "version": "1.6.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "from": "lowercase-keys@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
     "lru-cache": {
-      "version": "4.0.1",
-      "from": "lru-cache@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+      "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
       "dev": true
     },
     "lsmod": {
-      "version": "1.0.0",
-      "from": "lsmod@1.0.0",
-      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
+      "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
     },
     "lzma-native": {
-      "version": "1.5.2",
-      "from": "lzma-native@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-1.5.2.tgz",
+      "version": "https://registry.npmjs.org/lzma-native/-/lzma-native-1.5.2.tgz",
+      "integrity": "sha1-22VqwTNggVW9Dm6yqWqxrw3TPSQ=",
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
         },
         "node-pre-gyp": {
-          "version": "0.6.29",
-          "from": "node-pre-gyp@0.6.29",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
+          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
+          "integrity": "sha1-sL0TY1uvfRvnriM8FvvPMwms03w=",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.9",
-              "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+              "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
             },
             "ansi-regex": {
-              "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
             },
             "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+              "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
             },
             "aproba": {
-              "version": "1.0.4",
-              "from": "aproba@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+              "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+              "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
             },
             "are-we-there-yet": {
-              "version": "1.1.2",
-              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+              "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM="
             },
             "asn1": {
-              "version": "0.2.3",
-              "from": "asn1@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+              "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
             },
             "assert-plus": {
-              "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
             },
             "async": {
-              "version": "1.5.2",
-              "from": "async@>=1.5.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+              "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
             },
             "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+              "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
             },
             "aws4": {
-              "version": "1.4.1",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+              "version": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE="
             },
             "balanced-match": {
-              "version": "0.4.1",
-              "from": "balanced-match@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+              "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+              "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU="
             },
             "bl": {
-              "version": "1.1.2",
-              "from": "bl@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "version": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44="
                 }
               }
             },
             "block-stream": {
-              "version": "0.0.9",
-              "from": "block-stream@*",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+              "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo="
             },
             "boom": {
-              "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+              "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
             },
             "brace-expansion": {
-              "version": "1.1.5",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
+              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+              "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY="
             },
             "buffer-shims": {
-              "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
             },
             "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+              "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
             },
             "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+              "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
             },
             "code-point-at": {
-              "version": "1.0.0",
-              "from": "code-point-at@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+              "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY="
             },
             "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+              "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
             },
             "commander": {
-              "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+              "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q="
             },
             "concat-map": {
-              "version": "0.0.1",
-              "from": "concat-map@0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+              "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "console-control-strings": {
-              "version": "1.1.0",
-              "from": "console-control-strings@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+              "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+              "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
             },
             "dashdash": {
-              "version": "1.14.0",
-              "from": "dashdash@>=1.12.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+              "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+              "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
               "dependencies": {
                 "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+              "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo="
             },
             "deep-extend": {
-              "version": "0.4.1",
-              "from": "deep-extend@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+              "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
             },
             "delayed-stream": {
-              "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
             },
             "delegates": {
-              "version": "1.0.0",
-              "from": "delegates@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
             },
             "ecc-jsbn": {
-              "version": "0.1.1",
-              "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
               "optional": true
             },
             "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+              "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
             },
             "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
             },
             "extsprintf": {
-              "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
             },
             "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+              "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
             },
             "form-data": {
-              "version": "1.0.0-rc4",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+              "version": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+              "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14="
             },
             "fs.realpath": {
-              "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
             },
             "fstream": {
-              "version": "1.0.10",
-              "from": "fstream@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
+              "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+              "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI="
             },
             "fstream-ignore": {
-              "version": "1.0.5",
-              "from": "fstream-ignore@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+              "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU="
             },
             "gauge": {
-              "version": "2.6.0",
-              "from": "gauge@>=2.6.0 <2.7.0",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
+              "version": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+              "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY="
             },
             "generate-function": {
-              "version": "2.0.0",
-              "from": "generate-function@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
             },
             "generate-object-property": {
-              "version": "1.2.0",
-              "from": "generate-object-property@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+              "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
             },
             "getpass": {
-              "version": "0.1.6",
-              "from": "getpass@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+              "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+              "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
               "dependencies": {
                 "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "glob": {
-              "version": "7.0.5",
-              "from": "glob@>=7.0.0 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+              "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+              "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU="
             },
             "graceful-fs": {
-              "version": "4.1.4",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+              "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
+              "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
             },
             "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+              "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
             },
             "har-validator": {
-              "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0="
             },
             "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
             },
             "has-color": {
-              "version": "0.1.7",
-              "from": "has-color@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+              "version": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+              "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
             },
             "has-unicode": {
-              "version": "2.0.1",
-              "from": "has-unicode@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+              "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
             },
             "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
             },
             "hoek": {
-              "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+              "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
             },
             "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
             },
             "inflight": {
-              "version": "1.0.5",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo="
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             },
             "ini": {
-              "version": "1.3.4",
-              "from": "ini@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+              "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
             },
             "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
             },
             "is-my-json-valid": {
-              "version": "2.13.1",
-              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+              "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+              "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc="
             },
             "is-property": {
-              "version": "1.0.2",
-              "from": "is-property@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
             },
             "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
             },
             "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
             },
             "jodid25519": {
-              "version": "1.0.2",
-              "from": "jodid25519@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
               "optional": true
             },
             "jsbn": {
-              "version": "0.1.0",
-              "from": "jsbn@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+              "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+              "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
               "optional": true
             },
             "json-schema": {
-              "version": "0.2.2",
-              "from": "json-schema@0.2.2",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+              "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+              "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
             },
             "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
             },
             "jsonpointer": {
-              "version": "2.0.0",
-              "from": "jsonpointer@2.0.0",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+              "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk="
             },
             "jsprim": {
-              "version": "1.3.0",
-              "from": "jsprim@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
+              "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+              "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA="
             },
             "mime-db": {
-              "version": "1.23.0",
-              "from": "mime-db@>=1.23.0 <1.24.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+              "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+              "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
             },
             "mime-types": {
-              "version": "2.1.11",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw="
             },
             "minimatch": {
-              "version": "3.0.2",
-              "from": "minimatch@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
+              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+              "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo="
             },
             "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             },
             "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+              "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
             },
             "ms": {
-              "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             },
             "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
             },
             "nopt": {
-              "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+              "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k="
             },
             "npmlog": {
-              "version": "3.1.2",
-              "from": "npmlog@>=3.1.2 <3.2.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
+              "version": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+              "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM="
             },
             "number-is-nan": {
-              "version": "1.0.0",
-              "from": "number-is-nan@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+              "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
             },
             "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+              "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
             },
             "object-assign": {
-              "version": "4.1.0",
-              "from": "object-assign@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
             },
             "once": {
-              "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
             },
             "pinkie": {
-              "version": "2.0.4",
-              "from": "pinkie@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+              "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
             },
             "pinkie-promise": {
-              "version": "2.0.1",
-              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+              "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
             },
             "process-nextick-args": {
-              "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
             },
             "qs": {
-              "version": "6.1.0",
-              "from": "qs@>=6.1.0 <6.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
+              "version": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+              "integrity": "sha1-7B0WJrJCeNmfD99FSeUk4k7O6yY="
             },
             "rc": {
-              "version": "1.1.6",
-              "from": "rc@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+              "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+              "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
               "dependencies": {
                 "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                  "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
               }
             },
             "readable-stream": {
-              "version": "2.1.4",
-              "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
+              "integrity": "sha1-cLl5HG/LhIDbRL0VWg9rtY8XJGg="
             },
             "request": {
-              "version": "2.72.0",
-              "from": "request@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz"
+              "version": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
+              "integrity": "sha1-DOOheVEmILEEQfFMguIcEsDdtOE="
             },
             "rimraf": {
-              "version": "2.5.2",
-              "from": "rimraf@>=2.5.0 <2.6.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
+              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY="
             },
             "semver": {
-              "version": "5.2.0",
-              "from": "semver@>=5.2.0 <5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
+              "version": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
+              "integrity": "sha1-KBmVuAwUSCCUFd28TPUMJpzvVcU="
             },
             "set-blocking": {
-              "version": "2.0.0",
-              "from": "set-blocking@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
             },
             "signal-exit": {
-              "version": "3.0.0",
-              "from": "signal-exit@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
+              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+              "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g="
             },
             "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+              "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
             },
             "sshpk": {
-              "version": "1.8.3",
-              "from": "sshpk@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+              "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+              "integrity": "sha1-iQzJ1hTcUpLlyxpUOwPJq6pcN04=",
               "dependencies": {
                 "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                 }
               }
             },
             "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             },
             "string-width": {
-              "version": "1.0.1",
-              "from": "string-width@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
             },
             "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
             },
             "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
             },
             "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.4 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+              "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             },
             "tar": {
-              "version": "2.2.1",
-              "from": "tar@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+              "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE="
             },
             "tar-pack": {
-              "version": "3.1.4",
-              "from": "tar-pack@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
+              "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
+              "integrity": "sha1-vIz5oi9YMnOfEvORDaweuXtJcIw="
             },
             "tough-cookie": {
-              "version": "2.2.2",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+              "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc="
             },
             "tunnel-agent": {
-              "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
             },
             "tweetnacl": {
-              "version": "0.13.3",
-              "from": "tweetnacl@>=0.13.0 <0.14.0",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+              "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+              "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
               "optional": true
             },
             "uid-number": {
-              "version": "0.0.6",
-              "from": "uid-number@>=0.0.6 <0.1.0",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+              "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
             },
             "util-deprecate": {
-              "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
             },
             "verror": {
-              "version": "1.3.6",
-              "from": "verror@1.3.6",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+              "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
             },
             "wide-align": {
-              "version": "1.1.0",
-              "from": "wide-align@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+              "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+              "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0="
             },
             "wrappy": {
-              "version": "1.0.2",
-              "from": "wrappy@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         }
@@ -4577,1066 +3907,975 @@
     },
     "macaddress": {
       "version": "0.2.8",
-      "from": "macaddress@>=0.2.7 <0.3.0",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
     "make-dir": {
       "version": "1.0.0",
-      "from": "make-dir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "dev": true
     },
     "make-iterator": {
-      "version": "0.2.1",
-      "from": "make-iterator@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz",
+      "integrity": "sha1-oZxmATK1SubWT4gewUBWx0bb6XI=",
       "dev": true
     },
     "map-obj": {
-      "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "markdown": {
-      "version": "0.5.0",
-      "from": "markdown@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
+      "version": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
+      "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
       "dev": true,
       "dependencies": {
         "nopt": {
-          "version": "2.1.2",
-          "from": "nopt@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+          "version": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+          "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
           "dev": true
         }
       }
     },
     "markdown-utils": {
-      "version": "0.7.3",
-      "from": "markdown-utils@>=0.7.3 <0.8.0",
-      "resolved": "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz",
+      "version": "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz",
+      "integrity": "sha1-TFg6MeJR1psxOs6zgCpPXRsPHnY=",
       "dev": true
     },
     "mem": {
       "version": "1.1.0",
-      "from": "mem@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true
     },
     "meow": {
-      "version": "3.7.0",
-      "from": "meow@>=3.7.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true
     },
     "merge": {
-      "version": "1.2.0",
-      "from": "merge@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "dev": true
-    },
-    "methods": {
-      "version": "1.0.1",
-      "from": "methods@1.0.1",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
     },
     "micromatch": {
-      "version": "2.3.11",
-      "from": "micromatch@>=2.3.10 <3.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true
     },
     "miller-rabin": {
-      "version": "4.0.0",
-      "from": "miller-rabin@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "dev": true
     },
     "mime": {
       "version": "1.3.6",
-      "from": "mime@>=1.3.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
       "dev": true
     },
     "mime-db": {
-      "version": "1.27.0",
-      "from": "mime-db@>=1.27.0 <1.28.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
     },
     "mime-types": {
-      "version": "2.1.15",
-      "from": "mime-types@latest",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
     },
     "mimic-fn": {
       "version": "1.1.0",
-      "from": "mimic-fn@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
       "dev": true
     },
     "minimalistic-assert": {
-      "version": "1.0.0",
-      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.3",
-      "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
       "dev": true
     },
     "minimist": {
-      "version": "1.2.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.2.0",
-      "from": "mixin-deep@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
+      "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
       "dev": true,
       "dependencies": {
         "for-in": {
-          "version": "1.0.2",
-          "from": "for-in@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         }
       }
     },
     "mixpanel": {
-      "version": "0.6.0",
-      "from": "mixpanel@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.6.0.tgz"
+      "version": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.6.0.tgz",
+      "integrity": "sha1-67sBGvASLcyDR5o6NdcVh4odeOI="
     },
     "mixpanel-browser": {
-      "version": "2.11.0",
-      "from": "mixpanel-browser@>=2.11.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.11.0.tgz"
+      "version": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.11.0.tgz",
+      "integrity": "sha1-WRmpTbE+/x0TdRyvxgvGhf88jvI="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
     },
     "mkpath": {
-      "version": "0.1.0",
-      "from": "mkpath@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
       "dev": true
     },
     "mksnapshot": {
-      "version": "0.1.0",
-      "from": "mksnapshot@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
+      "integrity": "sha1-99CavKgGrYw3gNpwG7GHeNfOaaw=",
       "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "0.1.5",
-          "from": "assert-plus@>=0.1.5 <0.2.0",
-          "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "version": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
           "dev": true
         },
         "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         },
         "aws-sign2": {
-          "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "version": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
           "dev": true
         },
         "bluebird": {
-          "version": "2.11.0",
-          "from": "bluebird@>=2.9.30 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         },
         "caseless": {
-          "version": "0.9.0",
-          "from": "caseless@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "version": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+          "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
           "dev": true
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.8.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "form-data": {
-          "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "version": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
           "dev": true
         },
         "fs-extra": {
-          "version": "0.18.2",
-          "from": "fs-extra@0.18.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
+          "integrity": "sha1-rwXKcCsLbfp96AOh96tHnsXCFSU=",
           "dev": true
         },
         "graceful-fs": {
-          "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true
         },
         "har-validator": {
-          "version": "1.8.0",
-          "from": "har-validator@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "version": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+          "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
           "dev": true
         },
         "hawk": {
-          "version": "2.3.1",
-          "from": "hawk@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "version": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
           "dev": true
         },
         "http-signature": {
-          "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "version": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
           "dev": true
         },
         "mime-db": {
-          "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
           "dev": true
         },
         "mime-types": {
-          "version": "2.0.14",
-          "from": "mime-types@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "dev": true
         },
         "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
           "dev": true
         },
         "oauth-sign": {
-          "version": "0.6.0",
-          "from": "oauth-sign@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+          "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
           "dev": true
         },
         "qs": {
-          "version": "2.4.2",
-          "from": "qs@>=2.4.0 <2.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "version": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
           "dev": true
         },
         "request": {
-          "version": "2.55.0",
-          "from": "request@2.55.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "version": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
           "dev": true
         },
         "tunnel-agent": {
-          "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         }
       }
     },
     "mocha": {
-      "version": "3.2.0",
-      "from": "mocha@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
+      "version": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
+      "integrity": "sha1-fcT0XlCIB1FxpoiWgU5q6et6heM=",
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true
         },
         "glob": {
-          "version": "7.0.5",
-          "from": "glob@7.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
           "dev": true
         },
         "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true
         }
       }
     },
     "mochainon": {
-      "version": "1.0.0",
-      "from": "mochainon@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mochainon/-/mochainon-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/mochainon/-/mochainon-1.0.0.tgz",
+      "integrity": "sha1-r6Po2kfA0Ox6eFdW8EudqkFhMbs=",
       "dev": true
     },
     "module-deps": {
-      "version": "4.1.1",
-      "from": "module-deps@>=4.0.8 <5.0.0",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "version": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "moment": {
-      "version": "2.13.0",
-      "from": "moment@>=2.8.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+      "version": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI="
     },
     "moment-duration-format": {
-      "version": "1.3.0",
-      "from": "moment-duration-format@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
+      "version": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz",
+      "integrity": "sha1-VBdxtfh6BJzGVUBHXTrZZnN9aQg="
     },
     "mountutils": {
       "version": "1.2.0",
-      "from": "mountutils@latest",
       "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.2.0.tgz",
+      "integrity": "sha512-P64iNn/+w083X2jZIqYvYNTuJsey3MYLSBcDRZ1lecmYVS0r65w8eqyD0xFjfW++E7DqRkE7weFeWI+mppGI0w==",
       "dependencies": {
         "nan": {
           "version": "2.6.2",
-          "from": "nan@>=2.5.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
         }
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "from": "ms@0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+      "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
     },
     "nan": {
-      "version": "2.3.5",
-      "from": "nan@>=2.3.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
+      "version": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg="
     },
     "natives": {
-      "version": "1.1.0",
-      "from": "natives@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
       "dev": true
     },
     "natural-compare": {
-      "version": "1.4.0",
-      "from": "natural-compare@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "netmask": {
-      "version": "1.0.6",
-      "from": "netmask@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "version": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
     },
     "ngcomponent": {
-      "version": "3.0.1",
-      "from": "ngcomponent@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ngcomponent/-/ngcomponent-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/ngcomponent/-/ngcomponent-3.0.1.tgz",
+      "integrity": "sha1-Os62qfDxmg1pUo4GudzkkNxQIIQ=",
       "dependencies": {
         "lodash.assign": {
-          "version": "4.2.0",
-          "from": "lodash.assign@>=4.2.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+          "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
         }
       }
     },
     "nock": {
-      "version": "9.0.9",
-      "from": "nock@9.0.9",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.9.tgz",
+      "version": "https://registry.npmjs.org/nock/-/nock-9.0.9.tgz",
+      "integrity": "sha1-ykzZIzUuIGrjx9ZZXP1/siMpnsA=",
       "dev": true,
       "dependencies": {
         "deep-equal": {
-          "version": "1.0.1",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
           "dev": true
         },
         "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@>=4.17.2 <4.18.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
     },
     "node-cmd": {
-      "version": "1.1.1",
-      "from": "node-cmd@>=1.1.1",
-      "resolved": "https://registry.npmjs.org/node-cmd/-/node-cmd-1.1.1.tgz"
+      "version": "https://registry.npmjs.org/node-cmd/-/node-cmd-1.1.1.tgz",
+      "integrity": "sha1-nGFZ025rNbWexKtAhA0mqxSpgG0="
     },
     "node-emoji": {
       "version": "1.5.1",
-      "from": "node-emoji@>=1.5.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.1.tgz",
+      "integrity": "sha1-/ZGOQSdpv4xEgFEjgjOECyr/FqE=",
       "dev": true
     },
     "node-fetch": {
-      "version": "1.6.3",
-      "from": "node-fetch@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
+      "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ="
     },
     "node-forge": {
       "version": "0.7.1",
-      "from": "node-forge@>=0.7.1 <0.8.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
       "dev": true
     },
     "node-gyp": {
-      "version": "3.5.0",
-      "from": "node-gyp@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
+      "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
+      "integrity": "sha1-qP5eYR0HnsFjSKPrlg544RyFJ0o=",
       "dev": true,
       "dependencies": {
         "semver": {
-          "version": "5.3.0",
-          "from": "semver@~5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
     },
     "node-ipc": {
-      "version": "8.9.2",
-      "from": "node-ipc@latest",
-      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-8.9.2.tgz"
+      "version": "https://registry.npmjs.org/node-ipc/-/node-ipc-8.9.2.tgz",
+      "integrity": "sha1-HQEDWVXFpr0fC5MhdOoDMKud2XY="
     },
     "node-sass": {
-      "version": "4.5.3",
-      "from": "node-sass@latest",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "version": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "dependencies": {
         "cross-spawn": {
-          "version": "3.0.1",
-          "from": "cross-spawn@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "dev": true
         },
         "lodash.assign": {
-          "version": "4.2.0",
-          "from": "lodash.assign@>=4.2.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "version": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
           "dev": true
         }
       }
     },
     "node-stream-zip": {
-      "version": "1.3.4",
-      "from": "node-stream-zip@>=1.3.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.4.tgz"
-    },
-    "node.extend": {
-      "version": "1.1.6",
-      "from": "node.extend@>=1.1.5 <1.2.0",
-      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-      "dev": true
+      "version": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.4.tgz",
+      "integrity": "sha1-FaJMCUsBx3vp2PuswwwDTOwl13I="
     },
     "nopt": {
-      "version": "3.0.6",
-      "from": "nopt@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true
     },
     "normalize-package-data": {
-      "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8="
     },
     "normalize-path": {
-      "version": "2.0.1",
-      "from": "normalize-path@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+      "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
       "dev": true
     },
     "npm-run-path": {
       "version": "1.0.0",
-      "from": "npm-run-path@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
       "dev": true
     },
     "npmlog": {
-      "version": "4.0.2",
-      "from": "npmlog@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+      "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+      "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
       "dev": true,
       "dependencies": {
         "set-blocking": {
-          "version": "2.0.0",
-          "from": "set-blocking@~2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         }
       }
     },
     "npx": {
       "version": "5.2.0",
-      "from": "npx@latest",
       "resolved": "https://registry.npmjs.org/npx/-/npx-5.2.0.tgz",
+      "integrity": "sha512-I4qqDjY/OqHa6XB+hfQJoVHQc/N/B7vOSmv1noezTeryD/zTx5BCi86Zw+r9/Mf3rUkH6iJIqIG4b8nPF7MHAQ==",
       "dev": true,
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "from": "ansi-align@^2.0.0",
           "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "from": "ansi-regex@2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "from": "ansi-styles@2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "from": "balanced-match@0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@3.5.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
           "dev": true
         },
         "boxen": {
           "version": "1.1.0",
-          "from": "boxen@^1.0.0",
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+          "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "from": "brace-expansion@1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "from": "builtin-modules@1.1.1",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "from": "builtins@1.0.3",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "from": "capture-stack-trace@^1.0.0",
           "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "from": "cli-boxes@^1.0.0",
           "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "from": "cliui@3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true
             }
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "from": "code-point-at@1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "configstore": {
           "version": "3.1.0",
-          "from": "configstore@^3.0.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+          "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
           "dev": true,
           "dependencies": {
             "dot-prop": {
               "version": "4.1.1",
-              "from": "dot-prop@^4.1.0",
               "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+              "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
               "dev": true
             }
           }
         },
         "create-error-class": {
           "version": "3.0.2",
-          "from": "create-error-class@^3.0.0",
           "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "from": "cross-spawn@4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true
         },
         "cross-spawn-async": {
           "version": "2.2.5",
-          "from": "cross-spawn-async@^2.1.1",
           "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+          "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
           "dev": true
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "from": "crypto-random-string@^1.0.0",
           "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "from": "decamelize@1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.4.2",
-          "from": "deep-extend@~0.4.0",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true
         },
         "dotenv": {
           "version": "4.0.0",
-          "from": "dotenv@^4.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+          "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "from": "duplexer3@^0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "error-ex": {
           "version": "1.3.1",
-          "from": "error-ex@1.3.1",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "from": "execa@0.5.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "from": "fs.realpath@1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "from": "get-caller-file@1.0.2",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "from": "get-stream@2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true
         },
         "got": {
           "version": "6.7.1",
-          "from": "got@^6.7.1",
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "from": "get-stream@^3.0.0",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-ansi": {
           "version": "2.0.0",
-          "from": "has-ansi@2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.4.2",
-          "from": "hosted-git-info@2.4.2",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
           "dev": true
         },
         "import-lazy": {
           "version": "2.1.0",
-          "from": "import-lazy@^2.1.0",
           "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "from": "imurmurhash@0.1.4",
           "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "from": "inflight@1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true
         },
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "from": "ini@1.3.4",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "from": "invert-kv@1.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "from": "is-arrayish@0.2.1",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "from": "is-builtin-module@1.0.0",
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "from": "is-fullwidth-code-point@1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true
         },
         "is-npm": {
           "version": "1.0.0",
-          "from": "is-npm@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "from": "is-obj@1.0.1",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-redirect": {
           "version": "1.0.0",
-          "from": "is-redirect@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "from": "is-retry-allowed@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "from": "is-stream@1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "from": "isexe@2.0.0",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "latest-version": {
           "version": "3.1.0",
-          "from": "latest-version@^3.0.0",
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true
         },
         "lcid": {
           "version": "1.0.0",
-          "from": "lcid@1.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "from": "load-json-file@2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true
         },
         "locate-path": {
           "version": "2.0.0",
-          "from": "locate-path@2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.0",
-          "from": "lowercase-keys@^1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.0.2",
-          "from": "lru-cache@4.0.2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
           "dev": true
         },
         "make-dir": {
           "version": "1.0.0",
-          "from": "make-dir@^1.0.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+          "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "from": "mem@1.1.0",
           "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "from": "mimic-fn@1.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.8",
-          "from": "normalize-package-data@2.3.8",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
           "dev": true
         },
         "npm": {
           "version": "5.0.3",
-          "from": "npm@5.0.3",
           "resolved": "https://registry.npmjs.org/npm/-/npm-5.0.3.tgz",
+          "integrity": "sha512-mnDS+181aU952rCrHnLr1eyHOUbpCE2VrTYt1N/MXK0JRgUneofhHzuDXiwrNY0JmNb1n0VrHdwDEqS6x1iukQ==",
           "dev": true,
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "from": "abbrev@~1.1.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "dev": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "from": "ansi-regex@~2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
-              "from": "ansicolors@~0.3.2",
               "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "from": "ansistyles@~0.1.3",
               "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
               "dev": true
             },
             "aproba": {
               "version": "1.1.2",
-              "from": "aproba@1.1.2",
               "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+              "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "from": "archy@~1.0.0",
               "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "dev": true
             },
             "bluebird": {
               "version": "3.5.0",
-              "from": "bluebird@~3.5.0",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+              "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
               "dev": true
             },
             "cacache": {
               "version": "9.2.8",
-              "from": "cacache@9.2.8",
               "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.8.tgz",
+              "integrity": "sha512-nA3gmaDPEsFWqI5eYAe35IfvW54yGJ3ns2wDopWf4iDA3fkhBNsdvnYp4NrL+L7ysMt0/isM84Mwi+b4l8/pMQ==",
               "dev": true,
               "dependencies": {
                 "y18n": {
                   "version": "3.2.1",
-                  "from": "y18n@^3.2.1",
                   "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                   "dev": true
                 }
               }
             },
             "call-limit": {
               "version": "1.1.0",
-              "from": "call-limit@~1.1.0",
               "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+              "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "from": "chownr@~1.0.1",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "from": "cmd-shim@~2.0.2",
               "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "dev": true
             },
             "columnify": {
               "version": "1.5.4",
-              "from": "columnify@~1.5.4",
               "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "dev": true,
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.1",
-                  "from": "wcwidth@^1.0.0",
                   "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+                  "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
                   "dev": true,
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "from": "defaults@^1.0.3",
                       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "dev": true,
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "from": "clone@^1.0.2",
                           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                           "dev": true
                         }
                       }
@@ -5647,102 +4886,102 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "from": "config-chain@~1.1.11",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
               "dev": true,
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@~1.2.1",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                   "dev": true
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "from": "debuglog@*",
               "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "dev": true
             },
             "detect-indent": {
               "version": "5.0.0",
-              "from": "detect-indent",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+              "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
               "dev": true
             },
             "dezalgo": {
               "version": "1.0.3",
-              "from": "dezalgo@~1.0.3",
               "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "dependencies": {
                 "asap": {
                   "version": "2.0.5",
-                  "from": "asap@^2.0.0",
                   "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+                  "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
                   "dev": true
                 }
               }
             },
             "editor": {
               "version": "1.0.0",
-              "from": "editor@~1.0.0",
               "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "from": "fs-vacuum@~1.2.10",
               "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+              "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
               "dev": true
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "from": "fs-write-stream-atomic@~1.0.10",
               "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+              "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
               "dev": true
             },
             "fstream": {
               "version": "1.0.11",
-              "from": "fstream@~1.0.11",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true
             },
             "fstream-npm": {
               "version": "1.2.1",
-              "from": "fstream-npm@latest",
               "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
+              "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
               "dev": true,
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "from": "fstream-ignore@^1.0.0",
                   "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "dev": true,
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
-                      "from": "minimatch@^3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                       "dev": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "from": "brace-expansion@^1.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                           "dev": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@^0.4.1",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -5755,38 +4994,38 @@
             },
             "glob": {
               "version": "7.1.2",
-              "from": "glob@7.1.2",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "fs.realpath@^1.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@^3.0.4",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                       "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@^0.4.1",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -5795,322 +5034,322 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "path-is-absolute@^1.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "from": "graceful-fs@~4.1.11",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "has-unicode": {
               "version": "2.0.1",
-              "from": "has-unicode@~2.0.1",
               "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.4.2",
-              "from": "hosted-git-info@~2.4.2",
               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+              "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "from": "iferr@~0.1.5",
               "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "from": "imurmurhash@*",
               "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "from": "inflight@~1.0.6",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@~2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@~1.3.4",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true
             },
             "init-package-json": {
               "version": "1.10.1",
-              "from": "init-package-json@~1.10.1",
               "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
+              "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
               "dev": true,
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
-                  "from": "promzard@^0.3.0",
                   "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "dev": true
                 }
               }
             },
             "JSONStream": {
               "version": "1.3.1",
-              "from": "JSONStream@~1.3.1",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+              "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
               "dev": true,
               "dependencies": {
                 "jsonparse": {
                   "version": "1.3.0",
-                  "from": "jsonparse@^1.2.0",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+                  "integrity": "sha1-hfwkWx2SWazGlBlguQWt9k594Og=",
                   "dev": true
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
                   "dev": true
                 }
               }
             },
             "lazy-property": {
               "version": "1.0.0",
-              "from": "lazy-property@~1.0.0",
               "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+              "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
               "dev": true
             },
             "lockfile": {
               "version": "1.0.3",
-              "from": "lockfile@~1.0.3",
               "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+              "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
               "dev": true
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "from": "lodash._baseindexof@*",
               "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
               "dev": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "from": "lodash._baseuniq@~4.6.0",
               "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "dev": true,
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
-                  "from": "lodash._createset@~4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
                   "dev": true
                 },
                 "lodash._root": {
                   "version": "3.0.1",
-                  "from": "lodash._root@~3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
                   "dev": true
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@*",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
               "dev": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "from": "lodash._cacheindexof@*",
               "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
               "dev": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "from": "lodash._createcache@*",
               "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "dev": true
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "from": "lodash._getnative@*",
               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
               "dev": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "from": "lodash.clonedeep@~4.5.0",
               "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
               "dev": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@*",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
               "dev": true
             },
             "lodash.union": {
               "version": "4.6.0",
-              "from": "lodash.union@~4.6.0",
               "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
               "dev": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "from": "lodash.uniq@~4.5.0",
               "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
               "dev": true
             },
             "lodash.without": {
               "version": "4.4.0",
-              "from": "lodash.without@~4.4.0",
               "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
               "dev": true
             },
             "lru-cache": {
               "version": "4.0.2",
-              "from": "lru-cache@~4.0.2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+              "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
               "dev": true,
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "from": "pseudomap@^1.0.1",
                   "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "from": "yallist@^2.0.0",
                   "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                   "dev": true
                 }
               }
             },
             "mississippi": {
               "version": "1.3.0",
-              "from": "mississippi@~1.3.0",
               "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+              "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
               "dev": true,
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "from": "concat-stream@^1.5.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "dev": true,
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@^0.0.6",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
                 },
                 "duplexify": {
                   "version": "3.5.0",
-                  "from": "duplexify@^3.4.2",
                   "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+                  "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
                   "dev": true,
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "from": "end-of-stream@1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                       "dev": true,
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@~1.3.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                           "dev": true
                         }
                       }
                     },
                     "stream-shift": {
                       "version": "1.0.0",
-                      "from": "stream-shift@^1.0.0",
                       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "from": "end-of-stream@^1.1.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                   "dev": true
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
-                  "from": "flush-write-stream@^1.0.0",
                   "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+                  "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
                   "dev": true
                 },
                 "from2": {
                   "version": "2.3.0",
-                  "from": "from2@^2.1.0",
                   "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+                  "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                   "dev": true
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
-                  "from": "parallel-transform@^1.1.0",
                   "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+                  "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                   "dev": true,
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "from": "cyclist@~0.2.2",
                       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                       "dev": true
                     }
                   }
                 },
                 "pump": {
                   "version": "1.0.2",
-                  "from": "pump@^1.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                   "dev": true
                 },
                 "pumpify": {
                   "version": "1.3.5",
-                  "from": "pumpify@^1.3.3",
                   "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+                  "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
                   "dev": true
                 },
                 "stream-each": {
                   "version": "1.2.0",
-                  "from": "stream-each@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+                  "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
                   "dev": true,
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "from": "stream-shift@^1.0.0",
                       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
                 },
                 "through2": {
                   "version": "2.0.3",
-                  "from": "through2@^2.0.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                  "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                   "dev": true,
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@~4.0.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
@@ -6119,66 +5358,66 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@~0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
               }
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "from": "move-concurrently@~1.0.1",
               "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+              "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
               "dev": true,
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
-                  "from": "copy-concurrently@^1.0.0",
                   "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
+                  "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
                   "dev": true
                 },
                 "run-queue": {
                   "version": "1.0.3",
-                  "from": "run-queue@^1.0.3",
                   "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+                  "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
                   "dev": true
                 }
               }
             },
             "node-gyp": {
               "version": "3.6.2",
-              "from": "node-gyp@3.6.2",
               "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+              "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
               "dev": true,
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@^3.0.2",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                       "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@^0.4.1",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -6187,34 +5426,34 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "from": "nopt@2 || 3",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                   "dev": true
                 }
               }
             },
             "nopt": {
               "version": "4.0.1",
-              "from": "nopt@~4.0.1",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.3.8",
-              "from": "normalize-package-data@~2.3.8",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+              "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
               "dev": true,
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "from": "is-builtin-module@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "dev": true,
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "from": "builtin-modules@^1.0.0",
                       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                       "dev": true
                     }
                   }
@@ -6223,38 +5462,38 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "from": "npm-cache-filename@~1.0.2",
               "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "dev": true
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "from": "npm-install-checks@~3.0.0",
               "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "dev": true
             },
             "npm-package-arg": {
               "version": "5.1.1",
-              "from": "npm-package-arg@latest",
               "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.1.tgz",
+              "integrity": "sha512-67wPa1moaLvn9YAVLLECpGe+v3jL82pBDTE2jMxLOQHd0kWBLnmtCqbxrFagp5pVNFukqmtYRruK3wfoeVTZ2g==",
               "dev": true
             },
             "npm-registry-client": {
               "version": "8.3.0",
-              "from": "npm-registry-client@~8.3.0",
               "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.3.0.tgz",
+              "integrity": "sha512-rBFLIisl55sq77Bf189ptxaFGEkTNcZpvR7UFZI7bmG/wYD2hY/2Ix1Ss26aOLSbyctwHuUPZ3tJRSYnkmMQkg==",
               "dev": true,
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "from": "concat-stream@^1.5.2",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+                  "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                   "dev": true,
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@^0.0.6",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
@@ -6263,76 +5502,76 @@
             },
             "npm-user-validate": {
               "version": "1.0.0",
-              "from": "npm-user-validate@latest",
               "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+              "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
               "dev": true
             },
             "npmlog": {
               "version": "4.1.0",
-              "from": "npmlog@latest",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+              "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
               "dev": true,
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
-                  "from": "are-we-there-yet@~1.1.2",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                  "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                   "dev": true,
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "from": "delegates@^1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "dev": true
                     }
                   }
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "from": "console-control-strings@~1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "from": "gauge@~2.7.1",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                  "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                   "dev": true,
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
-                      "from": "object-assign@^4.1.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "from": "signal-exit@^3.0.0",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "from": "string-width@^1.0.1",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "from": "code-point-at@^1.0.0",
                           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "from": "is-fullwidth-code-point@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "from": "number-is-nan@^1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
@@ -6341,80 +5580,80 @@
                     },
                     "wide-align": {
                       "version": "1.1.0",
-                      "from": "wide-align@^1.1.0",
                       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
                       "dev": true
                     }
                   }
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "from": "set-blocking@~2.0.0",
                   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true
                 }
               }
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@~1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true
             },
             "opener": {
               "version": "1.4.3",
-              "from": "opener@~1.4.3",
               "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+              "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
               "dev": true
             },
             "osenv": {
               "version": "0.1.4",
-              "from": "osenv@~0.1.4",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "from": "os-homedir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "from": "os-tmpdir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                   "dev": true
                 }
               }
             },
             "pacote": {
               "version": "2.7.30",
-              "from": "pacote@2.7.30",
               "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.30.tgz",
+              "integrity": "sha512-xFxozbxytemyfNPZmkL2seTD15mozK8ghov9npjBO4YTs3SnA8I55aiN94eZJ+XhLKzbN8yXqQMr9ti4c3WIDw==",
               "dev": true,
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.11",
-                  "from": "make-fetch-happen@^2.4.11",
                   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.11.tgz",
+                  "integrity": "sha512-3dbl9CVS9Y0hqVzcD5HBYnaNUGw3XWpmeTqGT6ACRrmKS7WKwSDfv5+Gd1K0X/Mt52hsvZwtOH8hrNIulYkhag==",
                   "dev": true,
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.1.0",
-                      "from": "agentkeepalive@^3.1.0",
                       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.1.0.tgz",
+                      "integrity": "sha1-A5Ok8eaPhdNViHwucWgbKPO33zU=",
                       "dev": true,
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
-                          "from": "humanize-ms@^1.2.0",
                           "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                           "dev": true,
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "from": "ms@^2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
@@ -6423,124 +5662,123 @@
                     },
                     "http-cache-semantics": {
                       "version": "3.7.3",
-                      "from": "http-cache-semantics@^3.7.3",
                       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.7.3.tgz",
+                      "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
                       "dev": true
                     },
                     "http-proxy-agent": {
                       "version": "1.0.0",
-                      "from": "http-proxy-agent@^1.0.0",
                       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
+                      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
                       "dev": true,
                       "dependencies": {
                         "agent-base": {
                           "version": "2.1.1",
-                          "from": "agent-base@2",
                           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+                          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
                           "dev": true,
                           "dependencies": {
                             "semver": {
                               "version": "5.0.3",
-                              "from": "semver@~5.0.1",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
                               "dev": true
                             }
                           }
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "from": "debug@2",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "dev": true,
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "from": "ms@2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
                         },
                         "extend": {
                           "version": "3.0.1",
-                          "from": "extend@3",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                           "dev": true
                         }
                       }
                     },
                     "https-proxy-agent": {
                       "version": "1.0.0",
-                      "from": "https-proxy-agent@^1.0.0",
                       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+                      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
                       "dev": true,
                       "dependencies": {
                         "agent-base": {
                           "version": "2.1.1",
-                          "from": "agent-base@2",
                           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+                          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
                           "dev": true,
                           "dependencies": {
                             "semver": {
                               "version": "5.0.3",
-                              "from": "semver@~5.0.1",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
                               "dev": true
                             }
                           }
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "from": "debug@2",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                           "dev": true,
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "from": "ms@2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                               "dev": true
                             }
                           }
                         },
                         "extend": {
                           "version": "3.0.1",
-                          "from": "extend@3",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                           "dev": true
                         }
                       }
                     },
                     "node-fetch-npm": {
                       "version": "2.0.1",
-                      "from": "node-fetch-npm@^2.0.0",
                       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
+                      "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
                       "dev": true,
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
-                          "from": "encoding@^0.1.11",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                           "dev": true,
                           "dependencies": {
                             "iconv-lite": {
-                              "version": "0.4.17",
-                              "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
-                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
+                              "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
+                              "integrity": "sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0=",
                               "dev": true
                             }
                           }
                         },
                         "json-parse-helpfulerror": {
                           "version": "1.0.3",
-                          "from": "json-parse-helpfulerror@^1.0.3",
                           "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                          "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                           "dev": true,
                           "dependencies": {
                             "jju": {
                               "version": "1.3.0",
-                              "from": "jju@^1.1.0",
                               "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                              "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                               "dev": true
                             }
                           }
@@ -6549,46 +5787,46 @@
                     },
                     "socks-proxy-agent": {
                       "version": "2.1.0",
-                      "from": "socks-proxy-agent@^2.0.0",
                       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.0.tgz",
+                      "integrity": "sha1-3fsBtdvqX8h5SQyjiiX+h9PRWRI=",
                       "dev": true,
                       "dependencies": {
                         "agent-base": {
                           "version": "2.1.1",
-                          "from": "agent-base@2",
                           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+                          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
                           "dev": true,
                           "dependencies": {
                             "semver": {
                               "version": "5.0.3",
-                              "from": "semver@~5.0.1",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
                               "dev": true
                             }
                           }
                         },
                         "extend": {
                           "version": "3.0.1",
-                          "from": "extend@3",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                           "dev": true
                         },
                         "socks": {
                           "version": "1.1.10",
-                          "from": "socks@~1.1.5",
                           "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                          "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                           "dev": true,
                           "dependencies": {
                             "ip": {
                               "version": "1.1.5",
-                              "from": "ip@^1.1.4",
                               "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                               "dev": true
                             },
                             "smart-buffer": {
                               "version": "1.1.15",
-                              "from": "smart-buffer@^1.0.13",
                               "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                              "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                               "dev": true
                             }
                           }
@@ -6599,26 +5837,26 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@^3.0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                       "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@^0.4.1",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -6627,54 +5865,54 @@
                 },
                 "npm-pick-manifest": {
                   "version": "1.0.3",
-                  "from": "npm-pick-manifest@^1.0.3",
                   "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.3.tgz",
+                  "integrity": "sha512-L2UKmHEWw2RMlqZEx/0iHq1TWkSV1TiODFsmZ11Jxl2lBqL6+f2Pu4gBPsYkYIuSdgd7bALz28rgaoH1EiGHcg==",
                   "dev": true
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "from": "promise-retry@^1.1.1",
                   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "dev": true,
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "from": "err-code@^1.0.0",
                       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                       "dev": true
                     }
                   }
                 },
                 "protoduck": {
                   "version": "4.0.0",
-                  "from": "protoduck@^4.0.0",
                   "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+                  "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
                   "dev": true,
                   "dependencies": {
                     "genfun": {
                       "version": "4.0.1",
-                      "from": "genfun@^4.0.1",
                       "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                      "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                       "dev": true
                     }
                   }
                 },
                 "tar-fs": {
                   "version": "1.15.2",
-                  "from": "tar-fs@^1.15.1",
                   "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.2.tgz",
+                  "integrity": "sha1-dh9bMpMsezlGGmDVN/rqDYCEgww=",
                   "dev": true,
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
-                      "from": "pump@^1.0.0",
                       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+                      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                       "dev": true,
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
-                          "from": "end-of-stream@^1.1.0",
                           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                           "dev": true
                         }
                       }
@@ -6683,26 +5921,26 @@
                 },
                 "tar-stream": {
                   "version": "1.5.4",
-                  "from": "tar-stream@^1.5.2",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+                  "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
                   "dev": true,
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
-                      "from": "bl@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+                      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
                       "dev": true
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "from": "end-of-stream@^1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                       "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@^4.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                       "dev": true
                     }
                   }
@@ -6711,66 +5949,66 @@
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "from": "path-is-inside@~1.0.2",
               "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
               "dev": true
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "from": "promise-inflight@~1.0.1",
               "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+              "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
               "dev": true
             },
             "read": {
               "version": "1.0.7",
-              "from": "read@~1.0.7",
               "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.7",
-                  "from": "mute-stream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                  "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
                   "dev": true
                 }
               }
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "from": "read-cmd-shim@~1.0.1",
               "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
               "dev": true
             },
             "read-installed": {
               "version": "4.0.3",
-              "from": "read-installed@~4.0.3",
               "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
-                  "from": "util-extend@^1.0.1",
                   "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
                   "dev": true
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.5",
-              "from": "read-package-json@~2.0.5",
               "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.5.tgz",
+              "integrity": "sha1-+Tpk5kFSnfaKCMZN5GOJ6KP4iEU=",
               "dev": true,
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "from": "json-parse-helpfulerror@^1.0.2",
                   "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "dev": true,
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "from": "jju@^1.1.0",
                       "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                       "dev": true
                     }
                   }
@@ -6779,146 +6017,146 @@
             },
             "read-package-tree": {
               "version": "5.1.6",
-              "from": "read-package-tree@5.1.6",
               "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+              "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
               "dev": true
             },
             "readable-stream": {
               "version": "2.2.10",
-              "from": "readable-stream@2.2.10",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+              "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
               "dev": true,
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@~1.0.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@~1.0.6",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "1.0.1",
-                  "from": "string_decoder@~1.0.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+                  "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true
                 }
               }
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "from": "readdir-scoped-modules@*",
               "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "dev": true
             },
             "request": {
               "version": "2.81.0",
-              "from": "request@~2.81.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "from": "aws4@^1.2.1",
                   "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                  "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
                   "dev": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "from": "caseless@~0.12.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                  "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@~1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "dev": true
                     }
                   }
                 },
                 "extend": {
                   "version": "3.0.1",
-                  "from": "extend@~3.0.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                  "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@~0.6.1",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "from": "form-data@~2.1.1",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                  "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                   "dev": true,
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "from": "asynckit@^0.4.0",
                       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "from": "har-validator@~4.2.1",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                  "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                   "dev": true,
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
-                      "from": "ajv@^4.9.1",
                       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                       "dev": true,
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "from": "co@^4.6.0",
                           "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                           "dev": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "from": "json-stable-stringify@^1.0.1",
                           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                           "dev": true,
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "from": "jsonify@~0.0.0",
                               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                               "dev": true
                             }
                           }
@@ -6927,150 +6165,150 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "from": "har-schema@^1.0.5",
                       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                       "dev": true
                     }
                   }
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "from": "hawk@~3.1.3",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true
                     }
                   }
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "from": "http-signature@~1.1.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "from": "assert-plus@^0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "from": "jsprim@^1.2.2",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                       "dev": true,
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "from": "extsprintf@1.0.2",
                           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "from": "json-schema@0.2.3",
                           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "from": "verror@1.3.6",
                           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "dev": true
                         }
                       }
                     },
                     "sshpk": {
                       "version": "1.13.0",
-                      "from": "sshpk@^1.7.0",
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
                       "dev": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "from": "asn1@~0.2.3",
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@^1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "from": "bcrypt-pbkdf@^1.0.0",
                           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                           "dev": true,
                           "optional": true
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "from": "dashdash@^1.12.0",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                           "dev": true
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "from": "ecc-jsbn@~0.1.1",
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
                           "optional": true
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "from": "getpass@^0.1.1",
                           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                           "dev": true
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "from": "jodid25519@^1.0.0",
                           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                           "dev": true,
                           "optional": true
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "from": "jsbn@~0.1.0",
                           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "from": "tweetnacl@~0.14.0",
                           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                           "dev": true,
                           "optional": true
                         }
@@ -7080,164 +6318,164 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "from": "is-typedarray@~1.0.0",
                   "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@~0.1.2",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.1",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "from": "mime-types@~2.1.7",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                  "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "from": "mime-db@~1.27.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                       "dev": true
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "from": "oauth-sign@~0.8.1",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "dev": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "from": "performance-now@^0.2.0",
                   "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                  "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
                   "dev": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "from": "qs@~6.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                  "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
                   "dev": true
                 },
                 "safe-buffer": {
                   "version": "5.0.1",
-                  "from": "safe-buffer@^5.0.1",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                  "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "from": "tough-cookie@~2.3.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                   "dev": true,
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "from": "punycode@^1.4.1",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                       "dev": true
                     }
                   }
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "from": "tunnel-agent@^0.6.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                  "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.1",
-              "from": "retry@~0.10.1",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             },
             "rimraf": {
               "version": "2.6.1",
-              "from": "rimraf@~2.6.1",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true
             },
             "safe-buffer": {
               "version": "5.1.0",
-              "from": "safe-buffer@latest",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+              "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "from": "semver@~5.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "from": "sha@~2.0.1",
               "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "dev": true
             },
             "slide": {
               "version": "1.1.6",
-              "from": "slide@~1.1.6",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.1",
-              "from": "sorted-object@~2.0.1",
               "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
               "dev": true
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "from": "sorted-union-stream@~2.1.3",
               "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+              "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
               "dev": true,
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "from": "from2@^1.3.0",
                   "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+                  "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                   "dev": true,
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
-                      "from": "readable-stream@~1.1.10",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                       "dev": true,
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         }
                       }
@@ -7246,14 +6484,14 @@
                 },
                 "stream-iterate": {
                   "version": "1.2.0",
-                  "from": "stream-iterate@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+                  "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
                   "dev": true,
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "from": "stream-shift@^1.0.0",
                       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                       "dev": true
                     }
                   }
@@ -7262,108 +6500,108 @@
             },
             "ssri": {
               "version": "4.1.5",
-              "from": "ssri@4.1.5",
               "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.5.tgz",
+              "integrity": "sha512-TaLitc/pZH1UF8LCgZWdbssPiOUcPjBmIJsYJa+YltP77mY2qQ0Y2b+VS4C9RbZRH1GPMt4zckqqBd7GE/61ew==",
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@~3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true
             },
             "tar": {
               "version": "2.2.1",
-              "from": "tar@~2.2.1",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true
                 }
               }
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "text-table@~0.2.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "from": "uid-number@0.0.6",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "from": "umask@~1.1.0",
               "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "dev": true
             },
             "unique-filename": {
               "version": "1.1.0",
-              "from": "unique-filename@~1.1.0",
               "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
               "dev": true,
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
-                  "from": "unique-slug@^2.0.0",
                   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "dev": true
                 }
               }
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@~1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
               "dev": true
             },
             "update-notifier": {
               "version": "2.1.0",
-              "from": "update-notifier@~2.1.0",
               "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
+              "integrity": "sha1-7AweU1NrdmR6JLd8uDlm2TFRI9k=",
               "dev": true,
               "dependencies": {
                 "boxen": {
                   "version": "1.0.0",
-                  "from": "boxen@^1.0.0",
                   "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz",
+                  "integrity": "sha1-smlLrx9gX3CP8Bd8Ehk7IvKaqqs=",
                   "dev": true,
                   "dependencies": {
                     "ansi-align": {
                       "version": "1.1.0",
-                      "from": "ansi-align@^1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+                      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
                       "dev": true,
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "from": "string-width@^1.0.1",
                           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "dev": true,
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "from": "code-point-at@^1.0.0",
                               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "from": "is-fullwidth-code-point@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "dev": true,
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                                   "dev": true
                                 }
                               }
@@ -7374,76 +6612,76 @@
                     },
                     "camelcase": {
                       "version": "4.1.0",
-                      "from": "camelcase@^4.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                       "dev": true
                     },
                     "cli-boxes": {
                       "version": "1.0.0",
-                      "from": "cli-boxes@^1.0.0",
                       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "2.0.0",
-                      "from": "string-width@^2.0.0",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+                      "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
                       "dev": true,
                       "dependencies": {
                         "is-fullwidth-code-point": {
                           "version": "2.0.0",
-                          "from": "is-fullwidth-code-point@^2.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                           "dev": true
                         }
                       }
                     },
                     "term-size": {
                       "version": "0.1.1",
-                      "from": "term-size@^0.1.0",
                       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+                      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
                       "dev": true,
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
-                          "from": "execa@^0.4.0",
                           "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+                          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
                           "dev": true,
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
-                              "from": "cross-spawn-async@^2.1.1",
                               "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+                              "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "from": "is-stream@^1.1.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "dev": true
                             },
                             "npm-run-path": {
                               "version": "1.0.0",
-                              "from": "npm-run-path@^1.0.0",
                               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+                              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
                               "dev": true
                             },
                             "object-assign": {
                               "version": "4.1.1",
-                              "from": "object-assign@^4.0.1",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                               "dev": true
                             },
                             "path-key": {
                               "version": "1.0.0",
-                              "from": "path-key@^1.0.0",
                               "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+                              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
                               "dev": true
                             },
                             "strip-eof": {
                               "version": "1.0.0",
-                              "from": "strip-eof@^1.0.0",
                               "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                               "dev": true
                             }
                           }
@@ -7452,32 +6690,32 @@
                     },
                     "widest-line": {
                       "version": "1.0.0",
-                      "from": "widest-line@^1.0.0",
                       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                       "dev": true,
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "from": "string-width@^1.0.1",
                           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "dev": true,
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "from": "code-point-at@^1.0.0",
                               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "from": "is-fullwidth-code-point@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "dev": true,
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                                   "dev": true
                                 }
                               }
@@ -7490,180 +6728,180 @@
                 },
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@^1.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                   "dev": true,
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "from": "ansi-styles@^2.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@^1.0.2",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                       "dev": true
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@^2.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                       "dev": true
                     }
                   }
                 },
                 "configstore": {
                   "version": "3.0.0",
-                  "from": "configstore@^3.0.0",
                   "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz",
+                  "integrity": "sha1-4bhmnBgDzMULVF6S+ObnmqgOAZY=",
                   "dev": true,
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
-                      "from": "dot-prop@^4.1.0",
                       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+                      "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
                       "dev": true,
                       "dependencies": {
                         "is-obj": {
                           "version": "1.0.1",
-                          "from": "is-obj@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                           "dev": true
                         }
                       }
                     },
                     "unique-string": {
                       "version": "1.0.0",
-                      "from": "unique-string@^1.0.0",
                       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                       "dev": true,
                       "dependencies": {
                         "crypto-random-string": {
                           "version": "1.0.0",
-                          "from": "crypto-random-string@^1.0.0",
                           "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                           "dev": true
                         }
                       }
                     },
                     "write-file-atomic": {
                       "version": "1.3.4",
-                      "from": "write-file-atomic@^1.1.2",
                       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+                      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
                       "dev": true
                     }
                   }
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "is-npm@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+                  "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
                   "dev": true
                 },
                 "latest-version": {
                   "version": "3.1.0",
-                  "from": "latest-version@^3.0.0",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+                  "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
                   "dev": true,
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
-                      "from": "package-json@^4.0.0",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                       "dev": true,
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
-                          "from": "got@^6.7.1",
                           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                           "dev": true,
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
-                              "from": "create-error-class@^3.0.0",
                               "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                              "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                               "dev": true,
                               "dependencies": {
                                 "capture-stack-trace": {
                                   "version": "1.0.0",
-                                  "from": "capture-stack-trace@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                                  "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                                   "dev": true
                                 }
                               }
                             },
                             "duplexer3": {
                               "version": "0.1.4",
-                              "from": "duplexer3@^0.1.4",
                               "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                              "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                               "dev": true
                             },
                             "get-stream": {
                               "version": "3.0.0",
-                              "from": "get-stream@^3.0.0",
                               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                               "dev": true
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "from": "is-redirect@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                              "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                               "dev": true
                             },
                             "is-retry-allowed": {
                               "version": "1.1.0",
-                              "from": "is-retry-allowed@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                              "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "from": "is-stream@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                               "dev": true
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "lowercase-keys@^1.0.0",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                               "dev": true
                             },
                             "safe-buffer": {
                               "version": "5.0.1",
-                              "from": "safe-buffer@^5.0.1",
                               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                               "dev": true
                             },
                             "timed-out": {
                               "version": "4.0.1",
-                              "from": "timed-out@^4.0.0",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                              "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                               "dev": true
                             },
                             "unzip-response": {
                               "version": "2.0.1",
-                              "from": "unzip-response@^2.0.1",
                               "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                              "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                               "dev": true
                             },
                             "url-parse-lax": {
                               "version": "1.0.0",
-                              "from": "url-parse-lax@^1.0.0",
                               "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                              "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                               "dev": true,
                               "dependencies": {
                                 "prepend-http": {
                                   "version": "1.0.4",
-                                  "from": "prepend-http@^1.0.1",
                                   "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                                  "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                                   "dev": true
                                 }
                               }
@@ -7672,72 +6910,72 @@
                         },
                         "registry-auth-token": {
                           "version": "3.3.0",
-                          "from": "registry-auth-token@^3.0.1",
                           "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
+                          "integrity": "sha1-V65nNH5z2WNF7RvAEpTHI3wCqmM=",
                           "dev": true,
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "from": "rc@^1.1.6",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "dev": true,
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.1",
-                                  "from": "deep-extend@~0.4.0",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+                                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "from": "minimist@^1.2.0",
                                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "from": "strip-json-comments@~2.0.1",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "dev": true
                                 }
                               }
                             },
                             "safe-buffer": {
                               "version": "5.0.1",
-                              "from": "safe-buffer@^5.0.1",
                               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                               "dev": true
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.1.0",
-                          "from": "registry-url@^3.0.3",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                           "dev": true,
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "from": "rc@^1.0.1",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                               "dev": true,
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.1",
-                                  "from": "deep-extend@~0.4.0",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+                                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "from": "minimist@^1.2.0",
                                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "from": "strip-json-comments@~2.0.1",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                                  "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                                   "dev": true
                                 }
                               }
@@ -7750,2723 +6988,2195 @@
                 },
                 "lazy-req": {
                   "version": "2.0.0",
-                  "from": "lazy-req@^2.0.0",
                   "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
+                  "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
                   "dev": true
                 },
                 "semver-diff": {
                   "version": "2.1.0",
-                  "from": "semver-diff@^2.0.0",
                   "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+                  "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
                   "dev": true
                 },
                 "xdg-basedir": {
                   "version": "3.0.0",
-                  "from": "xdg-basedir@^3.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+                  "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
                   "dev": true
                 }
               }
             },
             "uuid": {
               "version": "3.0.1",
-              "from": "uuid@~3.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "from": "validate-npm-package-license@*",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "from": "spdx-correct@~1.0.0",
                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "dev": true,
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.2",
-                      "from": "spdx-license-ids@^1.0.2",
                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                       "dev": true
                     }
                   }
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.4",
-                  "from": "spdx-expression-parse@~1.0.0",
                   "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
                   "dev": true
                 }
               }
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "from": "validate-npm-package-name@~3.0.0",
               "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+              "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
               "dev": true,
               "dependencies": {
                 "builtins": {
                   "version": "1.0.3",
-                  "from": "builtins@^1.0.3",
                   "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+                  "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.14",
-              "from": "which@~1.2.14",
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+              "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "dev": true,
               "dependencies": {
                 "isexe": {
                   "version": "2.0.0",
-                  "from": "isexe@^2.0.0",
                   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                  "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                   "dev": true
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "from": "wrappy@~1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "from": "write-file-atomic@latest",
               "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+              "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
               "dev": true
             }
           }
         },
         "npm-package-arg": {
           "version": "5.1.2",
-          "from": "npm-package-arg@5.1.2",
           "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+          "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "from": "npm-run-path@2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "from": "number-is-nan@1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "from": "once@1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "from": "os-homedir@1.0.2",
           "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "from": "os-locale@2.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "from": "os-tmpdir@1.0.2",
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.4",
-          "from": "osenv@0.1.4",
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "from": "p-finally@1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "from": "p-limit@1.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "from": "p-locate@2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "from": "package-json@^4.0.0",
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "from": "parse-json@2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "from": "path-is-absolute@1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "from": "path-key@2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "from": "path-type@2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true
         },
         "pify": {
           "version": "2.3.0",
-          "from": "pify@2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "from": "pinkie@2.0.4",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "from": "pinkie-promise@2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "from": "prepend-http@^1.0.1",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "from": "pseudomap@1.0.2",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "rc": {
           "version": "1.2.1",
-          "from": "rc@^1.1.6",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@^1.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
             }
           }
         },
         "read-pkg": {
           "version": "2.0.0",
-          "from": "read-pkg@2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "from": "read-pkg-up@2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true
         },
         "registry-auth-token": {
           "version": "3.3.1",
-          "from": "registry-auth-token@^3.0.1",
           "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
           "dev": true
         },
         "registry-url": {
           "version": "3.1.0",
-          "from": "registry-url@^3.0.3",
           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "from": "require-directory@2.1.1",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "from": "require-main-filename@1.0.1",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.1",
-          "from": "rimraf@^2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true
         },
         "safe-buffer": {
           "version": "5.1.0",
-          "from": "safe-buffer",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+          "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "from": "semver-diff@^2.0.0",
           "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@2.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "from": "signal-exit@3.0.2",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "from": "slide@^1.1.5",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "from": "spdx-correct@1.0.2",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "from": "spdx-expression-parse@1.0.4",
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "from": "spdx-license-ids@1.2.2",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true,
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "from": "is-fullwidth-code-point@2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "from": "strip-ansi@3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "from": "strip-eof@1.0.0",
           "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "from": "strip-json-comments@2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "term-size": {
           "version": "0.1.1",
-          "from": "term-size@^0.1.0",
           "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+          "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
           "dev": true,
           "dependencies": {
             "execa": {
               "version": "0.4.0",
-              "from": "execa@^0.4.0",
               "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+              "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
               "dev": true
             },
             "npm-run-path": {
               "version": "1.0.0",
-              "from": "npm-run-path@^1.0.0",
               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+              "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
               "dev": true
             },
             "path-key": {
               "version": "1.0.0",
-              "from": "path-key@^1.0.0",
               "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+              "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
               "dev": true
             }
           }
         },
         "timed-out": {
           "version": "4.0.1",
-          "from": "timed-out@^4.0.0",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "from": "unique-string@^1.0.0",
           "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "from": "unzip-response@^2.0.1",
           "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.2.0",
-          "from": "update-notifier@2.2.0",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+          "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
           "dev": true
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "from": "url-parse-lax@^1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "from": "validate-npm-package-license@3.0.1",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "from": "validate-npm-package-name@3.0.0",
           "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true
         },
         "which": {
           "version": "1.2.14",
-          "from": "which@1.2.14",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true
         },
         "which-module": {
           "version": "2.0.0",
-          "from": "which-module@2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "widest-line": {
           "version": "1.0.0",
-          "from": "widest-line@^1.0.0",
           "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+          "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
           "dev": true,
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@^1.0.1",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true
             }
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "from": "wrap-ansi@2.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "from": "wrappy@1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "from": "write-file-atomic@^2.0.0",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+          "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
           "dev": true
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "from": "xdg-basedir@^3.0.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "y18n": {
           "version": "3.2.1",
-          "from": "y18n@latest",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "from": "yallist@2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "8.0.1",
-          "from": "yargs@8.0.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
+          "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
           "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "from": "yargs-parser@7.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true
         }
       }
     },
     "nugget": {
       "version": "2.0.1",
-      "from": "nugget@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
       "dev": true
     },
     "number-is-nan": {
-      "version": "1.0.0",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
-      "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
     },
     "object-keys": {
-      "version": "0.4.0",
-      "from": "object-keys@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+      "version": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "object.omit": {
-      "version": "2.0.1",
-      "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true
     },
     "omit-empty": {
-      "version": "0.4.1",
-      "from": "omit-empty@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+      "version": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
+      "integrity": "sha1-KUo3gvLLIMdJfEEitiN8ncwMY6s=",
       "dev": true
     },
     "once": {
-      "version": "1.3.3",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA="
     },
     "onetime": {
-      "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "optimist": {
-      "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
-      "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "version": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "version": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "wordwrap": {
-          "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "from": "optionator@>=0.8.2 <0.9.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "from": "os-browserify@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
-      "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+      "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
     },
     "os-tmpdir": {
-      "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "from": "osenv@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
-      "from": "p-finally@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
       "version": "1.1.0",
-      "from": "p-limit@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
       "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
-      "from": "p-locate@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "dev": true
-    },
-    "pac-proxy-agent": {
-      "version": "0.2.0",
-      "from": "pac-proxy-agent@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-0.2.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "extend": {
-          "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-          "dev": true
-        }
-      }
-    },
-    "pac-resolver": {
-      "version": "1.2.6",
-      "from": "pac-resolver@>=1.2.1 <1.3.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-1.2.6.tgz",
-      "dev": true,
-      "dependencies": {
-        "co": {
-          "version": "3.0.6",
-          "from": "co@>=3.0.6 <3.1.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
-          "dev": true
-        }
-      }
-    },
-    "package": {
-      "version": "1.0.1",
-      "from": "package@>=1.0.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true
     },
     "package-json": {
       "version": "4.0.1",
-      "from": "package-json@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true
     },
     "pako": {
-      "version": "0.2.9",
-      "from": "pako@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parents": {
-      "version": "1.0.1",
-      "from": "parents@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true
     },
     "parse-asn1": {
-      "version": "5.1.0",
-      "from": "parse-asn1@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true
     },
     "parse-author": {
-      "version": "1.0.0",
-      "from": "parse-author@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
+      "integrity": "sha1-XsFZAGKXe9nLOWLpFzuHWGQ39d8=",
       "dev": true
     },
     "parse-code-context": {
-      "version": "0.1.3",
-      "from": "parse-code-context@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-0.1.3.tgz",
+      "integrity": "sha1-sMr+ZcNLkWQ0EAAz6zNOnSgstGE=",
       "dev": true
     },
     "parse-color": {
       "version": "1.0.0",
-      "from": "parse-color@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
       "dev": true
     },
     "parse-git-config": {
-      "version": "1.1.1",
-      "from": "parse-git-config@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "dev": true
     },
     "parse-github-url": {
-      "version": "0.3.2",
-      "from": "parse-github-url@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
+      "integrity": "sha1-du8B6/4LHpwPSTZylSzGpM2csmA=",
       "dev": true
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true
     },
     "parse-json": {
-      "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
     },
     "parse-passwd": {
-      "version": "1.0.0",
-      "from": "parse-passwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "from": "path-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
-      "version": "1.0.2",
-      "from": "path-is-inside@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "1.0.0",
-      "from": "path-key@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "from": "path-parse@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-platform": {
-      "version": "0.11.15",
-      "from": "path-platform@>=0.11.15 <0.12.0",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "version": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.4",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
+          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
         }
       }
     },
     "pbkdf2": {
-      "version": "3.0.12",
-      "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
+      "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
+      "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
       "dev": true
     },
     "pend": {
-      "version": "1.2.0",
-      "from": "pend@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+      "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
-      "version": "0.2.0",
-      "from": "performance-now@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "pify": {
-      "version": "2.3.0",
-      "from": "pify@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
-      "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
-      "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
     },
     "pkg-conf": {
-      "version": "1.1.3",
-      "from": "pkg-conf@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz"
+      "version": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls="
     },
     "plist": {
       "version": "2.1.0",
-      "from": "plist@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+      "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
       "dev": true,
       "dependencies": {
         "base64-js": {
           "version": "1.2.0",
-          "from": "base64-js@1.2.0",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
           "dev": true
         },
         "xmlbuilder": {
           "version": "8.2.2",
-          "from": "xmlbuilder@8.2.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
           "dev": true
         }
       }
     },
     "pluralize": {
-      "version": "1.2.1",
-      "from": "pluralize@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "from": "prepend-http@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
-      "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-bytes": {
-      "version": "1.0.4",
-      "from": "pretty-bytes@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-      "dev": true
-    },
-    "private": {
-      "version": "0.1.7",
-      "from": "private@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
       "dev": true
     },
     "process": {
-      "version": "0.11.10",
-      "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "version": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
-      "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "progress-bar-formatter": {
-      "version": "2.0.1",
-      "from": "progress-bar-formatter@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/progress-bar-formatter/-/progress-bar-formatter-2.0.1.tgz"
+      "version": "https://registry.npmjs.org/progress-bar-formatter/-/progress-bar-formatter-2.0.1.tgz",
+      "integrity": "sha1-DZfrsWRn4sIwg3NXIXa3w1UeVW4="
     },
     "progress-stream": {
-      "version": "1.2.0",
-      "from": "progress-stream@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz"
+      "version": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c="
     },
     "project-name": {
-      "version": "0.2.6",
-      "from": "project-name@>=0.2.6 <0.3.0",
-      "resolved": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+      "version": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
+      "integrity": "sha1-Pk94H+HulLB4apuuU1BjdsN5r2k=",
       "dev": true
     },
     "promise": {
-      "version": "7.1.1",
-      "from": "promise@>=7.1.1 <7.2.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+      "version": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
     },
     "prop-types": {
-      "version": "15.5.9",
-      "from": "prop-types@>=15.5.4 <16.0.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.9.tgz",
+      "version": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.9.tgz",
+      "integrity": "sha1-1Hju8OdhOWlC9wx453L3bovnR8k=",
       "dependencies": {
         "js-tokens": {
-          "version": "3.0.1",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc="
         },
         "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.3.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+          "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
         }
       }
     },
     "propagate": {
-      "version": "0.4.0",
-      "from": "propagate@0.4.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "version": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
       "dev": true
     },
-    "proxy-agent": {
-      "version": "1.1.1",
-      "from": "proxy-agent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-1.1.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.5.2",
-          "from": "lru-cache@>=2.5.0 <2.6.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz",
-          "dev": true
-        }
-      }
-    },
     "pseudomap": {
-      "version": "1.0.2",
-      "from": "pseudomap@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "public-encrypt": {
-      "version": "4.0.0",
-      "from": "public-encrypt@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true
     },
     "punycode": {
-      "version": "1.4.1",
-      "from": "punycode@>=1.3.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
-      "version": "1.4.1",
-      "from": "q@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
       "dev": true
     },
     "qs": {
-      "version": "6.4.0",
-      "from": "qs@>=6.4.0 <6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+      "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
     },
     "querystring": {
-      "version": "0.2.0",
-      "from": "querystring@0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "from": "querystring-es3@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.6",
-      "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
       "dev": true
     },
     "randombytes": {
-      "version": "2.0.3",
-      "from": "randombytes@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+      "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+      "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew=",
       "dev": true
     },
     "raven": {
-      "version": "1.2.1",
-      "from": "raven@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
+      "version": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
+      "integrity": "sha1-lJwTTbAooZC3u/j3kKrlQbfAIL0=",
       "dependencies": {
         "uuid": {
-          "version": "3.0.0",
-          "from": "uuid@3.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
+          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
         }
       }
     },
     "raven-js": {
-      "version": "3.14.1",
-      "from": "raven-js@>=3.12.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.14.1.tgz"
+      "version": "https://registry.npmjs.org/raven-js/-/raven-js-3.14.1.tgz",
+      "integrity": "sha1-nDxfVwobkYtcMMX61mmC4X/jjjk="
+    },
+    "raw-body": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "dev": true
     },
     "rc": {
-      "version": "1.1.7",
-      "from": "rc@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+      "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+      "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
       "dev": true
     },
     "react": {
-      "version": "15.5.4",
-      "from": "react@15.5.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.5.4.tgz"
+      "version": "https://registry.npmjs.org/react/-/react-15.5.4.tgz",
+      "integrity": "sha1-+oPrAVBqsjfNwcjDsc6o3gEr8Ec="
     },
     "react-dom": {
-      "version": "15.5.4",
-      "from": "react-dom@15.5.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz"
+      "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz",
+      "integrity": "sha1-ugwoeG/VLtfk8hNf4CiNRirvk9o="
     },
     "react2angular": {
-      "version": "1.1.3",
-      "from": "react2angular@1.1.3",
-      "resolved": "https://registry.npmjs.org/react2angular/-/react2angular-1.1.3.tgz"
+      "version": "https://registry.npmjs.org/react2angular/-/react2angular-1.1.3.tgz",
+      "integrity": "sha1-nWn1J3mA1BrxpiWwTHikSXxkGJM="
     },
     "read-only-stream": {
-      "version": "2.0.0",
-      "from": "read-only-stream@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
     },
     "readable-stream": {
-      "version": "2.2.2",
-      "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+      "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
     "readline2": {
-      "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
-    },
-    "recast": {
-      "version": "0.10.33",
-      "from": "recast@0.10.33",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-      "dev": true,
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.12",
-          "from": "ast-types@0.8.12",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-          "dev": true
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "dev": true
-        }
-      }
+      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU="
     },
     "rechoir": {
-      "version": "0.6.2",
-      "from": "rechoir@>=0.6.2 <0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true
     },
     "redent": {
-      "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "dev": true
-    },
-    "reduce-component": {
-      "version": "1.0.1",
-      "from": "reduce-component@1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true
     },
     "reduce-object": {
-      "version": "0.1.3",
-      "from": "reduce-object@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
+      "version": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
+      "integrity": "sha1-1UnUCmwpNvpOPpt4yonJMxRZQhg=",
       "dev": true
     },
     "redux": {
-      "version": "3.5.2",
-      "from": "redux@>=3.5.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz"
+      "version": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz",
+      "integrity": "sha1-RTN0XpcLZH7CYGaoOqMOnib6+EM="
     },
     "redux-localstorage": {
-      "version": "0.4.1",
-      "from": "redux-localstorage@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz"
-    },
-    "regenerator": {
-      "version": "0.8.46",
-      "from": "regenerator@>=0.8.13 <0.9.0",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.46.tgz",
-      "dev": true,
-      "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "dev": true
-        }
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.9.6",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-      "dev": true
+      "version": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz",
+      "integrity": "sha1-+vbXGcWBOXKU2BFHP/zt7gZckzw="
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true
     },
     "registry-auth-token": {
       "version": "3.3.1",
-      "from": "registry-auth-token@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true
     },
     "registry-url": {
       "version": "3.1.0",
-      "from": "registry-url@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true
     },
     "relative": {
-      "version": "3.0.2",
-      "from": "relative@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "version": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         }
       }
     },
     "remarkable": {
-      "version": "1.7.1",
-      "from": "remarkable@>=1.6.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "version": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
       "dev": true,
       "dependencies": {
         "argparse": {
-          "version": "0.1.16",
-          "from": "argparse@>=0.1.15 <0.2.0",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true
         },
         "underscore.string": {
-          "version": "2.4.0",
-          "from": "underscore.string@>=2.4.0 <2.5.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
           "dev": true
         }
       }
     },
     "remote-origin-url": {
-      "version": "0.5.2",
-      "from": "remote-origin-url@>=0.5.1 <0.6.0",
-      "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.2.tgz",
+      "version": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.2.tgz",
+      "integrity": "sha1-6N0uGItPLCFfASfnargbFPOOt0g=",
       "dev": true
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "from": "repeat-string@>=1.5.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
-      "version": "2.0.1",
-      "from": "repeating@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "repo-utils": {
-      "version": "0.3.7",
-      "from": "repo-utils@>=0.3.4 <0.4.0",
-      "resolved": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
+      "version": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
+      "integrity": "sha1-SrZq80DLEfp+XPgFgekr6Xwb964=",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
-          "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "request": {
-      "version": "2.81.0",
-      "from": "request@2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dependencies": {
         "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
         },
         "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         }
       }
     },
     "require-directory": {
-      "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-uncached": {
-      "version": "1.0.3",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true
     },
     "resin-cli-form": {
-      "version": "1.4.1",
-      "from": "resin-cli-form@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resin-cli-form/-/resin-cli-form-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/resin-cli-form/-/resin-cli-form-1.4.1.tgz",
+      "integrity": "sha1-BhI0afWVsHM305mdb6p4ykZCawc=",
       "dependencies": {
         "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@>=2.9.30 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+          "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
         },
         "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.9.3 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "resin-cli-visuals": {
-      "version": "1.3.1",
-      "from": "resin-cli-visuals@1.3.1",
-      "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.3.1.tgz",
+      "integrity": "sha1-Gfc5cGtCKO1+MGcxPSO2CnZ4K7M=",
       "dependencies": {
         "bluebird": {
-          "version": "2.11.0",
-          "from": "bluebird@>=2.9.34 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+          "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         },
         "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.10.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "resin-corvus": {
-      "version": "1.0.0-beta.26",
-      "from": "resin-corvus@latest",
-      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.26.tgz",
+      "version": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.26.tgz",
+      "integrity": "sha1-N4LX/9JOYvW69miJlZNjTYYlorw=",
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@>=4.17.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
     "resolve": {
-      "version": "1.3.2",
-      "from": "resolve@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
+      "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
+      "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
       "dev": true
     },
     "resolve-dir": {
-      "version": "0.1.1",
-      "from": "resolve-dir@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
     },
     "right-align": {
-      "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "dev": true
+      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true
     },
     "rimraf": {
-      "version": "2.6.1",
-      "from": "rimraf@>=2.5.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "from": "ripemd160@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true
     },
     "run-async": {
-      "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
+      "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
     },
     "rx": {
-      "version": "4.1.0",
-      "from": "rx@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
+      "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "from": "safe-buffer@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "samsam": {
-      "version": "1.1.2",
-      "from": "samsam@1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "version": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sanitize-filename": {
       "version": "1.6.1",
-      "from": "sanitize-filename@>=1.6.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
       "dev": true
     },
     "sass-graph": {
-      "version": "2.2.4",
-      "from": "sass-graph@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "dependencies": {
         "set-blocking": {
-          "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "string-width": {
-          "version": "1.0.2",
-          "from": "string-width@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true
         },
         "yargs": {
-          "version": "7.1.0",
-          "from": "yargs@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true
         },
         "yargs-parser": {
-          "version": "5.0.0",
-          "from": "yargs-parser@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true
         }
       }
     },
     "sass-lint": {
-      "version": "1.10.2",
-      "from": "sass-lint@>=1.10.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.10.2.tgz",
+      "version": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.10.2.tgz",
+      "integrity": "sha1-glvWsNp53dNqQv+uW21ErEkiUCs=",
       "dev": true,
       "dependencies": {
         "cli-width": {
-          "version": "2.1.0",
-          "from": "cli-width@^2.0.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+          "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
           "dev": true
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "commander@^2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true
         },
         "doctrine": {
-          "version": "1.5.0",
-          "from": "doctrine@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true
         },
         "eslint": {
-          "version": "2.13.1",
-          "from": "eslint@>=2.7.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "version": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true
         },
         "file-entry-cache": {
-          "version": "1.3.1",
-          "from": "file-entry-cache@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+          "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
           "dev": true
         },
         "fs-extra": {
-          "version": "1.0.0",
-          "from": "fs-extra@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true
         },
         "globule": {
-          "version": "1.1.0",
-          "from": "globule@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+          "version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+          "integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
           "dev": true,
           "dependencies": {
             "lodash": {
-              "version": "4.16.6",
-              "from": "lodash@>=4.16.4 <4.17.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+              "version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+              "integrity": "sha1-0iyaxmAojzhD4Wun0rXQbMon13c=",
               "dev": true
             }
           }
         },
         "inquirer": {
-          "version": "0.12.0",
-          "from": "inquirer@^0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@^1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true
         },
         "shelljs": {
-          "version": "0.6.1",
-          "from": "shelljs@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+          "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+          "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
           "dev": true
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
         }
       }
     },
     "sax": {
-      "version": "1.2.2",
-      "from": "sax@>=0.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
+      "version": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+      "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg="
     },
     "scss-tokenizer": {
-      "version": "0.2.3",
-      "from": "scss-tokenizer@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true
         }
       }
     },
     "seek-bzip": {
-      "version": "1.0.5",
-      "from": "seek-bzip@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
+      "version": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w="
     },
     "semver": {
-      "version": "5.1.1",
-      "from": "semver@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz"
+      "version": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+      "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
     },
     "semver-diff": {
       "version": "2.1.0",
-      "from": "semver-diff@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true
     },
     "set-blocking": {
-      "version": "1.0.0",
-      "from": "set-blocking@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz"
+      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz",
+      "integrity": "sha1-zV5dk4BI3xrJLf6S4fFq3WVvXsU="
     },
     "set-getter": {
-      "version": "0.1.0",
-      "from": "set-getter@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "version": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "from": "setimmediate@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+      "version": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "sha.js": {
-      "version": "2.4.8",
-      "from": "sha.js@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
       "dev": true
     },
     "shasum": {
-      "version": "1.0.2",
-      "from": "shasum@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true
     },
     "shell-quote": {
-      "version": "1.6.1",
-      "from": "shell-quote@>=1.6.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "version": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true
     },
     "shelljs": {
-      "version": "0.7.7",
-      "from": "shelljs@>=0.7.5 <0.8.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "dev": true
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "dev": true
-    },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "from": "simple-fmt@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "dev": true
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "from": "simple-is@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "single-line-log": {
       "version": "1.1.2",
-      "from": "single-line-log@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
       "dev": true
     },
     "sinon": {
-      "version": "1.17.7",
-      "from": "sinon@>=1.15.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "version": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true
     },
     "sinon-chai": {
-      "version": "2.8.0",
-      "from": "sinon-chai@>=2.8.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
+      "version": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
+      "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=",
       "dev": true
     },
     "ski": {
-      "version": "1.0.0",
-      "from": "ski@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ski/-/ski-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/ski/-/ski-1.0.0.tgz",
+      "integrity": "sha1-FeSd/U8EQmDib8c8AUJlEYUhN7Y=",
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "from": "slice-ansi@0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "slice-stream2": {
-      "version": "2.0.1",
-      "from": "slice-stream2@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-stream2/-/slice-stream2-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/slice-stream2/-/slice-stream2-2.0.1.tgz",
+      "integrity": "sha1-e9gO/BMjLsEVFLZlxLZBWv2mkbc=",
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@^2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "slide": {
       "version": "1.1.6",
-      "from": "slide@>=1.1.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "smart-buffer": {
-      "version": "1.1.15",
-      "from": "smart-buffer@>=1.0.13 <2.0.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "version": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
       "dev": true
     },
     "sntp": {
-      "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
     },
     "socks": {
-      "version": "1.1.10",
-      "from": "socks@>=1.1.5 <1.2.0",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "version": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true
     },
-    "socks-proxy-agent": {
-      "version": "1.0.2",
-      "from": "socks-proxy-agent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-1.0.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "extend": {
-          "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-          "dev": true
-        }
-      }
-    },
     "source-map": {
-      "version": "0.5.6",
-      "from": "source-map@>=0.5.3 <0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
       "dev": true
     },
     "source-map-support": {
       "version": "0.4.15",
-      "from": "source-map-support@>=0.4.15 <0.5.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
     },
     "spdx-exceptions": {
-      "version": "1.0.4",
-      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+      "version": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+      "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
     },
     "spdx-expression-parse": {
-      "version": "1.0.2",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+      "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY="
     },
     "spdx-license-ids": {
-      "version": "1.2.1",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz",
+      "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM="
     },
     "speedometer": {
-      "version": "0.1.4",
-      "from": "speedometer@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz"
+      "version": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0="
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.11.0",
-      "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
+      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
+      "integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
       "dependencies": {
         "asn1": {
-          "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
-    "stable": {
-      "version": "0.1.6",
-      "from": "stable@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-      "dev": true
-    },
     "stack-trace": {
-      "version": "0.0.9",
-      "from": "stack-trace@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+      "version": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
     },
     "stat-mode": {
       "version": "0.2.2",
-      "from": "stat-mode@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
       "dev": true
     },
     "stdout-stream": {
-      "version": "1.4.0",
-      "from": "stdout-stream@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "version": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true
     },
     "stream-browserify": {
-      "version": "2.0.1",
-      "from": "stream-browserify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true
     },
     "stream-chunker": {
-      "version": "1.2.8",
-      "from": "stream-chunker@>=1.2.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-chunker/-/stream-chunker-1.2.8.tgz",
+      "version": "https://registry.npmjs.org/stream-chunker/-/stream-chunker-1.2.8.tgz",
+      "integrity": "sha1-6zryyK7lJWzedvCh/qhjSDNtBPc=",
       "dependencies": {
         "through2": {
-          "version": "2.0.3",
-          "from": "through2@~2.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+          "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <4.1.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "stream-combiner2": {
-      "version": "1.1.1",
-      "from": "stream-combiner2@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "version": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true
     },
     "stream-http": {
-      "version": "2.7.1",
-      "from": "stream-http@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
+      "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
+      "integrity": "sha1-VGpRdBrVprB+njGwsQRBqRffUoo=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "from": "readable-stream@>=2.2.6 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true
         },
         "string_decoder": {
-          "version": "1.0.1",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
     },
     "stream-splicer": {
-      "version": "2.0.0",
-      "from": "stream-splicer@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
-      "dev": true
-    },
-    "stream-to-array": {
-      "version": "1.0.0",
-      "from": "stream-to-array@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "string-template": {
-      "version": "0.2.1",
-      "from": "string-template@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
+      "version": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
     },
     "string-width": {
-      "version": "1.0.1",
-      "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+      "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo="
     },
     "string.prototype.codepointat": {
       "version": "0.2.0",
-      "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
+      "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg=",
       "dev": true
     },
     "string.prototype.endswith": {
-      "version": "0.2.0",
-      "from": "string.prototype.endswith@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
-      "dev": true
-    },
-    "stringmap": {
-      "version": "0.2.2",
-      "from": "stringmap@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "dev": true
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "from": "stringset@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
+      "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
     },
     "strip-eof": {
       "version": "1.0.0",
-      "from": "strip-eof@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "from": "strip-json-comments@>=2.0.1 <2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "striptags": {
-      "version": "2.2.1",
-      "from": "striptags@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI=",
       "dev": true
     },
     "subarg": {
-      "version": "1.0.0",
-      "from": "subarg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true
     },
     "sudo-prompt": {
-      "version": "6.1.0",
-      "from": "sudo-prompt@6.1.0",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-6.1.0.tgz"
+      "version": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-6.1.0.tgz",
+      "integrity": "sha1-eBl8hN+PD7LgshjLIlTS4/w+3GM="
     },
     "sumchecker": {
-      "version": "1.3.1",
-      "from": "sumchecker@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
+      "version": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
+      "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
       "dev": true
     },
-    "superagent": {
-      "version": "0.21.0",
-      "from": "superagent@>=0.21.0 <0.22.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
-        },
-        "extend": {
-          "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-          "dev": true
-        },
-        "form-data": {
-          "version": "0.1.3",
-          "from": "form-data@0.1.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.2.11",
-          "from": "mime@1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "dev": true
-        },
-        "qs": {
-          "version": "1.2.0",
-          "from": "qs@1.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.27-1",
-          "from": "readable-stream@1.0.27-1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-          "dev": true
-        }
-      }
-    },
-    "superagent-proxy": {
-      "version": "0.3.2",
-      "from": "superagent-proxy@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-0.3.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "dev": true
-        }
-      }
-    },
     "supports-color": {
-      "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "symbol": {
-      "version": "0.2.3",
-      "from": "symbol@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz"
+      "version": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c="
     },
     "symbol-observable": {
-      "version": "0.2.4",
-      "from": "symbol-observable@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz"
+      "version": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
     },
     "syntax-error": {
-      "version": "1.3.0",
-      "from": "syntax-error@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "version": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
       "dev": true
     },
     "table": {
-      "version": "3.8.3",
-      "from": "table@>=3.7.8 <4.0.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "dependencies": {
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true
         }
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "from": "tar@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true
     },
     "tempfile": {
       "version": "1.1.1",
-      "from": "tempfile@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
-          "from": "uuid@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
           "dev": true
         }
       }
     },
-    "temporary": {
-      "version": "0.0.8",
-      "from": "temporary@>=0.0.8 <0.1.0",
-      "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
-      "dev": true
-    },
     "term-size": {
       "version": "0.1.1",
-      "from": "term-size@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+      "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
       "dev": true
     },
     "text-table": {
-      "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throttleit": {
-      "version": "0.0.2",
-      "from": "throttleit@0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "version": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
       "dev": true
     },
     "through": {
-      "version": "2.3.8",
-      "from": "through@>=2.3.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "0.2.3",
-      "from": "through2@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "version": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
       "dependencies": {
         "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
         }
       }
     },
     "thunkify": {
-      "version": "2.1.2",
-      "from": "thunkify@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "version": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
       "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
-      "from": "timed-out@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "from": "timers-browserify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true
     },
     "tmp": {
-      "version": "0.0.31",
-      "from": "tmp@0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz"
+      "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc="
     },
     "to-arraybuffer": {
-      "version": "1.0.1",
-      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "version": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-file": {
-      "version": "0.2.0",
-      "from": "to-file@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
+      "version": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
+      "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
       "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
-          "version": "2.1.0",
-          "from": "isobject@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true
         },
         "lazy-cache": {
-          "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true
         }
       }
     },
     "to-gfm-code-block": {
-      "version": "0.1.1",
-      "from": "to-gfm-code-block@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
+      "version": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
+      "integrity": "sha1-JdBFpfrlUxielje1kJANpzLYqoI=",
       "dev": true
     },
     "to-object-path": {
-      "version": "0.3.0",
-      "from": "to-object-path@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "version": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true
     },
     "touch": {
-      "version": "0.0.3",
-      "from": "touch@0.0.3",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
       "dev": true,
       "dependencies": {
         "nopt": {
-          "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "version": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true
         }
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "from": "tough-cookie@>=0.12.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
     },
     "tracery": {
-      "version": "1.0.3",
-      "from": "tracery@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tracery/-/tracery-1.0.3.tgz",
+      "version": "https://registry.npmjs.org/tracery/-/tracery-1.0.3.tgz",
+      "integrity": "sha1-PBMzxSq7IEvQGzHmUKJregHF9x0=",
       "dev": true
     },
     "trackjs": {
-      "version": "2.3.1",
-      "from": "trackjs@>=2.1.16 <3.0.0",
-      "resolved": "https://registry.npmjs.org/trackjs/-/trackjs-2.3.1.tgz"
+      "version": "https://registry.npmjs.org/trackjs/-/trackjs-2.3.1.tgz",
+      "integrity": "sha1-IrdKW1MQTRjyFQgzJuCcaulnWYU="
     },
     "traverse": {
-      "version": "0.3.9",
-      "from": "traverse@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "version": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "dev": true
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
-      "from": "truncate-utf8-bytes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "dev": true
     },
     "tryit": {
-      "version": "1.0.3",
-      "from": "tryit@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "dev": true
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "from": "tryor@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "from": "tty-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "from": "tunnel-agent@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
     "type-check": {
-      "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true
     },
     "type-detect": {
-      "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "typedarray": {
-      "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.12",
-      "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
+      "version": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+      "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
     },
     "udif": {
-      "version": "0.9.0",
-      "from": "udif@latest",
-      "resolved": "https://registry.npmjs.org/udif/-/udif-0.9.0.tgz",
+      "version": "https://registry.npmjs.org/udif/-/udif-0.9.0.tgz",
+      "integrity": "sha1-rqCjIFcjvMQSAMcLkAlv2EyMYbk=",
       "dependencies": {
         "base64-js": {
-          "version": "1.1.2",
-          "from": "base64-js@1.1.2",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
+          "version": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+          "integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
         },
         "plist": {
-          "version": "2.0.1",
-          "from": "plist@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz"
+          "version": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+          "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os="
         },
         "xmlbuilder": {
-          "version": "8.2.2",
-          "from": "xmlbuilder@8.2.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
+          "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
         }
       }
     },
     "uglify-js": {
-      "version": "2.8.13",
-      "from": "uglify-js@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.13.tgz",
+      "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.13.tgz",
+      "integrity": "sha1-0M3wLzxmFIT6xgG35yMge3NaN0w=",
       "dev": true,
       "optional": true,
       "dependencies": {
         "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@^2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true
         },
         "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
-          "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "version": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
         },
         "yargs": {
-          "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "optional": true
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "umd": {
-      "version": "3.0.1",
-      "from": "umd@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "version": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "1.0.11",
-      "from": "unbzip2-stream@1.0.11",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.11.tgz"
+      "version": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.11.tgz",
+      "integrity": "sha1-IE9VVJzR3YAP3YNbhmdoMOdJLY8="
     },
     "unc-path-regex": {
-      "version": "0.1.2",
-      "from": "unc-path-regex@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "version": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
-      "version": "1.7.0",
-      "from": "underscore@>=1.7.0 <1.8.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "version": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "underscore.string": {
-      "version": "3.3.4",
-      "from": "underscore.string@>=3.2.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz"
+      "version": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s="
     },
     "unique-string": {
       "version": "1.0.0",
-      "from": "unique-string@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true
     },
     "universalify": {
       "version": "0.1.0",
-      "from": "universalify@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
+      "integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unzip-response": {
       "version": "2.0.1",
-      "from": "unzip-response@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true
     },
     "update-json": {
-      "version": "1.0.0",
-      "from": "update-json@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/update-json/-/update-json-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/update-json/-/update-json-1.0.0.tgz",
+      "integrity": "sha1-f3HfLA3egBngR63bPEdKLQWPsGU=",
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@^1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
       }
     },
     "update-notifier": {
       "version": "2.2.0",
-      "from": "update-notifier@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
       "dev": true
     },
     "url": {
-      "version": "0.11.0",
-      "from": "url@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "from": "punycode@1.3.2",
-          "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "version": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
       }
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "from": "url-parse-lax@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true
     },
     "user-home": {
-      "version": "2.0.0",
-      "from": "user-home@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true
     },
     "utf8-byte-length": {
       "version": "1.0.4",
-      "from": "utf8-byte-length@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
     },
     "util": {
-      "version": "0.10.3",
-      "from": "util@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-extend": {
-      "version": "1.0.3",
-      "from": "util-extend@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
+      "version": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
     },
     "uuid": {
-      "version": "3.0.1",
-      "from": "uuid@latest",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+      "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
     },
     "uuid-1345": {
       "version": "0.99.6",
-      "from": "uuid-1345@>=0.99.6 <0.100.0",
       "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-0.99.6.tgz",
+      "integrity": "sha1-sScK4BWnchx63sbEbsFpxgmK7UA=",
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
     },
     "verror": {
-      "version": "1.3.6",
-      "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     },
     "versionist": {
-      "version": "2.8.1",
-      "from": "versionist@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/versionist/-/versionist-2.8.1.tgz",
+      "version": "https://registry.npmjs.org/versionist/-/versionist-2.8.1.tgz",
+      "integrity": "sha1-6iFvW4rn9Q/CTfAUm8uJ4DA9maM=",
       "dev": true,
       "dependencies": {
         "debug": {
-          "version": "2.5.1",
-          "from": "debug@2.5.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
+          "integrity": "sha1-kQe7SlBgUuwqAjFLxgYxPtK5IcE=",
           "dev": true
         },
         "nopt": {
-          "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "version": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true
         },
         "semver": {
-          "version": "5.3.0",
-          "from": "semver@^5.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "touch": {
-          "version": "1.0.0",
-          "from": "touch@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+          "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
           "dev": true
         }
       }
     },
     "vinyl": {
-      "version": "1.2.0",
-      "from": "vinyl@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+      "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+      "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "from": "vm-browserify@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true
     },
-    "w3cjs": {
-      "version": "0.3.0",
-      "from": "w3cjs@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/w3cjs/-/w3cjs-0.3.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "commander": {
-          "version": "2.6.0",
-          "from": "commander@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "dev": true
-        }
-      }
-    },
     "wcwidth": {
-      "version": "1.0.1",
-      "from": "wcwidth@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"
+      "version": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g="
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+      "version": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "which": {
-      "version": "1.2.10",
-      "from": "which@>=1.2.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
+      "version": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
+      "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
       "dev": true
     },
     "which-module": {
-      "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wide-align": {
-      "version": "1.1.0",
-      "from": "wide-align@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+      "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
       "dev": true
     },
     "widest-line": {
       "version": "1.0.0",
-      "from": "widest-line@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true
     },
     "window-size": {
-      "version": "0.2.0",
-      "from": "window-size@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+      "version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "wordwrap": {
-      "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.0.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
+      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
+      "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8="
     },
     "wrappy": {
-      "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
-      "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true
     },
     "write-file-atomic": {
       "version": "2.1.0",
-      "from": "write-file-atomic@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "dev": true
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "from": "xdg-basedir@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.17",
-      "from": "xml2js@0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz"
+      "version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg="
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "from": "xmlbuilder@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
+      "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
     },
     "xmldom": {
-      "version": "0.1.27",
-      "from": "xmldom@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz"
+      "version": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
     "xregexp": {
-      "version": "2.0.0",
-      "from": "xregexp@2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
       "dev": true
     },
     "xtend": {
-      "version": "2.1.2",
-      "from": "xtend@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+      "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
     },
     "y18n": {
-      "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "2.0.0",
-      "from": "yallist@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+      "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
       "dev": true
     },
     "yargs": {
-      "version": "4.7.1",
-      "from": "yargs@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz"
+      "version": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
+      "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8="
     },
     "yargs-parser": {
-      "version": "2.4.0",
-      "from": "yargs-parser@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
+      "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
+      "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "from": "camelcase@>=2.1.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
     "yauzl": {
-      "version": "2.6.0",
-      "from": "yauzl@2.6.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz"
+      "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz",
+      "integrity": "sha1-QIlNRYe7ElUA0F30VHHNXhFKdvk="
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -120,12 +120,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
     },
-    "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-      "dev": true
-    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -1480,15 +1474,21 @@
       "dev": true
     },
     "electron-builder": {
-      "version": "18.8.1",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-18.8.1.tgz",
-      "integrity": "sha512-NpzryxnocKYjGFUrCYYdk3aF0Bq6hEPO14uSo7aYalagVFvMrQh6riVFQixClroX9rcDU+bBbKBSPepEtu55cA==",
+      "version": "19.6.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.6.3.tgz",
+      "integrity": "sha512-ype68gLi6CepoM06Yq+D9f0OjuEwT1ksal3W01O0ikAMIJHv/mZ6SuObXstrEtldCHvEUOqECr+tn+iu27KbKw==",
       "dev": true,
       "dependencies": {
         "ajv": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
           "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
+          "dev": true
+        },
+        "ajv-keywords": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
           "dev": true
         },
         "camelcase": {
@@ -1503,10 +1503,34 @@
           "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
           "dev": true
         },
+        "electron-builder-http": {
+          "version": "19.6.0",
+          "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-19.6.0.tgz",
+          "integrity": "sha512-/p4EfLQA7h3YVY62GYxipKSdACa8tDI6KmiMkvyrGsr17nlb4eHN4j2LDVMVeAtNPAM2N6drO3Kpt7r38kwDzg==",
+          "dev": true
+        },
+        "electron-builder-util": {
+          "version": "19.6.0",
+          "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-19.6.0.tgz",
+          "integrity": "sha512-2+kHBxwp7FeFYx/u0Bx8ZegQ5ej/AlX9xlWs20EEPZ+hT5JkHpxk0uptjvRhrw/z1kSJNqlEfmQc5GgDbhtTpQ==",
+          "dev": true
+        },
         "electron-download-tf": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
           "integrity": "sha1-eTDySgjjZp6q04pffyiKEEYcr3I=",
+          "dev": true
+        },
+        "electron-publish": {
+          "version": "19.6.0",
+          "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.6.0.tgz",
+          "integrity": "sha512-mXG6AM/dYb0oMCGXKE5xYIbDzVJ1FHZhO9jDmilFO6himOjnAZLDcsAbmGQQM8K5fkm/CPgtFPrudG6KzU4ihw==",
+          "dev": true
+        },
+        "fcopy-pre-bundled": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/fcopy-pre-bundled/-/fcopy-pre-bundled-0.3.4.tgz",
+          "integrity": "sha512-fRjxOMNl5wv94LaYvsozGcRBMDo+EvrC4hx3WN8HURCJUFw0NbGDfIsIw+bT97sSvnAljjdprTcxnQT62AM18w==",
           "dev": true
         },
         "find-up": {
@@ -1607,24 +1631,6 @@
         }
       }
     },
-    "electron-builder-core": {
-      "version": "18.7.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-core/-/electron-builder-core-18.7.0.tgz",
-      "integrity": "sha512-gXQpgtsudDs9CuAthtQHhBDukFt8JNNxOkx60Dy8VAu6AUXmZhfdwb1XyH43axtDlJH5sFBFJVWP68h05LbGzw==",
-      "dev": true
-    },
-    "electron-builder-http": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.8.0.tgz",
-      "integrity": "sha512-pqTGItyJs8aZLJYHtsWZQcBZFCuUrUKE966ElGEvMOySMr1WrntuOyK1CGQGZYhReXoImHzr4zcdzX1gZRsjRw==",
-      "dev": true
-    },
-    "electron-builder-util": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-18.8.0.tgz",
-      "integrity": "sha512-E0J4RAoDl+95/QQAfmaSIESyUYJFuRmsLOakUvblN2KSIypJwrCKRzOIpwXphtXg1WLOegdUk/JfuzClrURb9w==",
-      "dev": true
-    },
     "electron-download": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
@@ -1683,12 +1689,6 @@
           "dev": true
         }
       }
-    },
-    "electron-publish": {
-      "version": "18.8.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-18.8.0.tgz",
-      "integrity": "sha512-T/6zvotjnGYvLYA0AXLsV+gd5fpvltqMIYeGjlbdoQdYmifi6hS5Eq9sFepP6J6lEQhJMA70THEx1JRfu9V2YQ==",
-      "dev": true
     },
     "electron-window": {
       "version": "0.8.1",
@@ -2051,12 +2051,6 @@
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
       "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
-    },
-    "fcopy-pre-bundled": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/fcopy-pre-bundled/-/fcopy-pre-bundled-0.1.2.tgz",
-      "integrity": "sha512-tsboc66HjCjXf93MAA316XR4IiL+NFoohvyczR+T/YnVbqVe9V3KchaJMlWLbH+fNX4seugCx3rCqGN9KT+zkg==",
-      "dev": true
     },
     "fd-slicer": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,14 +4,14 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@types/angular": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.18.tgz",
-      "integrity": "sha512-BZW2QjWyr6mbji1liIceUeryvmrpX37fC6Rel6MG9s0BeWMpvOrTHcHcB/8f2oII9R/k/ZNXDBorp+tDhTWTBg=="
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.20.tgz",
+      "integrity": "sha512-xaqoQpA9iSYyWw2R8/UuKbSqGVmDgjgtkXkok027SpphcSCpyz3ib3tR2NJY8olzdmlo015urcpHsuAxCHvB5A=="
     },
     "@types/jquery": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.46.tgz",
-      "integrity": "sha512-U64bkZqTfFi4HXHqOckD1Uxvg+oPooCjD5bQ10t9xOG5Ke6cR8tFnvERXrQtrRWvgS428nhAL1V8qv1b88kgyQ=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.3.tgz",
+      "integrity": "sha512-3/ETl4JziXnuFIx6W+WB7BzPGRnYH2O/AFKafSOulabMyAhRfv/oboEO2yytsRvzZDiLFODuydYbr7C0kudB9w=="
     },
     "@types/lodash": {
       "version": "4.14.66",
@@ -39,9 +39,9 @@
       "integrity": "sha1-0NFnq4NBfPTVdM30yqIY/7oyygA="
     },
     "@types/react": {
-      "version": "15.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.28.tgz",
-      "integrity": "sha512-B63xn08FhmOGoOwOw4QswI4sMrEMqRMpPtcLmqJeXAABcAD6qha9OcJ890yorRgf5B9pG0GR9u5gGyWSgsLVCQ=="
+      "version": "15.0.30",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.30.tgz",
+      "integrity": "sha512-Az6oT3g1sep2hl37L5x1PYEJeuJ2xd3olCT7AhY2rjhXmGX+sYO0q120HJMg6EkK+GZnVNJF84puz75f4KHlGg=="
     },
     "@types/react-dom": {
       "version": "15.5.0",
@@ -250,16 +250,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -433,12 +441,6 @@
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
-    "async-foreach": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-      "dev": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -541,9 +543,9 @@
       "integrity": "sha1-O96v+FBrBBj+4G5FbloIxc9xvLY="
     },
     "bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+      "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
       "dev": true
     },
     "boom": {
@@ -649,16 +651,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true,
           "dependencies": {
             "string_decoder": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
               "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-              "dev": true
+              "dev": true,
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                  "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+                  "dev": true
+                }
+              }
             }
           }
         },
@@ -1084,14 +1094,21 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw=="
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+            }
+          }
         }
       }
     },
@@ -1418,16 +1435,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -1455,15 +1480,15 @@
       "dev": true
     },
     "electron-builder": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-18.6.2.tgz",
-      "integrity": "sha512-CBr1dEuNSMls6U3zgESF4xUqAu4In4CNsEB13XUmt4CGawtMJX1UH9YIDLABuzLGjOMjFAHpE0HC5RJskRFRjQ==",
+      "version": "18.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-18.8.1.tgz",
+      "integrity": "sha512-NpzryxnocKYjGFUrCYYdk3aF0Bq6hEPO14uSo7aYalagVFvMrQh6riVFQixClroX9rcDU+bBbKBSPepEtu55cA==",
       "dev": true,
       "dependencies": {
         "ajv": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.5.tgz",
-          "integrity": "sha1-hzSTG2AfANT+73xlc4130bZdH2g=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
+          "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
           "dev": true
         },
         "camelcase": {
@@ -1583,21 +1608,21 @@
       }
     },
     "electron-builder-core": {
-      "version": "18.4.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-core/-/electron-builder-core-18.4.0.tgz",
-      "integrity": "sha512-nVDcWZnmBqzaoa9uOZA9qV8ByNhX0yBGPNxKnSxrJR13ruru2HFPzpaGEQnxmnYWFNOewsoehKaiH/dc1rYo1Q==",
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-core/-/electron-builder-core-18.7.0.tgz",
+      "integrity": "sha512-gXQpgtsudDs9CuAthtQHhBDukFt8JNNxOkx60Dy8VAu6AUXmZhfdwb1XyH43axtDlJH5sFBFJVWP68h05LbGzw==",
       "dev": true
     },
     "electron-builder-http": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.6.0.tgz",
-      "integrity": "sha512-/kNnHN2gslrbZdT+K8hF8tNnfn/QTvJvj/lGudXFVvbn0PPgQ6Nb/bwAh67v0DSyJE1XMgzsbn5qSShrY19gyA==",
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-18.8.0.tgz",
+      "integrity": "sha512-pqTGItyJs8aZLJYHtsWZQcBZFCuUrUKE966ElGEvMOySMr1WrntuOyK1CGQGZYhReXoImHzr4zcdzX1gZRsjRw==",
       "dev": true
     },
     "electron-builder-util": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-18.6.0.tgz",
-      "integrity": "sha512-8Kmfl5lpIhh1jFF2ZTnWIKs3jWsu7zoy0fhuZQn9srxPPbTG3ZD/uGnkEenH5QsNu5FGPtF+JmTMerJBH8No8A==",
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-18.8.0.tgz",
+      "integrity": "sha512-E0J4RAoDl+95/QQAfmaSIESyUYJFuRmsLOakUvblN2KSIypJwrCKRzOIpwXphtXg1WLOegdUk/JfuzClrURb9w==",
       "dev": true
     },
     "electron-download": {
@@ -1660,9 +1685,9 @@
       }
     },
     "electron-publish": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-18.6.0.tgz",
-      "integrity": "sha512-gCl+Jn/0Qqk1XZT1Hr76eyzX2nL7BdN5ilo9/XKJjP+yqOVagJx/Y5kisX5kAfP+a+esGESuQ/1n6STnQH4zBw==",
+      "version": "18.8.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-18.8.0.tgz",
+      "integrity": "sha512-T/6zvotjnGYvLYA0AXLsV+gd5fpvltqMIYeGjlbdoQdYmifi6hS5Eq9sFepP6J6lEQhJMA70THEx1JRfu9V2YQ==",
       "dev": true
     },
     "electron-window": {
@@ -1820,9 +1845,9 @@
       }
     },
     "eslint-plugin-lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.4.2.tgz",
-      "integrity": "sha1-oDFgEG34FKuUN2xUL/NIY0FKn3A=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.4.3.tgz",
+      "integrity": "sha1-jW9+/r3q7tDzOM8oQF793KJH/GQ=",
       "dev": true
     },
     "espree": {
@@ -1851,18 +1876,10 @@
       "dev": true
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-      "dev": true,
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -1986,16 +2003,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         },
         "yauzl": {
           "version": "2.4.1",
@@ -2010,6 +2035,12 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
     },
+    "fast-deep-equal": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz",
+      "integrity": "sha1-XG9FmaumszPuM0Li7ZeGcvEAH40=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2020,6 +2051,12 @@
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
       "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+    },
+    "fcopy-pre-bundled": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fcopy-pre-bundled/-/fcopy-pre-bundled-0.1.2.tgz",
+      "integrity": "sha512-tsboc66HjCjXf93MAA316XR4IiL+NFoohvyczR+T/YnVbqVe9V3KchaJMlWLbH+fNX4seugCx3rCqGN9KT+zkg==",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.0.1",
@@ -2271,12 +2308,6 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true
     },
-    "gaze": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-      "dev": true
-    },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -2324,16 +2355,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -2555,9 +2594,9 @@
       "dev": true
     },
     "hash.js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.1.tgz",
+      "integrity": "sha512-I2TYCUjYQMmqmRMCp6jKMC5bvdXxGIZ/heITRR/0F1u0OP920ImEj/cXt3WgcTKBnNYGn7enxUzdai3db829JA==",
       "dev": true
     },
     "hawk": {
@@ -2636,9 +2675,9 @@
           "dev": true
         },
         "xmlbuilder": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.0.tgz",
-          "integrity": "sha1-qTEbP4UJNFcAxJqPeb4GvMWYjRg=",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.1.tgz",
+          "integrity": "sha1-kc1wiXdVNj66V8Et3uq0o0GmH2U=",
           "dev": true
         }
       }
@@ -2709,12 +2748,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
@@ -3116,12 +3149,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
-      "dev": true
-    },
     "js-message": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
@@ -3152,6 +3179,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.0.tgz",
+      "integrity": "sha1-ABbAscoe/kbUTTdUG838Gdz64Ns=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -3344,12 +3377,6 @@
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
-    },
     "lodash.create": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
@@ -3424,12 +3451,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
       "dev": true
     },
     "lodash.partition": {
@@ -4435,16 +4456,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         },
         "xtend": {
           "version": "4.0.1",
@@ -4549,24 +4578,6 @@
       "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-8.10.3.tgz",
       "integrity": "sha1-IjvUMa1/suQMVDT4peRVi+JWj70="
     },
-    "node-sass": {
-      "version": "github:sass/node-sass#61d7e1c1abf762aad22bb2a6b3fdac884ca369bd",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        }
-      }
-    },
     "node-stream-zip": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.7.tgz",
@@ -4607,9 +4618,9 @@
       "dev": true
     },
     "npx": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npx/-/npx-5.3.0.tgz",
-      "integrity": "sha512-o8V4NqQqmAF7knAyCLwkCw++ap049Pwql8gtQiO4lQgGSHpmxxeW9INa6M5SlPEYL/dg5hSuFDKpNO0ohiUlvQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npx/-/npx-6.1.0.tgz",
+      "integrity": "sha512-uCzmlP8oojeQdJCtwuRPR0NrHSKMy/2DoMrn47PW4+pM54au7SSxHG+h1SYYLYiMSKdUXANKsodnVfMvgTk1AQ==",
       "dev": true,
       "dependencies": {
         "ansi-align": {
@@ -4634,12 +4645,6 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
           "dev": true
         },
         "boxen": {
@@ -7754,9 +7759,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
-          "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true
         },
         "yargs-parser": {
@@ -8145,9 +8150,9 @@
       }
     },
     "promise": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg=="
     },
     "prop-types": {
       "version": "15.5.10",
@@ -8245,15 +8250,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-          "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "raven": {
       "version": "1.2.1",
@@ -8328,16 +8325,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -8380,9 +8385,9 @@
       "dev": true
     },
     "redux": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
-      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.0.tgz",
+      "integrity": "sha512-GHjaOkEQtQnnuLoYPFkRKHIqs1i1tdTlisu/xUHfk2juzCobSy4STxs4Lz5bPkc07Owb6BeGKx/r76c9IVTkOw=="
     },
     "redux-localstorage": {
       "version": "0.4.1",
@@ -8655,9 +8660,9 @@
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
     },
     "samsam": {
       "version": "1.1.2",
@@ -8670,38 +8675,6 @@
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
       "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
       "dev": true
-    },
-    "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "dev": true,
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-          "dev": true
-        }
-      }
     },
     "sass-lint": {
       "version": "1.10.2",
@@ -8775,20 +8748,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
       "integrity": "sha1-/YYxojvHgmvvXYcb24c3jJVkeCg="
-    },
-    "scss-tokenizer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "dev": true,
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
-        }
-      }
     },
     "seek-bzip": {
       "version": "1.0.5",
@@ -8999,32 +8958,6 @@
       "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
       "dev": true
     },
-    "stdout-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "dev": true,
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
-        }
-      }
-    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -9038,16 +8971,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -9069,16 +9010,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -9095,16 +9044,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         },
         "xtend": {
           "version": "4.0.1",
@@ -9127,16 +9084,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -9243,16 +9208,24 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
-          "dev": true
+          "dev": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -9378,14 +9351,21 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
+          "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw=="
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
+          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+            }
+          }
         },
         "xtend": {
           "version": "4.0.1",
@@ -9735,9 +9715,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "uuid-1345": {
       "version": "0.99.6",
@@ -9756,9 +9736,9 @@
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
     },
     "versionist": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/versionist/-/versionist-2.10.0.tgz",
-      "integrity": "sha1-THYIHlWMg5d+TkGKE55dss5KZms=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/versionist/-/versionist-2.11.0.tgz",
+      "integrity": "sha1-0z51PckVTt9vBQ0VVkocxExOALU=",
       "dev": true,
       "dependencies": {
         "async": {

--- a/package.json
+++ b/package.json
@@ -159,8 +159,7 @@
     "mochainon": "^1.0.0",
     "nock": "^9.0.9",
     "node-gyp": "^3.5.0",
-    "node-sass": "github:sass/node-sass#61d7e1c1abf762aad22bb2a6b3fdac884ca369bd",
-    "npx": "^5.2.0",
+    "npx": "^6.1.0",
     "sass-lint": "^1.10.2",
     "tmp": "0.0.31",
     "versionist": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test": "make test",
     "start": "electron lib/start.js",
     "preshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
+    "postshrinkwrap": "node ./scripts/fix-shrinkwrap.js",
     "configure": "node-gyp configure",
     "build": "node-gyp build",
     "install": "node-gyp rebuild"

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "asar": "^0.10.0",
     "browserify": "github:jviotti/node-browserify#dynamic-dirname-filename",
     "electron": "1.6.6",
-    "electron-builder": "^18.6.2",
+    "electron-builder": "^19.6.3",
     "electron-mocha": "^3.1.1",
     "eslint": "^3.16.1",
     "eslint-plugin-lodash": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "eslint": "^3.16.1",
     "eslint-plugin-lodash": "^2.3.5",
     "file-exists": "^1.0.0",
-    "html-angular-validate": "^0.1.9",
+    "html-angular-validate": "github:jhermsmeier/html-angular-validate#fix-things",
     "mochainon": "^1.0.0",
     "nock": "^9.0.9",
     "node-gyp": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "mochainon": "^1.0.0",
     "nock": "^9.0.9",
     "node-gyp": "^3.5.0",
-    "node-sass": "^4.5.3",
+    "node-sass": "github:sass/node-sass#61d7e1c1abf762aad22bb2a6b3fdac884ca369bd",
     "npx": "^5.2.0",
     "sass-lint": "^1.10.2",
     "tmp": "0.0.31",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "flexboxgrid": "^6.3.0",
     "immutable": "^3.8.1",
     "lodash": "^4.5.1",
-    "lzma-native": "^1.5.2",
+    "lzma-native": "^2.0.2",
     "mime-types": "^2.1.15",
     "mountutils": "^1.2.0",
     "nan": "^2.3.5",

--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -90,18 +90,11 @@ fi
 
 function run_install() {
 
-  # Since we use an `npm-shrinkwrap.json` file, if you pull changes
-  # that update a dependency and try to `npm install` directly, npm
-  # will complain that your `node_modules` tree is not equal to what
-  # is defined by the `npm-shrinkwrap.json` file, and will thus
-  # refuse to do anything but install from scratch.
-  npm prune
+  npm install "$INSTALL_OPTS"
 
   # When changing between target architectures, rebuild all dependencies,
   # since compiled add-ons will not work otherwise.
   npm rebuild
-
-  npm install $INSTALL_OPTS
 
   if [ "$ARGV_PRODUCTION" == "true" ]; then
 

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -29,7 +29,7 @@ RUN apt-get update \
     python-software-properties \
     unzip \
     xvfb \
-    zip   \
+    zip \
     rpm
 
 # Install a C++11 compiler
@@ -37,15 +37,22 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
-# NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-  && apt-get install -y nodejs
+# Install Node@8.x.x
+RUN curl -L https://git.io/n-install | bash -s -- -y 8.1.0
 
 # See https://github.com/mapbox/node-pre-gyp/issues/165
 RUN npm config set unsafe-perm=true
 
-RUN npm config set spin=false
-RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1 electron-installer-redhat@0.5.0
+# Don't display progress or the spinner while installing,
+# but log HTTP requests & cache hits
+RUN npm config set spin false && \
+  npm config set progress false && \
+  npm config set loglevel http
+
+RUN npm install --global \
+  uglify-es@^3.0.15 \
+  electron-installer-debian@^0.5.1 \
+  electron-installer-redhat@^0.5.0
 
 # Python
 COPY requirements.txt requirements.txt

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -38,7 +38,9 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # Install Node@8.x.x
-RUN curl -L https://git.io/n-install | bash -s -- -y 8.1.0
+RUN git clone https://github.com/tj/n && \
+  cd n && git checkout v2.1.4 && make install && \
+  cd .. && n 8.1.0
 
 # See https://github.com/mapbox/node-pre-gyp/issues/165
 RUN npm config set unsafe-perm=true

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -52,6 +52,7 @@ RUN npm config set spin false && \
   npm config set loglevel http
 
 RUN npm install --global \
+  node-sass@^4.5.3 \
   uglify-es@^3.0.15 \
   electron-installer-debian@^0.5.1 \
   electron-installer-redhat@^0.5.0

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -37,7 +37,9 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # Install Node@8.x.x
-RUN curl -L https://git.io/n-install | bash -s -- -y 8.1.0
+RUN git clone https://github.com/tj/n && \
+  cd n && git checkout v2.1.4 && make install && \
+  cd .. && n 8.1.0
 
 # See https://github.com/mapbox/node-pre-gyp/issues/165
 RUN npm config set unsafe-perm=true

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -28,7 +28,7 @@ RUN apt-get update \
     python-software-properties \
     unzip \
     xvfb \
-    zip   \
+    zip \
     rpm
 
 # Install a C++11 compiler
@@ -36,15 +36,22 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
-# NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-  && apt-get install -y nodejs
+# Install Node@8.x.x
+RUN curl -L https://git.io/n-install | bash -s -- -y 8.1.0
 
 # See https://github.com/mapbox/node-pre-gyp/issues/165
 RUN npm config set unsafe-perm=true
 
-RUN npm config set spin=false
-RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1 electron-installer-redhat@0.5.0
+# Don't display progress or the spinner while installing,
+# but log HTTP requests & cache hits
+RUN npm config set spin false && \
+  npm config set progress false && \
+  npm config set loglevel http
+
+RUN npm install --global \
+  uglify-es@^3.0.15 \
+  electron-installer-debian@^0.5.1 \
+  electron-installer-redhat@^0.5.0
 
 # Python
 COPY requirements.txt requirements.txt

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -51,6 +51,7 @@ RUN npm config set spin false && \
   npm config set loglevel http
 
 RUN npm install --global \
+  node-sass@^4.5.3 \
   uglify-es@^3.0.15 \
   electron-installer-debian@^0.5.1 \
   electron-installer-redhat@^0.5.0

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -31,8 +31,7 @@ RUN apt-get update \
     python-software-properties \
     unzip \
     xvfb \
-
-    zip   \
+    zip \
     rpm
 
 # Install a C++11 compiler
@@ -40,15 +39,22 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && apt-get update && apt-get install -y gcc-4.8 g++-4.8 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
-# NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-  && apt-get install -y nodejs
+# Install Node@8.x.x
+RUN curl -L https://git.io/n-install | bash -s -- -y 8.1.0
 
 # See https://github.com/mapbox/node-pre-gyp/issues/165
 RUN npm config set unsafe-perm=true
 
-RUN npm config set spin=false
-RUN npm install -g uglify-es@3.0.3 electron-installer-debian@0.5.1 electron-installer-redhat@0.5.0
+# Don't display progress or the spinner while installing,
+# but log HTTP requests & cache hits
+RUN npm config set spin false && \
+  npm config set progress false && \
+  npm config set loglevel http
+
+RUN npm install --global \
+  uglify-es@^3.0.15 \
+  electron-installer-debian@^0.5.1 \
+  electron-installer-redhat@^0.5.0
 
 # Python
 COPY requirements.txt requirements.txt

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -40,7 +40,9 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 # Install Node@8.x.x
-RUN curl -L https://git.io/n-install | bash -s -- -y 8.1.0
+RUN git clone https://github.com/tj/n && \
+  cd n && git checkout v2.1.4 && make install && \
+  cd .. && n 8.1.0
 
 # See https://github.com/mapbox/node-pre-gyp/issues/165
 RUN npm config set unsafe-perm=true

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -54,6 +54,7 @@ RUN npm config set spin false && \
   npm config set loglevel http
 
 RUN npm install --global \
+  node-sass@^4.5.3 \
   uglify-es@^3.0.15 \
   electron-installer-debian@^0.5.1 \
   electron-installer-redhat@^0.5.0

--- a/scripts/ci/ensure-staged-shrinkwrap.sh
+++ b/scripts/ci/ensure-staged-shrinkwrap.sh
@@ -24,12 +24,12 @@ echo "npm version: $(npm --version)"
 
 SHRINKWRAP_FILE=npm-shrinkwrap.json
 
-npm shrinkwrap --dev
+npm shrinkwrap
 
 if [[ -n $(git status -s "$SHRINKWRAP_FILE") ]]; then
   echo "There are unstaged $SHRINKWRAP_FILE changes. Please commit the result of:" 1>&2
   echo ""
-  echo "    npm shrinkwrap --dev" 1>&2
+  echo "    npm shrinkwrap" 1>&2
   echo ""
   git --no-pager diff "$SHRINKWRAP_FILE"
   exit 1

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -67,8 +67,13 @@ else
   ./scripts/build/check-dependency.sh pip
   ./scripts/build/check-dependency.sh make
 
-  npm config set spin=false
-  npm install -g uglify-es@3.0.3
+  # Don't display progress or the spinner while installing
+  npm config set spin false
+  npm config set progress false
+  # Log HTTP requests & cache hits
+  npm config set loglevel http
+
+  npm install --global uglify-es@^3.0.15
   pip install -r requirements.txt
 
   make info

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -73,7 +73,7 @@ else
   # Log HTTP requests & cache hits
   npm config set loglevel http
 
-  npm install --global uglify-es@^3.0.15
+  npm install --global node-sass@^4.5.3 uglify-es@^3.0.15
   pip install -r requirements.txt
 
   make info

--- a/scripts/fix-shrinkwrap.js
+++ b/scripts/fix-shrinkwrap.js
@@ -1,46 +1,56 @@
+'use strict';
+
+const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
 
-var time = Date.now();
+// No magic numbers it is, eslint
+const ZERO = 0;
+const ONE = 1;
+const TWO = 2;
+const THOUSAND = 1000;
+
+let time = Date.now();
 
 // Load the shrinkwrap
 const SHRINKWRAP_FILE = path.join(__dirname, '..', 'npm-shrinkwrap.json');
 const shrinkwrap = JSON.parse(fs.readFileSync(SHRINKWRAP_FILE, 'utf8'));
 
-// Fix up an issue with the shrinkwrap caused by npm@5.0.3,
-// where nested dependencies in the shrinkwrap have the "resolved"
-// URL as "version" key, and are missing the "resolved" key
-function fixup(dependency) {
+/**
+ * Fix up an issue with the shrinkwrap caused by npm@5.0.3,
+ * where nested dependencies in the shrinkwrap have the "resolved"
+ * URL as "version" key, and are missing the "resolved" key
+ * @param {Object} dependency - dependency
+ * @returns {Boolean}
+ */
+const fixup = (dependency) => {
 
   // If the dependency version is a URL and
   // the "resolved" key is missing, we need to fix it
   if (!dependency.resolved && /^http(s):/i.test(dependency.version)) {
 
     // Extract the version number from the registry URL
-    var match = dependency.version.match(/(\d+\.\d+\.\d+(\-.+)?)\.tgz$/);
+    const match = dependency.version.match(/(\d+\.\d+\.\d+(-.+)?)\.tgz$/);
 
     // If something goes wrong, we do not want
     // this to continue in any way; so we crash
-    if (!match || !match[1]) {
+    if (!match || !match[ONE]) {
       throw new Error(`Unable to extract version from "${dependency.version}"`);
     }
 
     // We need to do some property magic here to
     // maintain the same order of keys as npm generates
     // when writing out, to not swap lines and create a diff
-    var integrity = dependency.integrity;
-    var dependencies = dependency.dependencies;
+    const integrity = dependency.integrity;
+    const dependencies = dependency.dependencies;
 
-    dependency.integrity = void 0;
-    dependency.dependencies = void 0;
-
-    delete dependency.integrity;
-    delete dependency.dependencies;
+    Reflect.deleteProperty(dependency, 'integrity');
+    Reflect.deleteProperty(dependency, 'dependencies');
 
     // Set "resolved" to the registry URL,
     // and "version" to the extracted version:
     dependency.resolved = dependency.version;
-    dependency.version = match[1];
+    dependency.version = match[ONE];
 
     // Put deleted properties back to maintain key order
     dependency.integrity = integrity;
@@ -52,36 +62,38 @@ function fixup(dependency) {
 
   return false;
 
-}
+};
 
-// Walk the shrinkwrap dependency tree,
-// and fix up any mangled versions along the way
-// while counting how many have been fixed (because, why not?)
-function walk(tree) {
+/**
+ * Walk the shrinkwrap dependency tree,
+ * and fix up any mangled versions along the way
+ * while counting how many have been fixed (because, why not?)
+ * @param {Object} tree - dependency tree
+ * @returns {Number}
+ */
+const walk = (tree) => {
 
   if (!tree.dependencies) {
-    return 0; // Nothing to do here
+    // Nothing to do here
+    return ZERO;
   }
 
-  var keys = Object.keys(tree.dependencies);
-  var fixes = 0;
-  var dep = null;
+  let fixes = ZERO;
 
-  for (var i = 0; i < keys.length; i++) {
-    dep = tree.dependencies[keys[i]];
-    fixes += fixup(dep) ? 1 : 0;
+  _.forEach(tree.dependencies, (dep) => {
+    fixes += fixup(dep) ? ONE : ZERO;
     fixes += walk(dep);
-  }
+  });
 
   return fixes;
 
-}
+};
 
 const fixes = walk(shrinkwrap);
 
 // Save the shrinkwrap back
-fs.writeFileSync(SHRINKWRAP_FILE, JSON.stringify(shrinkwrap, null, 2) + '\n');
+fs.writeFileSync(SHRINKWRAP_FILE, `${JSON.stringify(shrinkwrap, null, TWO)}\n`);
 
-time = (Date.now() - time) / 1000;
+time = (Date.now() - time) / THOUSAND;
 
-console.log( `Fixed up ${fixes} dependencies in ${time.toFixed(2)}s` )
+console.log(`Fixed up ${fixes} dependencies in ${time.toFixed(TWO)}s`);

--- a/scripts/fix-shrinkwrap.js
+++ b/scripts/fix-shrinkwrap.js
@@ -1,0 +1,87 @@
+const fs = require('fs');
+const path = require('path');
+
+var time = Date.now();
+
+// Load the shrinkwrap
+const SHRINKWRAP_FILE = path.join(__dirname, '..', 'npm-shrinkwrap.json');
+const shrinkwrap = JSON.parse(fs.readFileSync(SHRINKWRAP_FILE, 'utf8'));
+
+// Fix up an issue with the shrinkwrap caused by npm@5.0.3,
+// where nested dependencies in the shrinkwrap have the "resolved"
+// URL as "version" key, and are missing the "resolved" key
+function fixup(dependency) {
+
+  // If the dependency version is a URL and
+  // the "resolved" key is missing, we need to fix it
+  if (!dependency.resolved && /^http(s):/i.test(dependency.version)) {
+
+    // Extract the version number from the registry URL
+    var match = dependency.version.match(/(\d+\.\d+\.\d+(\-.+)?)\.tgz$/);
+
+    // If something goes wrong, we do not want
+    // this to continue in any way; so we crash
+    if (!match || !match[1]) {
+      throw new Error(`Unable to extract version from "${dependency.version}"`);
+    }
+
+    // We need to do some property magic here to
+    // maintain the same order of keys as npm generates
+    // when writing out, to not swap lines and create a diff
+    var integrity = dependency.integrity;
+    var dependencies = dependency.dependencies;
+
+    dependency.integrity = void 0;
+    dependency.dependencies = void 0;
+
+    delete dependency.integrity;
+    delete dependency.dependencies;
+
+    // Set "resolved" to the registry URL,
+    // and "version" to the extracted version:
+    dependency.resolved = dependency.version;
+    dependency.version = match[1];
+
+    // Put deleted properties back to maintain key order
+    dependency.integrity = integrity;
+    dependency.dependencies = dependencies;
+
+    return true;
+
+  }
+
+  return false;
+
+}
+
+// Walk the shrinkwrap dependency tree,
+// and fix up any mangled versions along the way
+// while counting how many have been fixed (because, why not?)
+function walk(tree) {
+
+  if (!tree.dependencies) {
+    return 0; // Nothing to do here
+  }
+
+  var keys = Object.keys(tree.dependencies);
+  var fixes = 0;
+  var dep = null;
+
+  for (var i = 0; i < keys.length; i++) {
+    dep = tree.dependencies[keys[i]];
+    fixes += fixup(dep) ? 1 : 0;
+    fixes += walk(dep);
+  }
+
+  return fixes;
+
+}
+
+const fixes = walk(shrinkwrap);
+
+// Save the shrinkwrap back
+fs.writeFileSync(SHRINKWRAP_FILE, JSON.stringify(shrinkwrap, null, 2) + '\n');
+
+time = (Date.now() - time) / 1000;
+
+console.log( `Fixed up ${fixes} dependencies in ${time.toFixed(2)}s` )


### PR DESCRIPTION
**Changes:**
- Update all CI services to use Node@8 and npm@5
- Remove preshrinkwrap script (now obsolete)
- Move `npm-shrinkwrap.json` -> `package-lock.json`

**Pending issues:**
- [x] Ubuntu 12.04 docker base image on Linux unsupported by Node@8 package
  - Problem solved by using [tj/n](https://github.com/tj/n) to install Node
- [x] npm@5: Installing npm@latest fails in Docker – https://github.com/npm/npm/issues/16807
  - Problem solved by using [tj/n](https://github.com/tj/n) to install Node
- [x] npm@5: Incorrect unmet peer dependency error – https://github.com/npm/npm/issues/16925
  - [ ] Await npm@5.0.4 **OR**
  - [x] Use a patched version of `html-angular-validate` to circumvent this
- [x] Node ABI mismatch for node-sass in sanity-checks – https://github.com/sass/node-sass/pull/1999
  - [ ] Await new version of `node-sass` with the above fix to be published **OR**
  - [x] Point to a known green commit on `node-sass` master

Connects-To: #1528