### PR TITLE
fix(GUI): throw a user error if the user is not in the sudoers file

### DIFF
--- a/lib/shared/permissions.js
+++ b/lib/shared/permissions.js
@@ -198,6 +198,13 @@ exports.elevateCommand = (command, options) => {
   // for now, we should make sure we double check if the error messages
   // have changed every time we upgrade `sudo-prompt`.
 
+  }).catch((error) => {
+    return _.includes(error.message, 'is not in the sudoers file');
+  }, () => {
+    throw errors.createUserError({
+      title: 'Your user doesn\'t have enough privileges to proceed',
+      description: 'This application requires sudo privileges to be able to write to drives'
+    });
   }).catch({
     message: 'User did not grant permission.'
   }, () => {


### PR DESCRIPTION
Change-Type: patch
Changelog-Entry: Display a user-friendly error message if the user is not in the sudoers file.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>