### PR TITLE
chore: cache as much as possible from electron-builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,16 @@ sudo: false
 node_js:
   - "6.10.3"
 
+# Remove wine from cache
+before_cache:
+  - rm -rf $HOME/.cache/electron-builder/wine
+
 cache:
   ccache: true
+  directories:
+    - $HOME/.cache/electron
+    - $HOME/.cache/electron-builder
+    - $HOME/.npm/_prebuilds
 
 services:
   - docker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ image: Visual Studio 2015
 
 cache:
   - C:\Users\appveyor\.node-gyp
+  - '%LOCALAPPDATA%\electron\Cache'
+  - '%LOCALAPPDATA%\electron-builder\cache'
   - '%AppData%\npm-cache'
   - node_modules
   - C:\ProgramData\chocolatey\bin -> appveyor.yml


### PR DESCRIPTION
These directories contain files downloaded by electron-builder (like
electron itself), that we can cache in Travis CI and Appveyor CI to
speed up builds.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>