### PR TITLE
chore:(windows): make use of NSIS one-click installers

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,8 +29,7 @@ dmg:
 win:
   icon: assets/icon.ico
 nsis:
-  oneClick: false
-  allowToChangeInstallationDirectory: true
+  oneClick: true
   runAfterFinish: true
   installerIcon: assets/icon.ico
   uninstallerIcon: assets/icon.ico


### PR DESCRIPTION
One-click installers are a "modern" version of usual wizard installers,
and somewhat resemble the Squirrel.Windows installers you can see in
apps like Atom.

As the name implies, the user needs to agree the license, and that's
all, the remaining installer is non-interactive, leading to a very
smooth user experience.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>