### PR TITLE
chore: publish development Bintray packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
 deploy:
   provider: script
   skip_cleanup: true
-  script: scripts/ci/deploy-aws-s3.sh -o $HOST_OS -r $TARGET_ARCH
+  script: scripts/ci/deploy.sh -o $HOST_OS -r $TARGET_ARCH
   on:
     branch: master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ test_script:
   - bash .\scripts\ci\build-installers.sh -o win32 -r %TARGET_ARCH%
 
 deploy_script:
-  - bash .\scripts\ci\deploy-aws-s3.sh -o win32 -r %TARGET_ARCH%
+  - if %APPVEYOR_REPO_BRANCH%==master (bash .\scripts\ci\deploy.sh -o win32 -r %TARGET_ARCH%)
 
 notifications:
 

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -48,8 +48,8 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
   ./scripts/build/docker/run-command.sh \
     -r "$ARGV_ARCHITECTURE" \
     -s "$(pwd)" \
-    -c "make publish-aws-s3"
+    -c "make installers-all"
 else
   ./scripts/build/check-dependency.sh make
-  make publish-aws-s3
+  make installers-all
 fi

--- a/scripts/publish/bintray.sh
+++ b/scripts/publish/bintray.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 ###
 # Copyright 2016 resin.io
 #
@@ -28,26 +27,32 @@ function usage() {
   echo "Options"
   echo ""
   echo "    -f <file>"
-  echo "    -v <debian-friendly version>"
+  echo "    -v <version>"
   echo "    -r <architecture>"
-  echo "    -c <component name>"
   echo "    -t <release type (production|snapshot)>"
+  echo "    -o <bintray organization>"
+  echo "    -p <bintray repository>"
+  echo "    -c <bintray component>"
   exit 1
 }
 
 ARGV_FILE=""
 ARGV_VERSION=""
 ARGV_ARCHITECTURE=""
-ARGV_COMPONENT_NAME=""
 ARGV_RELEASE_TYPE=""
+ARGV_ORGANIZATION=""
+ARGV_REPOSITORY=""
+ARGV_COMPONENT=""
 
-while getopts ":f:v:r:c:t:" option; do
+while getopts ":f:v:r:t:o:p:c:" option; do
   case $option in
     f) ARGV_FILE="$OPTARG" ;;
     v) ARGV_VERSION="$OPTARG" ;;
     r) ARGV_ARCHITECTURE="$OPTARG" ;;
-    c) ARGV_COMPONENT_NAME="$OPTARG" ;;
     t) ARGV_RELEASE_TYPE="$OPTARG" ;;
+    o) ARGV_ORGANIZATION="$OPTARG" ;;
+    p) ARGV_REPOSITORY="$OPTARG" ;;
+    c) ARGV_COMPONENT="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -55,8 +60,10 @@ done
 if [ -z "$ARGV_FILE" ] || \
    [ -z "$ARGV_VERSION" ] || \
    [ -z "$ARGV_ARCHITECTURE" ] || \
-   [ -z "$ARGV_COMPONENT_NAME" ] || \
-   [ -z "$ARGV_RELEASE_TYPE" ]
+   [ -z "$ARGV_RELEASE_TYPE" ] || \
+   [ -z "$ARGV_ORGANIZATION" ] || \
+   [ -z "$ARGV_REPOSITORY" ] || \
+   [ -z "$ARGV_COMPONENT" ]
 then
   usage
 fi
@@ -87,9 +94,10 @@ PACKAGE_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITE
 curl --upload-file $ARGV_FILE \
   --user $BINTRAY_USER:$BINTRAY_API_KEY \
   --header "X-Bintray-Debian-Distribution: $PACKAGE_DISTRIBUTION" \
-  --header "X-Bintray-Debian-Component: $ARGV_COMPONENT_NAME" \
+  --header "X-Bintray-Debian-Component: $ARGV_COMPONENT" \
   --header "X-Bintray-Debian-Architecture: $PACKAGE_ARCHITECTURE" \
+  --header "X-Bintray-Override: 1" \
   --header "X-Bintray-Publish: 1" \
-  https://api.bintray.com/content/resin-io/debian/$ARGV_COMPONENT_NAME/$ARGV_VERSION/$PACKAGE_FILE_NAME
+  https://api.bintray.com/content/$ARGV_ORGANIZATION/$ARGV_REPOSITORY/$ARGV_COMPONENT/$ARGV_VERSION/$PACKAGE_FILE_NAME
 
 echo "$ARGV_FILE has been uploaded successfully"


### PR DESCRIPTION
This commit includes several changes to adapt the CI configuration files
and Bintray publish script to perform development deployments.

- Move our Bintray details to the Makefile
- Deploy to a new Bintray component if `RELEASE_TYPE` is `snapshot`
- Call `publish-bintray-debian` and `publish-bintray-redhat` in the CI
    deployment script
- Call the Bintray deployment scripts for RPMs

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>