### PR TITLE
chore: increase npm retries and max timeout

### DIFF
--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -101,7 +101,7 @@ function run_install() {
   # since compiled add-ons will not work otherwise.
   npm rebuild
 
-  npm install $INSTALL_OPTS
+  npm install $INSTALL_OPTS --fetch-retries 10 --fetch-retry-maxtimeout 180000
 
   if [ "$ARGV_PRODUCTION" == "true" ]; then
 


### PR DESCRIPTION
CI servers fail with timeouts, or network issues quite frequently,
requiring maintainers to manually restart failed builds.

Hopefully these npm settings will help mitigating these issues.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>