### PR TITLE
chore: don't remove optional dependencies in clean-shrinkwrap.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,21 +77,18 @@
   "scripts": {
     "test": "make test",
     "start": "electron lib/start.js",
-    "preshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
+    "postshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
     "configure": "node-gyp configure",
     "build": "node-gyp build",
     "install": "node-gyp rebuild"
   },
   "author": "Resin Inc. <hello@etcher.io>",
   "license": "Apache-2.0",
-  "shrinkwrapIgnore": [
-    "macos-alias",
-    "fs-xattr",
-    "ds-store",
-    "appdmg",
-    "7zip-bin-mac",
-    "7zip-bin-win",
-    "7zip-bin-linux"
+  "platformSpecificDependencies": [
+    "appdmg@0.3.10",
+    "7zip-bin-mac@1.0.1",
+    "7zip-bin-win@2.1.0",
+    "7zip-bin-linux@1.1.0"
   ],
   "dependencies": {
     "angular": "1.6.3",

--- a/scripts/ci/build-installers.sh
+++ b/scripts/ci/build-installers.sh
@@ -48,8 +48,8 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
   ./scripts/build/docker/run-command.sh \
     -r "$TARGET_ARCH" \
     -s "$(pwd)" \
-    -c 'make electron-develop installers-all'
+    -c 'make installers-all'
 else
   ./scripts/build/check-dependency.sh make
-  make electron-develop installers-all
+  make installers-all
 fi

--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -1,43 +1,159 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
- * This script is in charge of generating the `shrinkwrap` file.
- *
- * `npm shrinkwrap` has a bug where it will add optional dependencies
- * to `npm-shrinkwrap.json`, therefore causing errors if these optional
- * dependendencies are platform dependent and you then try to build
- * the project in another platform.
- *
- * As a workaround, we keep a list of platform dependent dependencies in
- * the `shrinkwrapIgnore` property of `package.json`, and manually remove
- * them from `npm-shrinkwrap.json` if they exists.
- *
- * See: https://github.com/npm/npm/issues/2679
+ * This script is in charge of removing platform specific optional
+ * dependencies, and their dependencies from the `shrinkwrap` file.
  */
 
 'use strict';
 
+const _ = require('lodash');
+const fs = require('fs');
 const path = require('path');
-const os = require('os');
-const packageJSON = require('../package.json');
-const spawn = require('child_process').spawn;
-const shrinkwrapIgnore = packageJSON.shrinkwrapIgnore;
+const childProcess = require('child_process');
 
-console.log('Removing:', shrinkwrapIgnore.join(', '));
+const NPM_SHRINKWRAP_FILE_PATH = path.join(__dirname, '..', 'npm-shrinkwrap.json');
+const shrinkwrapFile = require(NPM_SHRINKWRAP_FILE_PATH);
+const platformSpecificDependencies = require('../package.json').platformSpecificDependencies;
 
 /**
- * Run an npm command
- * @param {Array} command - list of arguments
- * @returns {ChildProcess}
+ * @summary Normalize npm qualifiers
+ * @function
+ * @private
+ *
+ * @param {String[]} qualifiers - npm qualifiers
+ * @returns {String[]} normalized qualifiers
+ *
+ * @example
+ * const qualifiers = normalizeNpmQualifiers([ 'drivelist@^5.0.0', 'electron@1.6.6' ]);
+ * console.log(qualifiers);
+ * > [ 'drivelist', 'electron' ]
  */
-const npm = (command) => {
-  const npmBinary = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
-  return spawn(npmBinary, command, {
-    cwd: path.join(__dirname, '..'),
-    env: process.env,
-    stdio: [ process.stdin, process.stdout, process.stderr ]
+const normalizeNpmQualifiers = (qualifiers) => {
+  return _.map(qualifiers, (qualifier) => {
+    return _.first(_.split(qualifier, '@'));
   });
 };
 
-npm([ 'rm', '--ignore-scripts' ].concat(shrinkwrapIgnore))
-  .once('close', () => {
-    console.log('Done.');
+/**
+ * @summary Get the top level dependencies of a certain npm specifier
+ * @function
+ * @private
+ *
+ * @param {String} specifier - npm specifier
+ * @returns {String[]} top level dependencies
+ *
+ * @example
+ * const dependencies = getTopLevelDependencies('drivelist@^5.0.0');
+ */
+const getTopLevelDependencies = _.memoize((specifier) => {
+  const json = childProcess.execSync(`npm view --json ${specifier} dependencies`, {
+    encoding: 'utf8'
   });
+
+  if (!json) {
+    return [];
+  }
+
+  const data = JSON.parse(json);
+  const dependencies = _.isPlainObject(data) ? _.toPairs(data) : _.flatMap(data, _.toPairs);
+  return _.uniq(_.map(dependencies, ([ name, version ]) => {
+    return `${name}@${version}`;
+  }));
+});
+
+/**
+ * @summary Recursively fetch the dependency tree of an npm specifier
+ * @function
+ * @private
+ *
+ * @param {String} specifier - npm specifier
+ * @returns {String[]} all dependencies
+ *
+ * @example
+ * const dependencies = getNormalizedDependencyTree('drivelist@^5.0.0');
+ */
+const getNormalizedDependencyTree = (specifier) => {
+  const topLevelDependencies = getTopLevelDependencies(specifier);
+  const nestedDependencies = _.flatMapDeep(topLevelDependencies, getNormalizedDependencyTree);
+  return _.uniq(_.concat(normalizeNpmQualifiers(topLevelDependencies), nestedDependencies));
+};
+
+/**
+ * @summary Remove certain dependencies from a shrinkwrap object
+ * @function
+ * @private
+ *
+ * @description
+ * A shrinkwrap object is a recursive data structure, that apart
+ * from some extra metadata, has the following structure:
+ *
+ * {
+ *   ...
+ *   "dependencies": {
+ *     "<dependency_name>": <recursive definition>,
+ *     "<dependency_name>": <recursive definition>,
+ *     "<dependency_name>": <recursive definition>,
+ *     ...
+ *   }
+ * }
+ *
+ * The purpose of this function is to remove certain dependencies
+ * that match a blacklist. In order to do so, we start from the top
+ * level object, remove the blacklisted dependencies, and recurse
+ * if possible.
+ *
+ * @param {Object} object - shrinkwrap object
+ * @param {String[]} blacklist - list of blacklist
+ * @param {Object} qualifiers - qualifiers
+ * @param {Boolean} qualifiers.dev - development dependency
+ * @param {Boolean} qualifiers.optional - optional dependency
+ * @returns {Object} filtered shrinkwrap object
+ */
+const removeDependencies = (object, blacklist, qualifiers) => {
+  if (!_.isEmpty(object.dependencies)) {
+    object.dependencies = _.chain(object.dependencies)
+      .omitBy((dependency, name) => {
+        return _.every([
+          _.includes(blacklist, name),
+          dependency.dev === qualifiers.dev,
+          dependency.optional === qualifiers.optional
+        ]);
+      })
+      .mapValues((dependency) => {
+        return removeDependencies(dependency, blacklist, qualifiers);
+      })
+      .value();
+  }
+
+  return object;
+};
+
+console.log(`Fetching dependency tree for ${_.join(platformSpecificDependencies, ', ')} (this may take a couple of minutes)`);
+const blacklist = _.uniq(normalizeNpmQualifiers(
+  _.concat(platformSpecificDependencies,
+  _.flatMap(platformSpecificDependencies, getNormalizedDependencyTree))));
+console.log(`Attempting to remove: ${_.join(blacklist, ', ')}`);
+
+const JSON_INDENTATION_SPACES = 2;
+const result = JSON.stringify(removeDependencies(shrinkwrapFile, blacklist, {
+  dev: true,
+  optional: true
+}), null, JSON_INDENTATION_SPACES);
+
+fs.writeFileSync(NPM_SHRINKWRAP_FILE_PATH, `${result}\n`);
+console.log('Done');


### PR DESCRIPTION
If we include a platform specific optional dependency in the shrinkwrap
file, then npm will insist in installing it even if the platform doesn't
match. As a solution, we figured out we can avoid putting this platform
specific optional dependencies in the npm-shrinkwrap.json file.

In order to do this, we currently have a script called
`clean-shrinkwrap.js` that runs *before* any `npm shrinkwrap` file (its
a `preshrinkwrap` npm script) that deletes all the platform specific
modules we know about using `npm rm`.

The problem with this approach is that `npm rm` will remove the module's
code from `node_modules`, which means that if we run `npm shrinkwrap`,
we will lose certain optional dependencies, that may be needed at a
later stage.

The solution is to modify the `clean-shrinkwrap.js` script to parse
`npm-shrinkwrap.json`, and manually delete the entries that we want to
omit. Also, the script needs to be run *after* `npm shrinkwrap`, so we
change the npm script name to `postshrinkwrap`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>