### PR TITLE
chore: move `mkdir` call from node-package-cli.sh to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(TARGET_PLATF
 	$(BUILD_DIRECTORY)/node-$(TARGET_PLATFORM)-$(TARGET_ARCH)-dependencies \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(TARGET_PLATFORM)-$(APPLICATION_VERSION)-$(TARGET_ARCH).js \
 	| $(BUILD_DIRECTORY) $(BUILD_TEMPORARY_DIRECTORY)
+	mkdir $@
 	./scripts/build/node-package-cli.sh -o $@ -l $</node_modules \
 		-n $(APPLICATION_NAME) \
 		-e $(word 2,$^) \

--- a/scripts/build/node-package-cli.sh
+++ b/scripts/build/node-package-cli.sh
@@ -61,7 +61,6 @@ if [ -z "$ARGV_APPLICATION_NAME" ] \
   usage
 fi
 
-mkdir "$ARGV_OUTPUT"
 cp "$ARGV_ENTRY_POINT" "$ARGV_OUTPUT/index.js"
 
 ./scripts/build/dependencies-npm-extract-addons.sh \


### PR DESCRIPTION
This makes it more consistent with the other Makefile rules