### PR TITLE
upgrade: drivelist to v5.0.25

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -22,6 +22,10 @@ const path = require('path');
 const EXIT_CODES = require('../shared/exit-codes');
 let mainWindow = null;
 
+// Enable drivelist debugging information
+// See https://github.com/resin-io-modules/drivelist
+process.env.DRIVELIST_DEBUG = 1;
+
 electron.app.on('window-all-closed', electron.app.quit);
 
 // Sending a `SIGINT` (e.g: Ctrl-C) to an Electron app that registers

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1513,19 +1513,19 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.0.22",
-      "from": "drivelist@5.0.22",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.22.tgz",
+      "version": "5.0.25",
+      "from": "drivelist@5.0.25",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.25.tgz",
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "from": "bluebird@>=3.5.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
-        },
         "lodash": {
           "version": "4.17.4",
           "from": "lodash@>=4.16.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "nan": {
+          "version": "2.6.2",
+          "from": "nan@>=2.6.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bootstrap-sass": "3.3.6",
     "chalk": "1.1.3",
     "command-join": "2.0.0",
-    "drivelist": "5.0.22",
+    "drivelist": "5.0.25",
     "electron-is-running-in-asar": "1.0.0",
     "etcher-image-write": "9.1.3",
     "file-type": "4.1.0",


### PR DESCRIPTION
This version contains various improvements on the drive detection system
mainly on Windows. The improvements can be summarized as follows:

- Drivelist no longer spawns a .bat script to perform its job. This
  means that a lot of spawning related issues are now fixed

- Drivelist doesn't fetch drive sizes from WMI anymore, which was known
  to incorrectly report a very small size for certain drives, causing
  the famous "0.0 GB" Windows issues (see
  resin-io-modules/drivelist#142)

- Cleanup temporary scripts after execution

This PR also sets the DRIVELIST_DEBUG environment variable to enable
debug information from Windows' drivelist implementation.

Change-Type: patch
Changelog-Entry: Implement Windows drive detection using C++
Changelog-Entry: Fix various Windows `.bat` spawning issues
Changelog-Entry: Fix 0.0 GB Windows drive detection issues
Changelog-Entry: Cleanup drive detection temporary scripts created for other operating systems
Fixes: #1108
Fixes: #1054
Fixes: #995
Fixes: #1483
Fixes: #1142
Fixes: #1571 
See: https://github.com/resin-io-modules/drivelist/blob/master/CHANGELOG.md
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>