### PR TITLE
chore: cache electron-builder temporary files in macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ cache:
     - $HOME/.cache/electron
     - $HOME/.cache/electron-builder
     - $HOME/.npm/_prebuilds
+    - $HOME/Library/Caches/electron
+    - $HOME/Library/Caches/electron-builder
     - node_modules
 
 services:


### PR DESCRIPTION
Our current Travis CI configuration caches temporary files created by
electron-builder, but only for GNU/Linux builds. In macOS, electron and
electron-builder store their cache at ~/Library/Caches, so we must cache
that as well.

This commit was motivated by the fact that most macOS builds are failing
for Electron package download timeouts.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>