### PR TITLE
feat: support rpi-sdcard image file type

### DIFF
--- a/lib/image-stream/supported.js
+++ b/lib/image-stream/supported.js
@@ -72,5 +72,9 @@ module.exports = [
   {
     extension: 'sdcard',
     type: 'image'
+  },
+  {
+    extension: 'rpi-sdimg',
+    type: 'image'
   }
 ];

--- a/tests/shared/supported-formats.spec.js
+++ b/tests/shared/supported-formats.spec.js
@@ -35,7 +35,7 @@ describe('Shared: SupportedFormats', function() {
 
     it('should return the supported non compressed extensions', function() {
       const extensions = supportedFormats.getNonCompressedExtensions();
-      m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'dsk', 'hddimg', 'raw', 'dmg', 'sdcard' ]);
+      m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'dsk', 'hddimg', 'raw', 'dmg', 'sdcard', 'rpi-sdimg' ]);
     });
 
   });


### PR DESCRIPTION
Support the rpi-sdcard image file type output by Yocto for
the Raspberry Pi device.

Changelog-Entry: Add support for .rpi-sdcard images.