### PR TITLE
chore: remove ampersand from package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "semverRange": "<2.0.0"
   },
   "main": "lib/start.js",
-  "description": "Flash OS images to SD cards & USB drives, safely and easily.",
+  "description": "Flash OS images to SD cards and USB drives, safely and easily.",
   "productDescription": "Etcher is a powerful OS image flasher built with web technologies to ensure flashing an SDCard or USB drive is a pleasant and safe experience. It protects you from accidentally writing to your hard-drives, ensures every byte of data was written correctly and much more.",
   "homepage": "https://github.com/resin-io/etcher",
   "gypfile": true,


### PR DESCRIPTION
The ampersand confuses nupkg when generating Windows installers from
`electron-builder`.

The referenced issue talks about an issue where the ampersand is present
on the application name, but anything that gets into the `.nuspec` XML
file, including the description, triggers the issue.

See: https://github.com/electron-userland/electron-builder/issues/517
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>