### PR TITLE
feat(GUI): swap progress bar speed and time

### DIFF
--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -95,8 +95,8 @@
         </progress-button>
 
         <p class="step-footer step-footer-split" ng-show="main.state.getFlashState().speed && main.state.getFlashState().percentage != 100">
-          <span>ETA: {{ main.state.getFlashState().eta | secondsToDate | amDateFormat:'m[m]ss[s]' }}</span>
           <span ng-bind="main.state.getFlashState().speed.toFixed(2) + ' MB/s'"></span>
+          <span>ETA: {{ main.state.getFlashState().eta | secondsToDate | amDateFormat:'m[m]ss[s]' }}</span>
         </p>
       </div>
     </div>


### PR DESCRIPTION
We swap the placement of the progress speed and time residing below the
progress bar.

Changelog-Entry: Swap speed and time below the progress bar.
Closes: https://github.com/resin-io/etcher/issues/1312