### PR TITLE
upgrade: drivelist to v5.0.27

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1302,9 +1302,9 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.0.25",
-      "from": "drivelist@5.0.25",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.25.tgz",
+      "version": "5.0.27",
+      "from": "drivelist@5.0.27",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.27.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bootstrap-sass": "3.3.6",
     "chalk": "1.1.3",
     "command-join": "2.0.0",
-    "drivelist": "5.0.25",
+    "drivelist": "5.0.27",
     "electron-is-running-in-asar": "1.0.0",
     "etcher-image-write": "9.1.3",
     "file-type": "4.1.0",


### PR DESCRIPTION
This new version contains the following PRs that we're interested about:

- https://github.com/resin-io-modules/drivelist/pull/196

To reduce the amount of debug logging we produce (see
https://github.com/resin-io/etcher/pull/1600).

- https://github.com/resin-io-modules/drivelist/pull/195

To properly handle spawning EAGAIN errors.

Fixes: https://github.com/resin-io/etcher/issues/1578
Change-Type: patch
Changelog-Entry: Retry various times on EAGAIN when spawning drive scanning scripts.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>