### PR TITLE
upgrade(package): Update udif 0.9.0 -> 0.10.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10117,9 +10117,9 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "udif": {
-      "version": "0.9.0",
-      "from": "udif@0.9.0",
-      "resolved": "https://registry.npmjs.org/udif/-/udif-0.9.0.tgz",
+      "version": "0.10.0",
+      "from": "udif@0.10.0",
+      "resolved": "https://registry.npmjs.org/udif/-/udif-0.10.0.tgz",
       "dependencies": {
         "base64-js": {
           "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "semver": "5.1.1",
     "sudo-prompt": "6.1.0",
     "trackjs": "2.3.1",
-    "udif": "0.9.0",
+    "udif": "0.10.0",
     "unbzip2-stream": "1.0.11",
     "uuid": "3.0.1",
     "xml2js": "0.4.17",


### PR DESCRIPTION
This updates `udif` from 0.9.0 to 0.10.0, fixing two bugs;

* [57ddf788] fix(readstream): Avoid read-before-open situations
* [6333a183] fix(image): try/catch parsing the resource fork plist

[57ddf788]: https://github.com/jhermsmeier/node-udif/commit/57ddf788b72cc1ff17317e560532e5e89adf695c
[6333a183]: https://github.com/jhermsmeier/node-udif/commit/6333a183f6863348723f95b3c8183fea16a30703

Change-Type: patch
Connects To: #1572