### PR TITLE
chore: don't extract native dependencies out of the asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,6 @@
       "assets/icon.png",
       "node_modules/**/*"
     ],
-    "asar": {
-      "smartUnpack": false
-    },
-    "asarUnpack": [
-      "**/*.dll",
-      "**/*.node"
-    ],
     "mac": {
       "icon": "assets/icon.icns",
       "artifactName": "${productName}-${version}-darwin-${env.TARGET_ARCH}.${ext}",


### PR DESCRIPTION
Turns out add-ons are loaded just fine from the asar now.

See: https://github.com/electron-userland/electron-builder/issues/1723
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>