### PR TITLE
chore(appveyor): make node_modules cache depend on npm-shrinkwrap.json

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2015
 cache:
   - C:\Users\appveyor\.node-gyp
   - '%AppData%\npm-cache'
-  - node_modules
+  - node_modules -> npm-shrinkwrap.json
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - C:\Users\appveyor\AppData\Local\Temp\chocolatey -> appveyor.yml


### PR DESCRIPTION
We've been hitting some weird npm-shrinkwrap.json issues in our
shrinkwrap staged sanity checks, where Appveyor would complain that the
shrinkwrap is not up to date, while that wasn't the case either locally
or in Travis CI.

The issue is related to caching. If a commit changes a `from` entry of a
npm-shrinkwrap.json dependency, but the CI servers kept the cached
node_modules, then there will be a discrepancy between the `_from` field
from the `package.json` of a dependency in `node_modules` and what the
npm-shrinkwrap.json says. npm will obey `node_modules` over
`npm-shrinkwrap`, causing the invalid diff.

The fix is to make the Appveyor node_modules cached directory dependent
on any change to the npm-shrinkwrap.json file.

Change-Type: patch
See: https://github.com/resin-io/etcher/pull/1547
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>