### PR TITLE
feat(GUI): enlarge reflash button on success page

### DIFF
--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6597,7 +6597,7 @@ svg-icon > div[disabled] path {
   max-width: 165px; }
 
 .page-finish .button-primary, .page-finish .progress-button {
-  min-width: 255px;
+  min-width: 253px;
   min-height: 53px;
   font-size: 15px; }
 
@@ -6626,7 +6626,7 @@ svg-icon > div[disabled] path {
 .page-finish .center {
   display: flex;
   align-items: center;
-  justify-content: center; }
+  justify-content: space-around; }
 
 .page-finish .box > div {
   margin-bottom: 20px; }

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6597,7 +6597,9 @@ svg-icon > div[disabled] path {
   max-width: 165px; }
 
 .page-finish .button-primary, .page-finish .progress-button {
-  min-width: 170px; }
+  min-width: 255px;
+  min-height: 53px;
+  font-size: 15px; }
 
 .page-finish .title {
   color: #fff;

--- a/lib/gui/pages/finish/styles/_finish.scss
+++ b/lib/gui/pages/finish/styles/_finish.scss
@@ -26,7 +26,7 @@
 }
 
 .page-finish .button-primary {
-  min-width: 255px;
+  min-width: $btn-large-min-width;
   min-height: 53px;
   font-size: 15px;
 }
@@ -63,7 +63,7 @@
 .page-finish .center {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
 }
 
 .page-finish .box > div {

--- a/lib/gui/pages/finish/styles/_finish.scss
+++ b/lib/gui/pages/finish/styles/_finish.scss
@@ -26,7 +26,9 @@
 }
 
 .page-finish .button-primary {
-  min-width: $btn-min-width;
+  min-width: 255px;
+  min-height: 53px;
+  font-size: 15px;
 }
 
 .page-finish .title {

--- a/lib/gui/pages/finish/templates/success.tpl.html
+++ b/lib/gui/pages/finish/templates/success.tpl.html
@@ -5,7 +5,7 @@
         <h3 class="title"><span class="tick tick--success space-right-tiny"></span> Flash Complete!</h3>
       </div>
 
-      <div class="col-xs-4">
+      <div class="col-xs-5">
         <button class="button button-primary button-brick" ng-click="finish.restart({ preserveImage: true })">
           <b>Flash Another</b>
         </button>

--- a/lib/gui/scss/main.scss
+++ b/lib/gui/scss/main.scss
@@ -19,6 +19,7 @@ $font-size-base: 13px;
 $cursor-disabled: initial;
 $link-hover-decoration: none;
 $btn-min-width: 170px;
+$btn-large-min-width: 253px;
 $link-color: #ddd;
 
 @import "../../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap";


### PR DESCRIPTION
We change the `Flash Another` button in the top-right corner of the
success screen to be bigger, matching the banner buttons' size.

Changelog-Entry: Enlarge Flash Another button on success page.