### PR TITLE
fix(GUI): properly pass error object to "Flash error" event

### DIFF
--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -25,6 +25,7 @@ const _ = require('lodash');
 const childWriter = require('../../child-writer');
 const settings = require('../models/settings');
 const flashState = require('../../shared/models/flash-state');
+const errors = require('../../shared/errors');
 const windowProgress = require('../os/window-progress');
 const analytics = require('../modules/analytics');
 
@@ -134,7 +135,7 @@ imageWriter.service('ImageWriterService', function($q, $rootScope) {
         analytics.logEvent('Out of space', analyticsData);
       } else {
         analytics.logEvent('Flash error', _.merge({
-          error
+          error: errors.toJSON(error)
         }, analyticsData));
       }
 


### PR DESCRIPTION
Simply running `_.merge` on an Error object results in an empty plain
object `{}` being sent to Mixpanel/Sentry.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>