### PR TITLE
chore: move all electron-builder configuration to electron-builder.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ BUILD_OUTPUT_DIRECTORY = $(BUILD_DIRECTORY)/out
 ELECTRON_VERSION = $(shell jq -r '.devDependencies["electron"]' package.json)
 NODE_VERSION = 6.1.0
 COMPANY_NAME = Resinio Ltd
-APPLICATION_NAME = $(shell jq -r '.build.productName' package.json)
+APPLICATION_NAME = $(shell jq -r '.displayName' package.json)
 APPLICATION_DESCRIPTION = $(shell jq -r '.description' package.json)
-APPLICATION_COPYRIGHT = $(shell jq -r '.build.copyright' package.json)
+APPLICATION_COPYRIGHT = $(shell cat electron-builder.yml | shyaml get-value copyright)
 
 # ---------------------------------------------------------------------
 # Release type

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,93 @@
+appId: io.resin.etcher
+copyright: Copyright 2016 Resinio Ltd
+productName: Etcher
+npmRebuild: true
+nodeGypRebuild: true
+publish: null
+files:
+  - lib
+  - assets/icon.png
+  - node_modules/**/*
+mac:
+  icon: assets/icon.icns
+  artifactName: "${productName}-${version}-darwin-${env.TARGET_ARCH}.${ext}"
+  category: public.app-category.developer-tools
+dmg:
+  background: assets/osx/installer.tiff
+  icon: assets/icon.icns
+  iconSize: 110
+  contents:
+    - x: 140
+      y: 225
+    - x: 415
+      y: 225
+      type: link
+      path: /Applications
+  window:
+    width: 540
+    height: 405
+win:
+  icon: assets/icon.ico
+nsis:
+  oneClick: false
+  allowToChangeInstallationDirectory: true
+  runAfterFinish: true
+  installerIcon: assets/icon.ico
+  uninstallerIcon: assets/icon.ico
+  deleteAppDataOnUninstall: true
+  license: LICENSE
+  artifactName: "${productName}-${version}-win32-${env.TARGET_ARCH}.${ext}"
+portable:
+  artifactName: "${productName}-${version}-win32-${env.TARGET_ARCH}-portable.${ext}"
+  requestExecutionLevel: user
+linux:
+  category: Utility
+  packageCategory: utils
+  executableName: etcher-electron
+  synopsis: Etcher is a powerful OS image flasher built with web technologies to ensure flashing an SDCard or USB drive is a pleasant and safe experience. It protects you from accidentally writing to your hard-drives, ensures every byte of data was written correctly and much more.
+deb:
+  icon: assets/icon.png
+  priority: optional
+  depends:
+    - gconf2
+    - gconf-service
+    - libappindicator1
+    - libasound2
+    - libatk1.0-0
+    - libc6
+    - libcairo2
+    - libcups2
+    - libdbus-1-3
+    - libexpat1
+    - libfontconfig1
+    - libfreetype6
+    - libgcc1
+    - libgconf-2-4
+    - libgdk-pixbuf2.0-0
+    - libglib2.0-0
+    - libgtk2.0-0
+    - liblzma5
+    - libnotify4
+    - libnspr4
+    - libnss3
+    - libpango1.0-0
+    - libstdc++6
+    - libx11-6
+    - libxcomposite1
+    - libxcursor1
+    - libxdamage1
+    - libxext6
+    - libxfixes3
+    - libxi6
+    - libxrandr2
+    - libxrender1
+    - libxss1
+    - libxtst6
+    - polkit-1-auth-agent | policykit-1-gnome | polkit-kde-1
+rpm:
+  icon: assets/icon.png
+  depends:
+    - lsb
+    - libXScrnSaver
+appimage:
+  icon: assets/icon.png

--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -89,7 +89,7 @@ return permissions.isElevated().then((elevated) => {
     console.log(`Running: ${commandArguments.join(' ')}`);
 
     return permissions.elevateCommand(commandArguments, {
-      applicationName: packageJSON.build.productName,
+      applicationName: packageJSON.displayName,
       environment: {
         ELECTRON_RUN_AS_NODE: 1,
         IPC_SERVER_ID: process.env.IPC_SERVER_ID,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "etcher",
+  "displayName": "Etcher",
   "version": "1.0.0",
   "updates": {
     "enabled": true,
@@ -14,119 +15,6 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:resin-io/etcher.git"
-  },
-  "build": {
-    "appId": "io.resin.etcher",
-    "copyright": "Copyright 2016 Resinio Ltd",
-    "productName": "Etcher",
-    "npmRebuild": true,
-    "nodeGypRebuild": true,
-    "publish": null,
-    "files": [
-      "lib",
-      "assets/icon.png",
-      "node_modules/**/*"
-    ],
-    "mac": {
-      "icon": "assets/icon.icns",
-      "artifactName": "${productName}-${version}-darwin-${env.TARGET_ARCH}.${ext}",
-      "category": "public.app-category.developer-tools"
-    },
-    "dmg": {
-      "background": "assets/osx/installer.tiff",
-      "icon": "assets/icon.icns",
-      "iconSize": 110,
-      "contents": [
-        {
-          "x": 140,
-          "y": 225
-        },
-        {
-          "x": 415,
-          "y": 225,
-          "type": "link",
-          "path": "/Applications"
-        }
-      ],
-      "window": {
-        "width": 540,
-        "height": 405
-      }
-    },
-    "win": {
-      "icon": "assets/icon.ico"
-    },
-    "nsis": {
-      "oneClick": false,
-      "allowToChangeInstallationDirectory": true,
-      "runAfterFinish": true,
-      "installerIcon": "assets/icon.ico",
-      "uninstallerIcon": "assets/icon.ico",
-      "deleteAppDataOnUninstall": true,
-      "license": "LICENSE",
-      "artifactName": "${productName}-${version}-win32-${env.TARGET_ARCH}.${ext}"
-    },
-    "portable": {
-      "artifactName": "${productName}-${version}-win32-${env.TARGET_ARCH}-portable.${ext}",
-      "requestExecutionLevel": "user"
-    },
-    "linux": {
-      "category": "Utility",
-      "packageCategory": "utils",
-      "executableName": "etcher-electron",
-      "synopsis": "Etcher is a powerful OS image flasher built with web technologies to ensure flashing an SDCard or USB drive is a pleasant and safe experience. It protects you from accidentally writing to your hard-drives, ensures every byte of data was written correctly and much more."
-    },
-    "deb": {
-      "icon": "assets/icon.png",
-      "priority": "optional",
-      "depends": [
-        "gconf2",
-        "gconf-service",
-        "libappindicator1",
-        "libasound2",
-        "libatk1.0-0",
-        "libc6",
-        "libcairo2",
-        "libcups2",
-        "libdbus-1-3",
-        "libexpat1",
-        "libfontconfig1",
-        "libfreetype6",
-        "libgcc1",
-        "libgconf-2-4",
-        "libgdk-pixbuf2.0-0",
-        "libglib2.0-0",
-        "libgtk2.0-0",
-        "liblzma5",
-        "libnotify4",
-        "libnspr4",
-        "libnss3",
-        "libpango1.0-0",
-        "libstdc++6",
-        "libx11-6",
-        "libxcomposite1",
-        "libxcursor1",
-        "libxdamage1",
-        "libxext6",
-        "libxfixes3",
-        "libxi6",
-        "libxrandr2",
-        "libxrender1",
-        "libxss1",
-        "libxtst6",
-        "polkit-1-auth-agent | policykit-1-gnome | polkit-kde-1"
-      ]
-    },
-    "rpm": {
-      "icon": "assets/icon.png",
-      "depends": [
-        "lsb",
-        "libXScrnSaver"
-      ]
-    },
-    "appimage": {
-      "icon": "assets/icon.png"
-    }
   },
   "scripts": {
     "test": "make test",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 codespell==1.9.2
 cpplint==1.3.0
 awscli==1.11.87
+shyaml==0.5.0


### PR DESCRIPTION
The electron-builder configuration we're putting in package.json is
growing. To make it easier to read and edit, we'll move the whole
`build` property into a configuration file called
`electron-builder.yml`.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>