### PR TITLE
refactor(GUI): move redux store to lib/shared

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -33,6 +33,7 @@ const EXIT_CODES = require('../shared/exit-codes');
 const messages = require('../shared/messages');
 const s3Packages = require('../shared/s3-packages');
 const release = require('../shared/release');
+const store = require('../shared/store');
 const packageJSON = require('../../package.json');
 const flashState = require('./models/flash-state');
 const settings = require('./models/settings');
@@ -42,8 +43,6 @@ const updateNotifier = require('./components/update-notifier');
 const availableDrives = require('./models/available-drives');
 const selectionState = require('./models/selection-state');
 const driveScanner = require('./modules/drive-scanner');
-
-const Store = require('./models/store');
 
 const app = angular.module('Etcher', [
   require('angular-ui-router'),
@@ -153,7 +152,7 @@ app.run((ErrorService) => {
 });
 
 app.run(() => {
-  Store.subscribe(() => {
+  store.subscribe(() => {
     const currentFlashState = flashState.getFlashState();
 
     // There is usually a short time period between the `isFlashing()`

--- a/lib/gui/models/available-drives.js
+++ b/lib/gui/models/available-drives.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const _ = require('lodash');
-const Store = require('./store');
+const store = require('../../shared/store');
 
 /**
  * @summary Check if there are available drives
@@ -49,8 +49,8 @@ exports.hasAvailableDrives = () => {
  * availableDrives.setDrives([ ... ]);
  */
 exports.setDrives = (drives) => {
-  Store.dispatch({
-    type: Store.Actions.SET_AVAILABLE_DRIVES,
+  store.dispatch({
+    type: store.Actions.SET_AVAILABLE_DRIVES,
     data: drives
   });
 };
@@ -66,5 +66,5 @@ exports.setDrives = (drives) => {
  * const drives = availableDrives.getDrives();
  */
 exports.getDrives = () => {
-  return Store.getState().toJS().availableDrives;
+  return store.getState().toJS().availableDrives;
 };

--- a/lib/gui/models/flash-state.js
+++ b/lib/gui/models/flash-state.js
@@ -21,7 +21,7 @@
  */
 
 const _ = require('lodash');
-const Store = require('./store');
+const store = require('../../shared/store');
 const units = require('../../shared/units');
 
 /**
@@ -33,8 +33,8 @@ const units = require('../../shared/units');
  * flashState.resetState();
  */
 exports.resetState = () => {
-  Store.dispatch({
-    type: Store.Actions.RESET_FLASH_STATE
+  store.dispatch({
+    type: store.Actions.RESET_FLASH_STATE
   });
 };
 
@@ -51,7 +51,7 @@ exports.resetState = () => {
  * }
  */
 exports.isFlashing = () => {
-  return Store.getState().toJS().isFlashing;
+  return store.getState().toJS().isFlashing;
 };
 
 /**
@@ -69,8 +69,8 @@ exports.isFlashing = () => {
  * flashState.setFlashingFlag();
  */
 exports.setFlashingFlag = () => {
-  Store.dispatch({
-    type: Store.Actions.SET_FLASHING_FLAG
+  store.dispatch({
+    type: store.Actions.SET_FLASHING_FLAG
   });
 };
 
@@ -93,8 +93,8 @@ exports.setFlashingFlag = () => {
  * });
  */
 exports.unsetFlashingFlag = (results) => {
-  Store.dispatch({
-    type: Store.Actions.UNSET_FLASHING_FLAG,
+  store.dispatch({
+    type: store.Actions.UNSET_FLASHING_FLAG,
     data: results
   });
 };
@@ -118,8 +118,8 @@ exports.unsetFlashingFlag = (results) => {
  * });
  */
 exports.setProgressState = (state) => {
-  Store.dispatch({
-    type: Store.Actions.SET_FLASH_STATE,
+  store.dispatch({
+    type: store.Actions.SET_FLASH_STATE,
     data: {
       type: state.type,
       percentage: state.percentage,
@@ -151,7 +151,7 @@ exports.setProgressState = (state) => {
  * const results = flashState.getFlashResults();
  */
 exports.getFlashResults = () => {
-  return Store.getState().toJS().flashResults;
+  return store.getState().toJS().flashResults;
 };
 
 /**
@@ -165,7 +165,7 @@ exports.getFlashResults = () => {
  * const flashState = flashState.getFlashState();
  */
 exports.getFlashState = () => {
-  return Store.getState().get('flashState').toJS();
+  return store.getState().get('flashState').toJS();
 };
 
 /**
@@ -235,5 +235,5 @@ exports.getLastFlashErrorCode = () => {
  * const uuid = flashState.getFlashUuid();
  */
 exports.getFlashUuid = () => {
-  return Store.getState().toJS().flashUuid;
+  return store.getState().toJS().flashUuid;
 };

--- a/lib/gui/models/selection-state.js
+++ b/lib/gui/models/selection-state.js
@@ -17,7 +17,7 @@
 'use strict';
 
 const _ = require('lodash');
-const Store = require('./store');
+const store = require('../../shared/store');
 const availableDrives = require('./available-drives');
 
 /**
@@ -31,8 +31,8 @@ const availableDrives = require('./available-drives');
  * selectionState.setDrive('/dev/disk2');
  */
 exports.setDrive = (drive) => {
-  Store.dispatch({
-    type: Store.Actions.SELECT_DRIVE,
+  store.dispatch({
+    type: store.Actions.SELECT_DRIVE,
     data: drive
   });
 };
@@ -68,8 +68,8 @@ exports.toggleSetDrive = (drive) => {
  * });
  */
 exports.setImage = (image) => {
-  Store.dispatch({
-    type: Store.Actions.SELECT_IMAGE,
+  store.dispatch({
+    type: store.Actions.SELECT_IMAGE,
     data: image
   });
 };
@@ -86,7 +86,7 @@ exports.setImage = (image) => {
  */
 exports.getDrive = () => {
   return _.find(availableDrives.getDrives(), {
-    device: Store.getState().getIn([ 'selection', 'drive' ])
+    device: store.getState().getIn([ 'selection', 'drive' ])
   });
 };
 
@@ -101,7 +101,7 @@ exports.getDrive = () => {
  * const image = selectionState.getImage();
  */
 exports.getImage = () => {
-  return _.get(Store.getState().toJS(), [ 'selection', 'image' ]);
+  return _.get(store.getState().toJS(), [ 'selection', 'image' ]);
 };
 
 /**
@@ -115,7 +115,7 @@ exports.getImage = () => {
  * const imagePath = selectionState.getImagePath();
  */
 exports.getImagePath = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'path'
@@ -133,7 +133,7 @@ exports.getImagePath = () => {
  * const imageSize = selectionState.getImageSize();
  */
 exports.getImageSize = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'size',
@@ -153,7 +153,7 @@ exports.getImageSize = () => {
  * const imageUrl = selectionState.getImageUrl();
  */
 exports.getImageUrl = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'url'
@@ -171,7 +171,7 @@ exports.getImageUrl = () => {
  * const imageName = selectionState.getImageName();
  */
 exports.getImageName = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'name'
@@ -189,7 +189,7 @@ exports.getImageName = () => {
  * const imageLogo = selectionState.getImageLogo();
  */
 exports.getImageLogo = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'logo'
@@ -207,7 +207,7 @@ exports.getImageLogo = () => {
  * const imageSupportUrl = selectionState.getImageSupportUrl();
  */
 exports.getImageSupportUrl = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'supportUrl'
@@ -225,7 +225,7 @@ exports.getImageSupportUrl = () => {
  * const imageRecommendedDriveSize = selectionState.getImageRecommendedDriveSize();
  */
 exports.getImageRecommendedDriveSize = () => {
-  return _.get(Store.getState().toJS(), [
+  return _.get(store.getState().toJS(), [
     'selection',
     'image',
     'recommendedDriveSize'
@@ -273,8 +273,8 @@ exports.hasImage = () => {
  * selectionState.removeDrive();
  */
 exports.removeDrive = () => {
-  Store.dispatch({
-    type: Store.Actions.REMOVE_DRIVE
+  store.dispatch({
+    type: store.Actions.REMOVE_DRIVE
   });
 };
 
@@ -287,8 +287,8 @@ exports.removeDrive = () => {
  * selectionState.removeImage();
  */
 exports.removeImage = () => {
-  Store.dispatch({
-    type: Store.Actions.REMOVE_IMAGE
+  store.dispatch({
+    type: store.Actions.REMOVE_IMAGE
   });
 };
 
@@ -308,13 +308,13 @@ exports.removeImage = () => {
  */
 exports.clear = (options = {}) => {
   if (!options.preserveImage) {
-    Store.dispatch({
-      type: Store.Actions.REMOVE_IMAGE
+    store.dispatch({
+      type: store.Actions.REMOVE_IMAGE
     });
   }
 
-  Store.dispatch({
-    type: Store.Actions.REMOVE_DRIVE
+  store.dispatch({
+    type: store.Actions.REMOVE_DRIVE
   });
 };
 

--- a/lib/gui/models/settings.js
+++ b/lib/gui/models/settings.js
@@ -21,8 +21,8 @@
  */
 
 const _ = require('lodash');
-const Store = require('./store');
 const localSettings = require('./local-settings');
+const store = require('../../shared/store');
 const errors = require('../../shared/errors');
 
 /**
@@ -46,8 +46,8 @@ const errors = require('../../shared/errors');
 const setSettingsObject = (settings) => {
   const currentSettings = exports.getAll();
 
-  Store.dispatch({
-    type: Store.Actions.SET_SETTINGS,
+  store.dispatch({
+    type: store.Actions.SET_SETTINGS,
     data: settings
   });
 
@@ -56,8 +56,8 @@ const setSettingsObject = (settings) => {
   // Revert the application state if writing the data
   // to the local machine was not successful
   if (_.isError(result)) {
-    Store.dispatch({
-      type: Store.Actions.SET_SETTINGS,
+    store.dispatch({
+      type: store.Actions.SET_SETTINGS,
       data: currentSettings
     });
 
@@ -70,7 +70,7 @@ const setSettingsObject = (settings) => {
  * @constant
  * @type {Object}
  */
-const DEFAULT_SETTINGS = Store.Defaults.get('settings').toJS();
+const DEFAULT_SETTINGS = store.Defaults.get('settings').toJS();
 
 /**
  * @summary Reset settings to their default values
@@ -172,5 +172,5 @@ exports.get = (key) => {
  * console.log(allSettings.unmountOnSuccess);
  */
 exports.getAll = () => {
-  return Store.getState().get('settings').toJS();
+  return store.getState().get('settings').toJS();
 };

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -20,13 +20,13 @@ const Immutable = require('immutable');
 const _ = require('lodash');
 const redux = require('redux');
 const uuidV4 = require('uuid/v4');
-const constraints = require('../../shared/drive-constraints');
-const supportedFormats = require('../../shared/supported-formats');
-const errors = require('../../shared/errors');
-const release = require('../../shared/release');
-const fileExtensions = require('../../shared/file-extensions');
-const utils = require('../../shared/utils');
-const packageJSON = require('../../../package.json');
+const constraints = require('./drive-constraints');
+const supportedFormats = require('./supported-formats');
+const errors = require('./errors');
+const release = require('./release');
+const fileExtensions = require('./file-extensions');
+const utils = require('./utils');
+const packageJSON = require('../../package.json');
 
 /**
  * @summary Application default state

--- a/tests/gui/models/settings.spec.js
+++ b/tests/gui/models/settings.spec.js
@@ -2,7 +2,7 @@
 
 const m = require('mochainon');
 const _ = require('lodash');
-const Store = require('../../../lib/gui/models/store');
+const store = require('../../../lib/shared/store');
 const settings = require('../../../lib/gui/models/settings');
 const localSettings = require('../../../lib/gui/models/local-settings');
 
@@ -12,7 +12,7 @@ describe('Browser: settings', function() {
     settings.reset();
   });
 
-  const DEFAULT_SETTINGS = Store.Defaults.get('settings').toJS();
+  const DEFAULT_SETTINGS = store.Defaults.get('settings').toJS();
 
   it('should be able to set and read values', function() {
     m.chai.expect(settings.get('foo')).to.be.undefined;


### PR DESCRIPTION
After https://github.com/resin-io/etcher/pull/1569, the redux store can
run outside of a browser context. This commit moves it to `lib/shared`,
where we will likely move all the other models as well. As an extra, I
renamed `Store` to `store`, since there was no reason for that variable
to be capitalized.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>