### PR TITLE
fix(CLI): pass required arguments to flashComplete message

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const _ = require('lodash');
+const path = require('path');
 const Bluebird = require('bluebird');
 const visuals = require('resin-cli-visuals');
 const form = require('resin-cli-form');
@@ -105,6 +106,12 @@ permissions.isElevated().then((elevated) => {
         progressBars[state.type].update(state);
       }
 
+    }).then((results) => {
+      return {
+        imagePath,
+        flash: results,
+        drive: selectedDrive
+      };
     });
   });
 }).then((results) => {
@@ -112,14 +119,17 @@ permissions.isElevated().then((elevated) => {
   return Bluebird.try(() => {
     if (robot.isEnabled(process.env)) {
       return robot.printMessage('done', {
-        sourceChecksum: results.sourceChecksum
+        sourceChecksum: results.flash.sourceChecksum
       });
     }
 
-    console.log(messages.info.flashComplete());
+    console.log(messages.info.flashComplete({
+      drive: results.drive,
+      imageBasename: path.basename(results.imagePath)
+    }));
 
-    if (results.sourceChecksum) {
-      console.log(`Checksum: ${results.sourceChecksum}`);
+    if (results.flash.sourceChecksum) {
+      console.log(`Checksum: ${results.flash.sourceChecksum}`);
     }
 
     return Bluebird.resolve();

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -13,7 +13,7 @@
           <h4 class="list-group-item-heading">{{ drive.description }} -
             <span class="word-keep">{{ drive.size | gigabyte | number:1 }} GB</span>
           </h4>
-          <p class="list-group-item-text">{{ drive.name }}</p>
+          <p class="list-group-item-text">{{ drive.displayName }}</p>
 
           <footer class="list-group-item-footer">
 

--- a/lib/gui/modules/drive-scanner.js
+++ b/lib/gui/modules/drive-scanner.js
@@ -17,7 +17,6 @@
 'use strict';
 
 const Rx = require('rx');
-const os = require('os');
 const _ = require('lodash');
 const EventEmitter = require('events').EventEmitter;
 const drivelist = require('drivelist');
@@ -38,19 +37,6 @@ const availableDrives = Rx.Observable.timer(
 
   .flatMap(() => {
     return Rx.Observable.fromNodeCallback(drivelist.list)();
-  })
-
-  // Build human friendly "description"
-  .map((drives) => {
-    return _.map(drives, (drive) => {
-      drive.name = drive.device;
-
-      if (os.platform() === 'win32' && !_.isEmpty(drive.mountpoints)) {
-        drive.name = _.join(_.map(drive.mountpoints, 'path'), ', ');
-      }
-
-      return drive;
-    });
   })
 
   .map((drives) => {

--- a/lib/gui/pages/main/templates/main.tpl.html
+++ b/lib/gui/pages/main/templates/main.tpl.html
@@ -62,7 +62,7 @@
             ng-class="{
               'text-disabled': main.shouldDriveStepBeDisabled()
             }"
-            uib-tooltip="{{ main.selection.getDrive().description }} ({{ main.selection.getDrive().name }})">
+            uib-tooltip="{{ main.selection.getDrive().description }} ({{ main.selection.getDrive().displayName }})">
             <span class="step-drive step-name">
               <!-- middleEllipses errors on undefined, therefore fallback to empty string -->
               {{ (main.selection.getDrive().description || "") | middleEllipses:11 }}

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -34,7 +34,7 @@ module.exports = {
 
     flashComplete: _.template([
       '<%= imageBasename %> was successfully written to',
-      '<%= drive.description %> (<%= drive.name %>)'
+      '<%= drive.description %> (<%= drive.displayName %>)'
     ].join(' '))
 
   },
@@ -102,7 +102,7 @@ module.exports = {
 
     flashFailure: _.template([
       'Something went wrong while writing <%= imageBasename %>',
-      'to <%= drive.description %> (<%= drive.name %>)'
+      'to <%= drive.description %> (<%= drive.displayName %>)'
     ].join(' ')),
 
     driveUnplugged: _.template([

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1302,9 +1302,9 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.0.27",
-      "from": "drivelist@5.0.27",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.0.27.tgz",
+      "version": "5.1.0",
+      "from": "drivelist@5.1.0",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.1.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bootstrap-sass": "3.3.6",
     "chalk": "1.1.3",
     "command-join": "2.0.0",
-    "drivelist": "5.0.27",
+    "drivelist": "5.1.0",
     "electron-is-running-in-asar": "1.0.0",
     "etcher-image-write": "9.1.3",
     "file-type": "4.1.0",

--- a/tests/gui/modules/drive-scanner.spec.js
+++ b/tests/gui/modules/drive-scanner.spec.js
@@ -81,6 +81,7 @@ describe('Browser: driveScanner', function() {
         this.drivelistStub.yields(null, [
           {
             device: '/dev/sda',
+            displayName: '/dev/sda',
             description: 'WDC WD10JPVX-75J',
             size: '931.5G',
             mountpoints: [
@@ -92,6 +93,7 @@ describe('Browser: driveScanner', function() {
           },
           {
             device: '/dev/sdb',
+            displayName: '/dev/sdb',
             description: 'Foo',
             size: '14G',
             mountpoints: [
@@ -103,6 +105,7 @@ describe('Browser: driveScanner', function() {
           },
           {
             device: '/dev/sdc',
+            displayName: '/dev/sdc',
             description: 'Bar',
             size: '14G',
             mountpoints: [
@@ -124,7 +127,7 @@ describe('Browser: driveScanner', function() {
           m.chai.expect(drives).to.deep.equal([
             {
               device: '/dev/sdb',
-              name: '/dev/sdb',
+              displayName: '/dev/sdb',
               description: 'Foo',
               size: '14G',
               mountpoints: [
@@ -136,7 +139,7 @@ describe('Browser: driveScanner', function() {
             },
             {
               device: '/dev/sdc',
-              name: '/dev/sdc',
+              displayName: '/dev/sdc',
               description: 'Bar',
               size: '14G',
               mountpoints: [
@@ -177,6 +180,7 @@ describe('Browser: driveScanner', function() {
         this.drivelistStub.yields(null, [
           {
             device: '\\\\.\\PHYSICALDRIVE1',
+            displayName: 'C:',
             description: 'WDC WD10JPVX-75J',
             size: '931.5G',
             mountpoints: [
@@ -188,6 +192,7 @@ describe('Browser: driveScanner', function() {
           },
           {
             device: '\\\\.\\PHYSICALDRIVE2',
+            displayName: '\\\\.\\PHYSICALDRIVE2',
             description: 'Foo',
             size: '14G',
             mountpoints: [],
@@ -195,6 +200,7 @@ describe('Browser: driveScanner', function() {
           },
           {
             device: '\\\\.\\PHYSICALDRIVE3',
+            displayName: 'F:',
             description: 'Bar',
             size: '14G',
             mountpoints: [
@@ -216,7 +222,7 @@ describe('Browser: driveScanner', function() {
           m.chai.expect(drives).to.deep.equal([
             {
               device: '\\\\.\\PHYSICALDRIVE2',
-              name: '\\\\.\\PHYSICALDRIVE2',
+              displayName: '\\\\.\\PHYSICALDRIVE2',
               description: 'Foo',
               size: '14G',
               mountpoints: [],
@@ -224,7 +230,7 @@ describe('Browser: driveScanner', function() {
             },
             {
               device: '\\\\.\\PHYSICALDRIVE3',
-              name: 'F:',
+              displayName: 'F:',
               description: 'Bar',
               size: '14G',
               mountpoints: [
@@ -252,6 +258,7 @@ describe('Browser: driveScanner', function() {
         this.drivelistStub.yields(null, [
           {
             device: '\\\\.\\PHYSICALDRIVE3',
+            displayName: 'F:',
             description: 'Bar',
             size: '14G',
             mountpoints: [
@@ -271,7 +278,7 @@ describe('Browser: driveScanner', function() {
       it('should use the drive letter as the name', function(done) {
         driveScanner.once('drives', function(drives) {
           m.chai.expect(drives).to.have.length(1);
-          m.chai.expect(drives[0].name).to.equal('F:');
+          m.chai.expect(drives[0].displayName).to.equal('F:');
           driveScanner.stop();
           done();
         });
@@ -288,6 +295,7 @@ describe('Browser: driveScanner', function() {
         this.drivesListStub.yields(null, [
           {
             device: '\\\\.\\PHYSICALDRIVE3',
+            displayName: 'F:, G:, H:',
             description: 'Bar',
             size: '14G',
             mountpoints: [
@@ -313,7 +321,7 @@ describe('Browser: driveScanner', function() {
       it('should join all the mountpoints in `name`', function(done) {
         driveScanner.once('drives', function(drives) {
           m.chai.expect(drives).to.have.length(1);
-          m.chai.expect(drives[0].name).to.equal('F:, G:, H:');
+          m.chai.expect(drives[0].displayName).to.equal('F:, G:, H:');
           driveScanner.stop();
           done();
         });


### PR DESCRIPTION
The `flashComplete` message takes the drive object and the image
basename as arguments. This was updated on the GUI, but causes the CLI
to throw an error upon completion.

Change-Type: patch
Changelog-Entry: Fix "imageBasename is not defined" error on the CLI.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>