### PR TITLE
chore: re-organize package.json in a way similar to electron-builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ BUILD_OUTPUT_DIRECTORY = $(BUILD_DIRECTORY)/out
 
 ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron"]' package.json)
 NODE_VERSION = 6.1.0
-COMPANY_NAME = $(shell jq -r '.companyName' package.json)
-APPLICATION_NAME = $(shell jq -r '.displayName' package.json)
+COMPANY_NAME = Resinio Ltd
+APPLICATION_NAME = $(shell jq -r '.build.productName' package.json)
 APPLICATION_DESCRIPTION = $(shell jq -r '.description' package.json)
-APPLICATION_COPYRIGHT = $(shell jq -r '.copyright' package.json)
-APPLICATION_CATEGORY = public.app-category.developer-tools
-APPLICATION_BUNDLE_ID = io.resin.etcher
+APPLICATION_COPYRIGHT = $(shell jq -r '.build.copyright' package.json)
+APPLICATION_CATEGORY = $(shell jq -r '.build.mac.category' package.json)
+APPLICATION_BUNDLE_ID = $(shell jq -r '.build.appId' package.json)
 APPLICATION_FILES = lib,assets
 
 # Add the current commit to the version if release type is "snapshot"

--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -89,7 +89,7 @@ return permissions.isElevated().then((elevated) => {
     console.log(`Running: ${commandArguments.join(' ')}`);
 
     return permissions.elevateCommand(commandArguments, {
-      applicationName: packageJSON.displayName,
+      applicationName: packageJSON.build.productName,
       environment: {
         ELECTRON_RUN_AS_NODE: 1,
         IPC_SERVER_ID: process.env.IPC_SERVER_ID,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "etcher",
-  "displayName": "Etcher",
   "version": "1.0.0",
   "updates": {
     "sleepDays": 7,
@@ -14,6 +13,14 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:resin-io/etcher.git"
+  },
+  "build": {
+    "appId": "io.resin.etcher",
+    "copyright": "Copyright 2016 Resinio Ltd",
+    "productName": "Etcher",
+    "mac": {
+      "category": "public.app-category.developer-tools"
+    }
   },
   "scripts": {
     "test": "npm run lint && electron-mocha --recursive --renderer tests/gui -R spec && electron-mocha --recursive tests/shared tests/child-writer tests/image-stream -R spec",
@@ -33,8 +40,6 @@
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
-  "copyright": "Copyright 2016 Resinio Ltd",
-  "companyName": "Resinio Ltd",
   "shrinkwrapIgnore": [
     "macos-alias",
     "fs-xattr",


### PR DESCRIPTION
This commit re-organizes various metadata properties in package.json so
that the structure better matches what `electron-builder` expects, to
ease the transition.

- Move `.companyName` to the Makefile (we don't need this in
  package.json)
- Move `.displayName` to `.build.productName`
- Move `.copyright` to `.build.copyright`
- Move category to `.build.mac.category`
- Move bundle id to `.build.appId`

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>