### PR TITLE
chore(scripts): Silence stdout for npm install

### DIFF
--- a/scripts/build/dependencies-npm.sh
+++ b/scripts/build/dependencies-npm.sh
@@ -99,9 +99,9 @@ function run_install() {
 
   # When changing between target architectures, rebuild all dependencies,
   # since compiled add-ons will not work otherwise.
-  npm rebuild --silent
+  npm rebuild --silent > /dev/null
 
-  npm install --silent $INSTALL_OPTS
+  npm install --silent $INSTALL_OPTS > /dev/null
 
   if [ "$ARGV_PRODUCTION" == "true" ]; then
 

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -69,7 +69,7 @@ else
 
   npm config set spin=false
   npm config set progress=false
-  npm install -g --silent uglify-es@3.0.3
+  npm install -g --silent uglify-es@3.0.3 > /dev/null
   pip install -r requirements.txt
 
   make info


### PR DESCRIPTION
This silences `npm install`'s stdout to omit noisy output, and only show warnings & errors

Change-Type: patch