### PR TITLE
chore: send analytics about package types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,12 +289,14 @@ assets/osx/installer.tiff: assets/osx/installer.png assets/osx/installer@2x.png
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-darwin-$(TARGET_ARCH).dmg: assets/osx/installer.tiff \
 	| $(BUILD_DIRECTORY)
 	TARGET_ARCH=$(TARGET_ARCH) $(NPX) build --mac dmg $(ELECTRON_BUILDER_OPTIONS) \
-		 --extraMetadata.version=$(APPLICATION_VERSION)
+		--extraMetadata.version=$(APPLICATION_VERSION) \
+		--extraMetadata.packageType=dmg
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-darwin-$(TARGET_ARCH).zip: assets/osx/installer.tiff \
 	| $(BUILD_DIRECTORY)
 	TARGET_ARCH=$(TARGET_ARCH) $(NPX) build --mac zip $(ELECTRON_BUILDER_OPTIONS) \
-		 --extraMetadata.version=$(APPLICATION_VERSION)
+		--extraMetadata.version=$(APPLICATION_VERSION) \
+		--extraMetadata.packageType=zip
 
 APPLICATION_NAME_ELECTRON = $(APPLICATION_NAME_LOWERCASE)-electron
 
@@ -303,6 +305,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME_ELECTRON)-$(APPLICATION_VERSION_REDHAT).$(
 	$(NPX) build --linux rpm $(ELECTRON_BUILDER_OPTIONS) \
 		--extraMetadata.name=$(APPLICATION_NAME_ELECTRON) \
 		--extraMetadata.version=$(APPLICATION_VERSION_REDHAT) \
+		--extraMetadata.packageType=rpm \
 		$(DISABLE_UPDATES_ELECTRON_BUILDER_OPTIONS)
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME_ELECTRON)_$(APPLICATION_VERSION_DEBIAN)_$(TARGET_ARCH_DEBIAN).deb: \
@@ -310,12 +313,14 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME_ELECTRON)_$(APPLICATION_VERSION_DEBIAN)_$(
 	$(NPX) build --linux deb $(ELECTRON_BUILDER_OPTIONS) \
 		--extraMetadata.name=$(APPLICATION_NAME_ELECTRON) \
 		--extraMetadata.version=$(APPLICATION_VERSION_DEBIAN) \
+		--extraMetadata.packageType=deb \
 		$(DISABLE_UPDATES_ELECTRON_BUILDER_OPTIONS)
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-$(APPLICATION_VERSION)-$(TARGET_ARCH_APPIMAGE).AppImage: \
 	| $(BUILD_DIRECTORY)
 	$(NPX) build --linux AppImage $(ELECTRON_BUILDER_OPTIONS) \
-		 --extraMetadata.version=$(APPLICATION_VERSION)
+		--extraMetadata.version=$(APPLICATION_VERSION) \
+		--extraMetadata.packageType=AppImage
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-$(APPLICATION_VERSION)-linux-$(TARGET_ARCH).zip: \
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-$(APPLICATION_VERSION)-$(TARGET_ARCH_APPIMAGE).AppImage \
@@ -325,12 +330,14 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME_LOWERCASE)-$(APPLICATION_VERSION)-linux-$(
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-win32-$(TARGET_ARCH)-portable.exe: \
 	| $(BUILD_DIRECTORY)
 	TARGET_ARCH=$(TARGET_ARCH) $(NPX) build --win portable $(ELECTRON_BUILDER_OPTIONS) \
-		 --extraMetadata.version=$(APPLICATION_VERSION)
+		--extraMetadata.version=$(APPLICATION_VERSION) \
+		--extraMetadata.packageType=portable
 
 $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-$(APPLICATION_VERSION)-win32-$(TARGET_ARCH).exe: \
 	| $(BUILD_DIRECTORY)
 	TARGET_ARCH=$(TARGET_ARCH) $(NPX) build --win nsis $(ELECTRON_BUILDER_OPTIONS) \
-		 --extraMetadata.version=$(APPLICATION_VERSION)
+		--extraMetadata.version=$(APPLICATION_VERSION) \
+		--extraMetadata.packageType=nsis
 
 # ---------------------------------------------------------------------
 # Phony targets

--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -79,17 +79,24 @@ app.run(() => {
     '\\____/ \\__\\___|_| |_|\\___|_|',
     '',
     'Interested in joining the Etcher team?',
-    'Drop us a line at join+etcher@resin.io'
+    'Drop us a line at join+etcher@resin.io',
+    '',
+    `Version = ${packageJSON.version}, Type = ${packageJSON.packageType}`
   ].join('\n'));
 });
 
 app.run(() => {
-  analytics.logEvent('Application start');
+  const currentVersion = packageJSON.version;
+
+  analytics.logEvent('Application start', {
+    packageType: packageJSON.packageType,
+    version: currentVersion
+  });
+
   settings.load();
 
-  const currentVersion = packageJSON.version;
   const shouldCheckForUpdates = updateNotifier.shouldCheckForUpdates({
-    currentVersion: packageJSON.version,
+    currentVersion,
     lastSleptUpdateNotifier: settings.get('lastSleptUpdateNotifier'),
     lastSleptUpdateNotifierVersion: settings.get('lastSleptUpdateNotifierVersion')
   });

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "etcher",
   "displayName": "Etcher",
   "version": "1.0.0",
+  "packageType": "local",
   "updates": {
     "enabled": true,
     "sleepDays": 7,


### PR DESCRIPTION
This commit adds a `packageType` property to package.json, which is set
according to the package type of the Etcher target (e.g: dmg, nsis, deb,
etc).

This information is then sent to Mixpanel as the `packageType` property
of the "Application start" event.

Change-Type: patch
Changelog-Entry: Send anonymous analytics about package types.
Fixes: https://github.com/resin-io/etcher/issues/1328
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>