### PR TITLE
chore(ci): Enable node_modules & ccache caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 node_js:
   - "6.10.3"
 
+cache:
+  ccache: true
+  directories:
+    - node_modules
+
 services:
   - docker
 
@@ -34,6 +39,7 @@ os:
   - osx
 
 before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export HOST_OS="darwin";
     else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ image: Visual Studio 2015
 cache:
   - C:\Users\appveyor\.node-gyp
   - '%AppData%\npm-cache'
+  - node_modules
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - C:\Users\appveyor\AppData\Local\Temp\chocolatey -> appveyor.yml

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -52,7 +52,7 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
 else
   if [ "$ARGV_OPERATING_SYSTEM" == "darwin" ]; then
     ./scripts/build/check-dependency.sh brew
-    brew install jq
+    brew install ccache jq
   elif [ "$ARGV_OPERATING_SYSTEM" == "win32" ]; then
     ./scripts/build/check-dependency.sh choco
     choco install nsis -version 2.51


### PR DESCRIPTION
This enables caching of `node_modules`, and `ccache` directories,
as well as installation of ccache on Mac OS.

Change-Type: patch