### PR TITLE
fix(gui): Fix image checks in image selections

### DIFF
--- a/lib/gui/pages/main/controllers/image-selection.js
+++ b/lib/gui/pages/main/controllers/image-selection.js
@@ -83,10 +83,10 @@ module.exports = function(
     Bluebird.try(() => {
       let message = null;
 
-      if (supportedFormats.looksLikeWindowsImage(image)) {
+      if (supportedFormats.looksLikeWindowsImage(image.path)) {
         analytics.logEvent('Possibly Windows image', image);
         message = messages.warning.looksLikeWindowsImage();
-      } else if (supportedFormats.missingPartitionTable(image)) {
+      } else if (!image.hasMBR) {
         analytics.logEvent('Missing partition table', image);
         message = messages.warning.missingPartitionTable();
       }


### PR DESCRIPTION
I must have screwed something up during a rebase,
this mends the partition table an windows image checks.

Change-Type: patch