### PR TITLE
chore(package): Update mountutils to 1.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4962,14 +4962,14 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.0.6",
-      "from": "mountutils@1.0.6",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.0.6.tgz",
+      "version": "1.2.0",
+      "from": "mountutils@latest",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.2.0.tgz",
       "dependencies": {
         "nan": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "from": "nan@>=2.5.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lodash": "^4.5.1",
     "lzma-native": "^1.5.2",
     "mime-types": "^2.1.15",
-    "mountutils": "^1.0.6",
+    "mountutils": "^1.2.0",
     "nan": "^2.3.5",
     "node-ipc": "^8.9.2",
     "node-stream-zip": "^1.3.4",


### PR DESCRIPTION
This updates `mountutils` from 1.0.6 to 1.2.0, which includes
various fixes and adds AsyncWorkers:

- fix(windows): Replace use of `wsprintf()`
- fix(darwin): Add local context to avoid global state
- feat(src): Use Nan::AsyncWorker

Change-Type: upgrade