### PR TITLE
feat(GUI): add webview api version parameter

### DIFF
--- a/lib/gui/components/safe-webview.js
+++ b/lib/gui/components/safe-webview.js
@@ -46,6 +46,22 @@ const VERSION_PARAM = 'etcher-version';
 const ELECTRON_SESSION = 'persist:success-banner';
 
 /**
+ * @summary API version search parameter key
+ * @constant
+ * @private
+ * @type {String}
+ */
+const API_VERSION_PARAM = 'api-version';
+
+/**
+ * @summary Webview API version
+ * @constant
+ * @private
+ * @type {String}
+ */
+const API_VERSION = 1;
+
+/**
  * @summary Webviews that hide/show depending on the HTTP status returned
  * @type {Object}
  * @public
@@ -69,6 +85,7 @@ class SafeWebview extends react.PureComponent {
 
     // We set the version GET parameter here.
     url.searchParams.set(VERSION_PARAM, packageJSON.version);
+    url.searchParams.set(API_VERSION_PARAM, API_VERSION);
 
     this.entryHref = url.href;
 

--- a/lib/gui/components/safe-webview.js
+++ b/lib/gui/components/safe-webview.js
@@ -30,14 +30,6 @@ const MODULE_NAME = 'Etcher.Components.SafeWebview';
 const angularSafeWebview = angular.module(MODULE_NAME, []);
 
 /**
- * @summary GET parameter sent to the initial webview source URL
- * @constant
- * @private
- * @type {String}
- */
-const ETCHER_VERSION_PARAM = 'etcher-version';
-
-/**
  * @summary Electron session identifier
  * @constant
  * @private
@@ -46,7 +38,15 @@ const ETCHER_VERSION_PARAM = 'etcher-version';
 const ELECTRON_SESSION = 'persist:success-banner';
 
 /**
- * @summary API version search parameter key
+ * @summary Etcher version search-parameter key
+ * @constant
+ * @private
+ * @type {String}
+ */
+const ETCHER_VERSION_PARAM = 'etcher-version';
+
+/**
+ * @summary API version search-parameter key
  * @constant
  * @private
  * @type {String}

--- a/lib/gui/components/safe-webview.js
+++ b/lib/gui/components/safe-webview.js
@@ -35,7 +35,7 @@ const angularSafeWebview = angular.module(MODULE_NAME, []);
  * @private
  * @type {String}
  */
-const VERSION_PARAM = 'etcher-version';
+const ETCHER_VERSION_PARAM = 'etcher-version';
 
 /**
  * @summary Electron session identifier
@@ -58,6 +58,12 @@ const API_VERSION_PARAM = 'api-version';
  * @constant
  * @private
  * @type {String}
+ *
+ * @description
+ * Changing this number represents a departure from an older API and as such
+ * should only be changed when truly necessary as it introduces breaking changes.
+ * This version number is exposed to the banner such that it can determine what
+ * features are safe to utilize.
  */
 const API_VERSION = 1;
 
@@ -83,8 +89,8 @@ class SafeWebview extends react.PureComponent {
 
     const url = new URL(props.src);
 
-    // We set the version GET parameter here.
-    url.searchParams.set(VERSION_PARAM, packageJSON.version);
+    // We set the version GET parameters here.
+    url.searchParams.set(ETCHER_VERSION_PARAM, packageJSON.version);
     url.searchParams.set(API_VERSION_PARAM, API_VERSION);
 
     this.entryHref = url.href;


### PR DESCRIPTION
We add the API version sent to the banner via a GET search parameter,
allowing for more intricate control over what data needs or can be sent.

Changelog-Entry: Add Webview API version parameter.