### PR TITLE
chore: move npm targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Build configuration
 # ---------------------------------------------------------------------
 
+NODE_MODULES_BIN=./node_modules/.bin
+
 # This directory will be completely deleted by the `clean` rule
 BUILD_DIRECTORY ?= release
 
@@ -170,6 +172,9 @@ define execute-command
 	$(1)
 
 endef
+
+CHANGELOG.md:
+	$(NODE_MODULES_BIN)/versionist
 
 $(BUILD_DIRECTORY):
 	mkdir $@
@@ -426,6 +431,15 @@ $(BUILD_OUTPUT_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(TARGE
 TARGETS = \
 	help \
 	info \
+	lint \
+	lint-js \
+	lint-sass \
+	lint-cpp \
+	lint-html \
+	lint-spell \
+	test-gui \
+	test-sdk \
+	test \
 	sanity-checks \
 	clean \
 	distclean \
@@ -531,6 +545,41 @@ electron-develop:
 		-v "$(ELECTRON_VERSION)" \
 		-t electron \
 		-s "$(TARGET_PLATFORM)"
+
+sass:
+	$(NODE_MODULES_BIN)/node-sass ./lib/gui/scss/main.scss > ./lib/gui/css/main.css
+
+lint-js:
+	$(NODE_MODULES_BIN)/eslint lib tests scripts bin versionist.conf.js
+
+lint-sass:
+	$(NODE_MODULES_BIN)/sass-lint lib/gui/scss
+
+lint-cpp:
+	cpplint --recursive src
+
+lint-html:
+	node scripts/html-lint.js
+
+lint-spell:
+	codespell.py \
+		--skip *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,*.rpi-sdcard,.DS_Store \
+		lib tests docs scripts Makefile *.md LICENSE
+
+lint: lint-js lint-sass lint-cpp lint-html lint-spell
+
+ELECTRON_MOCHA_OPTIONS=--recursive --reporter spec
+
+test-gui:
+	$(NODE_MODULES_BIN)/electron-mocha $(ELECTRON_MOCHA_OPTIONS) --renderer tests/gui
+
+test-sdk:
+	$(NODE_MODULES_BIN)/electron-mocha $(ELECTRON_MOCHA_OPTIONS) \
+		tests/shared \
+		tests/child-writer \
+		tests/image-stream
+
+test: test-gui test-sdk
 
 help:
 	@echo "Available targets: $(TARGETS)"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,10 +18,10 @@ See the [RUNNING-LOCALLY.md][RUNNING-LOCALLY] guide.
 Developing
 ----------
 
-We rely on various `npm` scripts to perform some common tasks:
+We rely on various `make` targets to perform some common tasks:
 
-- `npm run lint`: Run the linter.
-- `npm run sass`: Compile SCSS files.
+- `make lint`: Run the linter.
+- `make sass`: Compile SCSS files.
 
 We make use of [EditorConfig] to communicate indentation, line endings and
 other text editing default. We encourage you to install the relevant plugin in

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -13,7 +13,7 @@ Preparing a new version
 
 - Bump the version number in the `npm-shrinkwrap.json`'s `version` property.
 
-- Add a new entry to `CHANGELOG.md` by running `npm run changelog`.
+- Add a new entry to `CHANGELOG.md` by running `make CHANGELOG.md`.
 
 - Re-take `screenshot.png` so it displays the latest version in the bottom
 right corner.

--- a/package.json
+++ b/package.json
@@ -16,15 +16,7 @@
     "url": "git@github.com:resin-io/etcher.git"
   },
   "scripts": {
-    "test": "npm run lint && electron-mocha --recursive --renderer tests/gui -R spec && electron-mocha --recursive tests/shared tests/child-writer tests/image-stream -R spec",
-    "sass": "node-sass ./lib/gui/scss/main.scss > ./lib/gui/css/main.css",
-    "cpplint": "cpplint --recursive src",
-    "jslint": "eslint lib tests scripts bin versionist.conf.js",
-    "sasslint": "sass-lint lib/gui/scss",
-    "htmllint": "node scripts/html-lint.js",
-    "codespell": "codespell.py --skip *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,*.rpi-sdcard,.DS_Store lib tests docs scripts Makefile *.md LICENSE",
-    "lint": "npm run jslint && npm run sasslint && npm run cpplint && npm run codespell && npm run htmllint",
-    "changelog": "versionist",
+    "test": "make test",
     "start": "electron lib/start.js",
     "preshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
     "configure": "node-gyp configure",

--- a/scripts/ci/ensure-staged-sass.sh
+++ b/scripts/ci/ensure-staged-sass.sh
@@ -19,13 +19,13 @@
 set -e
 set -u
 
-npm run sass
+make sass
 
 # From http://stackoverflow.com/a/9393642/1641422
 if [[ -n $(git status -s | grep "\\.css$" || true) ]]; then
   echo "There are unstaged sass changes. Please commit the result of:" 1>&2
   echo ""
-  echo "    npm run sass" 1>&2
+  echo "    make sass" 1>&2
   echo ""
   exit 1
 fi

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -48,11 +48,8 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
   ./scripts/build/docker/run-command.sh \
     -r "$ARGV_ARCHITECTURE" \
     -s "$(pwd)" \
-    -c 'make sanity-checks && xvfb-run --server-args=$XVFB_ARGS npm test'
+    -c 'xvfb-run --server-args=$XVFB_ARGS make lint test sanity-checks'
 else
   ./scripts/build/check-dependency.sh make
-  ./scripts/build/check-dependency.sh npm
-
-  make sanity-checks
-  npm test
+  make lint test sanity-checks
 fi


### PR DESCRIPTION
We currently have various npm script target, and some of them are
getting complex enough that making sense out of them in package.json is
not a trivial task.

This commit moves all npm targets that are not directly recognisable by
npm (like `start`, `test`, `preshrinkwrap`, etc) into the Makefile.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>