### PR TITLE
chore: pipe stdout from npm ls to /dev/null

### DIFF
--- a/scripts/ci/ensure-npm-valid-dependencies.sh
+++ b/scripts/ci/ensure-npm-valid-dependencies.sh
@@ -22,4 +22,4 @@ set -e
 # This command will exit with an error code if there
 # are invalid or extraneous dependencies, printing the
 # problematic ones if so.
-npm ls
+npm ls >/dev/null


### PR DESCRIPTION
As part of our CI sanity checks, we run `npm ls`, to ensure we don't
have any extraneous dependencies (the command fails if so), however by
its own definition, `npm ls` prints the whole dependency tree, which
spams the builds.

This commit redirects stdout to /dev/null, which contains the dependency
tree, but still prints and extraneous dependency warning, which is
printed to stderr instead.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>