### PR TITLE
chore: cache ~/.pkg-cache in Travis CI and Appveyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
     - $HOME/.npm/_prebuilds
     - $HOME/Library/Caches/electron
     - $HOME/Library/Caches/electron-builder
+    - $HOME/.pkg-cache
     - node_modules
 
 services:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ cache:
   - '%LOCALAPPDATA%\electron\Cache'
   - '%LOCALAPPDATA%\electron-builder\cache'
   - '%AppData%\npm-cache'
+  - '%USERPROFILE%\.pkg-cache'
   - node_modules -> npm-shrinkwrap.json
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml


### PR DESCRIPTION
Looks like pkg downloads node binaries from GitHub Releases, and GitHub
may impose a rate limiting if we download too many things from them in a
short period of time (likely to happen when there are many concurrent
PRs).

In order to mitigate this issue, this commit adds `$HOME/.pkg-cache`,
the directory where pkg stores node binaries, to the CI services cache.

See: https://github.com/resin-io/etcher/pull/1594
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>