### PR TITLE
chore: avoid brew taking a long time on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
     - CCACHE_COMPRESS=1
     - CC="clang"
     - CXX="clang++"
+    - HOMEBREW_NO_AUTO_UPDATE=1
   matrix:
     - TARGET_ARCH=x64
     - TARGET_ARCH=x86

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -52,7 +52,7 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
 else
   if [ "$ARGV_OPERATING_SYSTEM" == "darwin" ]; then
     ./scripts/build/check-dependency.sh brew
-    brew install ccache jq
+    brew install ccache jq --force-bottle
   elif [ "$ARGV_OPERATING_SYSTEM" == "win32" ]; then
     ./scripts/build/check-dependency.sh choco
     choco install nsis -version 2.51


### PR DESCRIPTION
- Homebrew now auto-updates before performing any installation, which
  can take quite some time. We can disable this by enabling
  HOMEBREW_NO_AUTO_UPDATE

- We can pass the --force-bottle option to `brew install` to force it to
  download pre-compiled binaries, and don't attempt any compilations

See: https://github.com/resin-io/etcher/pull/1582
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>