### PR TITLE
chore: output build artifacts to dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ node_modules
 bower_components
 
 # Compiled Electron releases
-release/
-etcher-release/
+dist
 
 # Certificates
 *.spc

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------
 
 # This directory will be completely deleted by the `clean` rule
-BUILD_DIRECTORY ?= release
+BUILD_DIRECTORY ?= dist
 
 # See http://stackoverflow.com/a/20763842/1641422
 BUILD_DIRECTORY_PARENT = $(dir $(BUILD_DIRECTORY))

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -71,7 +71,7 @@ employee by asking for it from the relevant people.
 Packaging
 ---------
 
-The resulting installers will be saved to `release/out`.
+The resulting installers will be saved to `dist/out`.
 
 Run the following commands:
 


### PR DESCRIPTION
This is the directory where `electron-builder` will output build
artifacts.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>