### PR TITLE
fix(writer): Use final size if it's not an estimation

### DIFF
--- a/lib/image-stream/handlers.js
+++ b/lib/image-stream/handlers.js
@@ -157,7 +157,9 @@ module.exports = {
         extension: fileExtensions.getLastFileExtension(imagePath),
         stream: udif.createReadStream(imagePath),
         size: {
-          original: options.size,
+          // FIXME(jhermsmeier): Originally `options.size`,
+          // See discussion in https://github.com/resin-io/etcher/pull/1587
+          original: size || options.size,
           final: {
             estimation: false,
             value: size

--- a/tests/image-stream/dmg.spec.js
+++ b/tests/image-stream/dmg.spec.js
@@ -81,14 +81,13 @@ describe('ImageStream: DMG', function() {
       it('should return the correct metadata', function() {
         const image = path.join(DMG_PATH, 'etcher-test-zlib.dmg');
         const uncompressedSize = fs.statSync(path.join(IMAGES_PATH, 'etcher-test.img')).size;
-        const compressedSize = fs.statSync(image).size;
 
         return imageStream.getImageMetadata(image).then((metadata) => {
           m.chai.expect(metadata).to.deep.equal({
             path: image,
             extension: 'dmg',
             size: {
-              original: compressedSize,
+              original: uncompressedSize,
               final: {
                 estimation: false,
                 value: uncompressedSize
@@ -122,14 +121,13 @@ describe('ImageStream: DMG', function() {
       it('should return the correct metadata', function() {
         const image = path.join(DMG_PATH, 'etcher-test-raw.dmg');
         const uncompressedSize = fs.statSync(path.join(IMAGES_PATH, 'etcher-test.img')).size;
-        const compressedSize = fs.statSync(image).size;
 
         return imageStream.getImageMetadata(image).then((metadata) => {
           m.chai.expect(metadata).to.deep.equal({
             path: image,
             extension: 'dmg',
             size: {
-              original: compressedSize,
+              original: uncompressedSize,
               final: {
                 estimation: false,
                 value: uncompressedSize


### PR DESCRIPTION
This avoids running into the "flashstate percentage above 100%" error again.

Change-Type: patch
See also: #1572 