### PR TITLE
upgrade: drivelist to v5.1.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1298,9 +1298,9 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.1.0",
-      "from": "drivelist@5.1.0",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.1.0.tgz",
+      "version": "5.1.3",
+      "from": "drivelist@5.1.3",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.1.3.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bootstrap-sass": "3.3.6",
     "chalk": "1.1.3",
     "command-join": "2.0.0",
-    "drivelist": "5.1.0",
+    "drivelist": "5.1.3",
     "electron-is-running-in-asar": "1.0.0",
     "etcher-image-write": "9.1.3",
     "file-type": "4.1.0",


### PR DESCRIPTION
This version contains the following fixes:

- Fix "Couldn't initialize the scanner: An unknown error occurred" error
- Fix "Couldn't scan the drives: An unknown error occurred" where there
  is a mounted virtual drive

See: https://github.com/resin-io-modules/drivelist/blob/master/CHANGELOG.md
Change-Type: patch
Changelog-Entry: Fix various drive scanning Windows errors.
Fixes: https://github.com/resin-io/etcher/issues/1646
Fixes: https://github.com/resin-io/etcher/issues/1639
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>