### PR TITLE
chore: don't use ./ when generating sass files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ electron-develop:
 		-s "$(TARGET_PLATFORM)"
 
 sass:
-	$(NODE_MODULES_BIN)/node-sass ./lib/gui/scss/main.scss > ./lib/gui/css/main.css
+	$(NODE_MODULES_BIN)/node-sass lib/gui/scss/main.scss > lib/gui/css/main.css
 
 lint-js:
 	$(NODE_MODULES_BIN)/eslint lib tests scripts bin versionist.conf.js


### PR DESCRIPTION
The `./` prefix is unnecessary.

See: https://github.com/resin-io/etcher/pull/1505#pullrequestreview-43444274
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>