### PR TITLE
refactor(image-stream): rename file variable to imagePath

### DIFF
--- a/lib/image-stream/handlers.js
+++ b/lib/image-stream/handlers.js
@@ -45,19 +45,19 @@ module.exports = {
    * @public
    * @memberof handlers
    *
-   * @param {String} file - file path
+   * @param {String} imagePath - image path
    * @param {Object} options - options
-   * @param {Number} [options.size] - file size
+   * @param {Number} [options.size] - image size
    *
    * @fulfil {Object} - image metadata
    * @returns {Promise}
    */
-  'application/x-bzip2': (file, options) => {
+  'application/x-bzip2': (imagePath, options) => {
     return Bluebird.props({
-      path: file,
-      archiveExtension: fileExtensions.getLastFileExtension(file),
-      extension: fileExtensions.getPenultimateFileExtension(file),
-      stream: fs.createReadStream(file),
+      path: imagePath,
+      archiveExtension: fileExtensions.getLastFileExtension(imagePath),
+      extension: fileExtensions.getPenultimateFileExtension(imagePath),
+      stream: fs.createReadStream(imagePath),
       size: {
         original: options.size,
         final: {
@@ -75,20 +75,20 @@ module.exports = {
    * @public
    * @memberof handlers
    *
-   * @param {String} file - file path
+   * @param {String} imagePath - image path
    * @param {Object} options - options
-   * @param {Number} [options.size] - file size
+   * @param {Number} [options.size] - image size
    *
    * @fulfil {Object} - image metadata
    * @returns {Promise}
    */
-  'application/gzip': (file, options) => {
-    return gzip.getUncompressedSize(file).then((uncompressedSize) => {
+  'application/gzip': (imagePath, options) => {
+    return gzip.getUncompressedSize(imagePath).then((uncompressedSize) => {
       return Bluebird.props({
-        path: file,
-        archiveExtension: fileExtensions.getLastFileExtension(file),
-        extension: fileExtensions.getPenultimateFileExtension(file),
-        stream: fs.createReadStream(file),
+        path: imagePath,
+        archiveExtension: fileExtensions.getLastFileExtension(imagePath),
+        extension: fileExtensions.getPenultimateFileExtension(imagePath),
+        stream: fs.createReadStream(imagePath),
         size: {
           original: options.size,
           final: {
@@ -107,24 +107,24 @@ module.exports = {
    * @public
    * @memberof handlers
    *
-   * @param {String} file - file path
+   * @param {String} imagePath - image path
    * @param {Object} options - options
-   * @param {Number} [options.size] - file size
+   * @param {Number} [options.size] - image size
    *
    * @fulfil {Object} - image metadata
    * @returns {Promise}
    */
-  'application/x-xz': (file, options) => {
-    return fs.openAsync(file, 'r').then((fileDescriptor) => {
+  'application/x-xz': (imagePath, options) => {
+    return fs.openAsync(imagePath, 'r').then((fileDescriptor) => {
       return lzma.parseFileIndexFDAsync(fileDescriptor).tap(() => {
         return fs.closeAsync(fileDescriptor);
       });
     }).then((metadata) => {
       return {
-        path: file,
-        archiveExtension: fileExtensions.getLastFileExtension(file),
-        extension: fileExtensions.getPenultimateFileExtension(file),
-        stream: fs.createReadStream(file),
+        path: imagePath,
+        archiveExtension: fileExtensions.getLastFileExtension(imagePath),
+        extension: fileExtensions.getPenultimateFileExtension(imagePath),
+        stream: fs.createReadStream(imagePath),
         size: {
           original: options.size,
           final: {
@@ -143,19 +143,19 @@ module.exports = {
    * @public
    * @memberof handlers
    *
-   * @param {String} file - file path
+   * @param {String} imagePath - image path
    * @param {Object} options - options
-   * @param {Number} [options.size] - file size
+   * @param {Number} [options.size] - image size
    *
    * @fulfil {Object} - image metadata
    * @returns {Promise}
    */
-  'application/x-apple-diskimage': (file, options) => {
-    return udif.getUncompressedSizeAsync(file).then((size) => {
+  'application/x-apple-diskimage': (imagePath, options) => {
+    return udif.getUncompressedSizeAsync(imagePath).then((size) => {
       return {
-        path: file,
-        extension: fileExtensions.getLastFileExtension(file),
-        stream: udif.createReadStream(file),
+        path: imagePath,
+        extension: fileExtensions.getLastFileExtension(imagePath),
+        stream: udif.createReadStream(imagePath),
         size: {
           original: options.size,
           final: {
@@ -169,7 +169,7 @@ module.exports = {
       if (/invalid footer/i.test(error.message)) {
         throw errors.createUserError({
           title: 'Invalid image',
-          description: `There was an error reading "${path.basename(file)}". `
+          description: `There was an error reading "${path.basename(imagePath)}". `
             + 'The image does not appear to be a valid Apple Disk Image (dmg), or may have the wrong filename extension.\n\n'
             + `Error: ${error.description || error.message}`
         });
@@ -184,12 +184,12 @@ module.exports = {
    * @public
    * @memberof handlers
    *
-   * @param {String} file - file path
+   * @param {String} imagePath - image path
    * @fulfil {Object} - image metadata
    * @returns {Promise}
    */
-  'application/zip': (file) => {
-    return archive.extractImage(file, zipArchiveHooks);
+  'application/zip': (imagePath) => {
+    return archive.extractImage(imagePath, zipArchiveHooks);
   },
 
   /**
@@ -198,18 +198,18 @@ module.exports = {
    * @public
    * @memberof handlers
    *
-   * @param {String} file - file path
+   * @param {String} imagePath - image path
    * @param {Object} options - options
-   * @param {Number} [options.size] - file size
+   * @param {Number} [options.size] - image size
    *
    * @fulfil {Object} - image metadata
    * @returns {Promise}
    */
-  'application/octet-stream': (file, options) => {
+  'application/octet-stream': (imagePath, options) => {
     return Bluebird.props({
-      path: file,
-      extension: fileExtensions.getLastFileExtension(file),
-      stream: fs.createReadStream(file),
+      path: imagePath,
+      extension: fileExtensions.getLastFileExtension(imagePath),
+      stream: fs.createReadStream(imagePath),
       size: {
         original: options.size,
         final: {


### PR DESCRIPTION
This is a small initial step towards decoupling the image stream
handlers from the concept of a "file."

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>