### PR TITLE
chore: don't install NSIS in Appveyor CI

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -55,7 +55,6 @@ else
     brew install ccache jq
   elif [ "$ARGV_OPERATING_SYSTEM" == "win32" ]; then
     ./scripts/build/check-dependency.sh choco
-    choco install nsis -version 2.51
     choco install jq
     choco install curl
   else


### PR DESCRIPTION
This dependency comes bundled with electron-builder, so there is no
reason to install it separately.

See: https://github.com/resin-io/etcher/pull/1582
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>