### PR TITLE
refactor(gui): Only enable full debug output on demand

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -22,10 +22,6 @@ const path = require('path')
 const EXIT_CODES = require('../shared/exit-codes')
 let mainWindow = null
 
-// Enable drivelist debugging information
-// See https://github.com/resin-io-modules/drivelist
-process.env.DRIVELIST_DEBUG = 1
-
 electron.app.on('window-all-closed', electron.app.quit)
 
 // Sending a `SIGINT` (e.g: Ctrl-C) to an Electron app that registers

--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -9,7 +9,12 @@
 
     <!-- Enable debug information from all modules that use `debug` -->
     <!-- See https://github.com/visionmedia/debug#browser-support -->
-    <script>window.localStorage.debug = '*';</script>
+    <script>
+      // Enable drivelist debugging information
+      // See https://github.com/resin-io-modules/drivelist
+      process.env['DRIVELIST_DEBUG'] = /drivelist|^\*$/i.test(process.env['DEBUG']) ? '1' : '';
+      window.localStorage.debug = process.env['DEBUG'];
+    </script>
 
     <script src="./app.js"></script>
   </head>

--- a/lib/start.js
+++ b/lib/start.js
@@ -16,10 +16,6 @@
 
 'use strict'
 
-// Enable debug information from all modules that use `debug`
-// See https://github.com/visionmedia/debug#browser-support
-process.env.DEBUG = '*'
-
 // See http://electron.atom.io/docs/v0.37.7/api/environment-variables/#electronrunasnode
 //
 // Notice that if running electron with `ELECTRON_RUN_AS_NODE`, the binary


### PR DESCRIPTION
This disables full wildcard debug output by default now,
leaving the possibility to manually enable debug output
via the `DEBUG` environment variable.

Change-Type: patch