### PR TITLE
refactor(GUI): remove flash of white electron webContents workaround

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -51,17 +51,7 @@ electron.app.on('ready', () => {
   });
 
   // Prevent flash of white when starting the application
-  // https://github.com/atom/electron/issues/2172
-  mainWindow.webContents.on('did-finish-load', () => {
-    const WEBVIEW_LOAD_TIMEOUT_MS = 100;
-
-    // The flash of white is still present for a very short
-    // while after the WebView reports it finished loading
-    setTimeout(() => {
-      mainWindow.show();
-    }, WEBVIEW_LOAD_TIMEOUT_MS);
-
-  });
+  mainWindow.on('ready-to-show', mainWindow.show);
 
   mainWindow.on('closed', () => {
     mainWindow = null;


### PR DESCRIPTION
The lib/gui/etcher.js file contained a workaround to an Electron issue
that have since then been solved. In summary:

- Replace the `did-finish-load` event of `webContents` with
  `ready-to-show`, which is only emitted when the whole webview has
  finished loading

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>