### PR TITLE
upgrade: `drivelist` to v5.0.22

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1480,9 +1480,9 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.0.20",
-      "from": "drivelist@5.0.20",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.20.tgz",
+      "version": "5.0.22",
+      "from": "drivelist@5.0.22",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.22.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "bootstrap-sass": "^3.3.5",
     "chalk": "^1.1.3",
     "command-join": "^2.0.0",
-    "drivelist": "^5.0.20",
+    "drivelist": "^5.0.22",
     "electron-is-running-in-asar": "^1.0.0",
     "etcher-image-write": "^9.1.3",
     "file-type": "^4.1.0",


### PR DESCRIPTION
- https://github.com/resin-io-modules/drivelist/pull/168

Change-Type: patch
Changelog-Entry: Fix occasional increased CPU usage because of perl regular expression in macOS.
Fixes: https://github.com/resin-io/etcher/issues/1288
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>