### PR TITLE
chore(scripts): Make npm output less verbose

### DIFF
--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -99,9 +99,9 @@ function run_install() {
 
   # When changing between target architectures, rebuild all dependencies,
   # since compiled add-ons will not work otherwise.
-  npm rebuild
+  npm rebuild --silent
 
-  npm install $INSTALL_OPTS --fetch-retries 10 --fetch-retry-maxtimeout 180000
+  npm install --silent $INSTALL_OPTS --fetch-retries 10 --fetch-retry-maxtimeout 180000
 
   if [ "$ARGV_PRODUCTION" == "true" ]; then
 

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -68,7 +68,8 @@ else
   ./scripts/build/check-dependency.sh make
 
   npm config set spin=false
-  npm install -g uglify-es@3.0.3
+  npm config set progress=false
+  npm install -g --silent uglify-es@3.0.3
   pip install -r requirements.txt
 
   make info


### PR DESCRIPTION
This adds the `--silent` flag to several npm commands,
ideally making the output less verbose, for better overview in CI logs.

Change-Type: patch