### PR TITLE
test(image-stream): increase DMG tests timeouts

### DIFF
--- a/tests/image-stream/dmg.spec.js
+++ b/tests/image-stream/dmg.spec.js
@@ -27,6 +27,8 @@ const tester = require('./tester');
 
 describe('ImageStream: DMG', function() {
 
+  this.timeout(20000);
+
   describe('compression method', function() {
 
     describe('NONE', function() {


### PR DESCRIPTION
I caught an sporadic issue a couple of times, where the DMG tests would
exceed the default 2000ms mocha timeout. All the other image
decompression tests have a much higher timeout already, so this commit
adds the same timeout to the DMG tests file.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>