### PR TITLE
chore(package): Disable node_modules caching on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
 
 cache:
   ccache: true
-  directories:
-    - node_modules
 
 services:
   - docker


### PR DESCRIPTION
This disabled caching of the `node_modules` directory again,
as this is causing failures on Travis CI while building the installers.

Change-Type: patch
Connects To: #1553 