### PR TITLE
fix(windows): include local native modules in final asar

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,6 +6,7 @@ nodeGypRebuild: true
 publish: null
 files:
   - lib
+  - build/**/*.node
   - assets/icon.png
   - node_modules/**/*
 mac:


### PR DESCRIPTION
Etcher has local native code that gets built to `build/`, but that's not
being included inside the final asar.

The fix is to manually add the `*.node` files inside `build/Release` by
adding the appropriate wilcard to the `files` section of
`electron-builder.yml`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>