### PR TITLE
chore: pass --quiet to pip install

### DIFF
--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -52,4 +52,4 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --quiet -r requirements.txt

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -51,4 +51,4 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --quiet -r requirements.txt

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -54,4 +54,4 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --quiet -r requirements.txt

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -68,7 +68,7 @@ else
 
   npm config set spin=false
   npm config set progress=false
-  pip install -r requirements.txt
+  pip install --quiet -r requirements.txt
 
   make info
   make electron-develop


### PR DESCRIPTION
This helps reduce a bit of output in the CI servers.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>