### PR TITLE
test(image-stream): move extraction timeout to a shared constant

### DIFF
--- a/tests/image-stream/archive-hooks/zip.spec.js
+++ b/tests/image-stream/archive-hooks/zip.spec.js
@@ -20,11 +20,12 @@ const m = require('mochainon');
 const path = require('path');
 const zipHooks = require('../../../lib/image-stream/archive-hooks/zip');
 const utils = require('../../../lib/image-stream/utils');
+const tester = require('../tester');
 const ZIP_PATH = path.join(__dirname, '..', 'data', 'zip');
 
 describe('ImageStream: Archive hooks: ZIP', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('.getEntries()', function() {
 

--- a/tests/image-stream/bz2.spec.js
+++ b/tests/image-stream/bz2.spec.js
@@ -27,7 +27,7 @@ const tester = require('./tester');
 
 describe('ImageStream: BZ2', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('compression method', function() {
 

--- a/tests/image-stream/dmg.spec.js
+++ b/tests/image-stream/dmg.spec.js
@@ -27,7 +27,7 @@ const tester = require('./tester');
 
 describe('ImageStream: DMG', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('compression method', function() {
 

--- a/tests/image-stream/gz.spec.js
+++ b/tests/image-stream/gz.spec.js
@@ -27,7 +27,7 @@ const tester = require('./tester');
 
 describe('ImageStream: GZ', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('.getFromFilePath()', function() {
 

--- a/tests/image-stream/img.spec.js
+++ b/tests/image-stream/img.spec.js
@@ -26,7 +26,7 @@ const tester = require('./tester');
 
 describe('ImageStream: IMG', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('.getFromFilePath()', function() {
 

--- a/tests/image-stream/iso.spec.js
+++ b/tests/image-stream/iso.spec.js
@@ -26,7 +26,7 @@ const tester = require('./tester');
 
 describe('ImageStream: ISO', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('.getFromFilePath()', function() {
 

--- a/tests/image-stream/tester.js
+++ b/tests/image-stream/tester.js
@@ -43,6 +43,8 @@ const deleteIfExists = (file) => {
   });
 };
 
+exports.DEFAULT_IMAGE_TESTS_TIMEOUT = 20000;
+
 exports.expectError = function(file, errorMessage, errorDetail) {
   it('should be rejected with an error', function() {
     return imageStream.getFromFilePath(file).catch((error) => {

--- a/tests/image-stream/xz.spec.js
+++ b/tests/image-stream/xz.spec.js
@@ -27,7 +27,7 @@ const tester = require('./tester');
 
 describe('ImageStream: XZ', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('.getFromFilePath()', function() {
 

--- a/tests/image-stream/zip.spec.js
+++ b/tests/image-stream/zip.spec.js
@@ -27,7 +27,7 @@ const tester = require('./tester');
 
 describe('ImageStream: ZIP', function() {
 
-  this.timeout(20000);
+  this.timeout(tester.DEFAULT_IMAGE_TESTS_TIMEOUT);
 
   describe('.getFromFilePath()', function() {
 


### PR DESCRIPTION
The image stream tests that extract images all have a 20s timeout, which
is manually set in all the suites related to extraction.

This commit extracts that number as a constant called DEFAULT_TIMEOUT.

See: https://github.com/resin-io/etcher/pull/1595
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>