### PR TITLE
chore(travis): remove unused afsctool macOS dependency

### DIFF
--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -43,7 +43,6 @@ The following MinGW packages are required:
 ### OS X
 
 - [XCode](https://developer.apple.com/xcode/)
-- [afsctool](https://brkirch.wordpress.com/afsctool/)
 
 Cloning the project
 -------------------

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -52,7 +52,7 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
 else
   if [ "$ARGV_OPERATING_SYSTEM" == "darwin" ]; then
     ./scripts/build/check-dependency.sh brew
-    brew install afsctool jq
+    brew install jq
   elif [ "$ARGV_OPERATING_SYSTEM" == "win32" ]; then
     ./scripts/build/check-dependency.sh choco
     choco install nsis -version 2.51


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>