### PR TITLE
fix: ignore EHOSTDOWN errors when querying S3

### DIFF
--- a/lib/shared/s3-packages.js
+++ b/lib/shared/s3-packages.js
@@ -157,6 +157,8 @@ exports.getRemoteVersions = _.memoize((bucketUrl) => {
     }, {
       code: 'ETIMEDOUT'
     }, {
+      code: 'EHOSTDOWN'
+    }, {
 
       // May happen when behind a proxy
       code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'

--- a/tests/shared/s3-packages.spec.js
+++ b/tests/shared/s3-packages.spec.js
@@ -643,6 +643,29 @@ describe('Shared: s3Packages', function() {
 
     });
 
+    describe('given EHOSTDOWN', function() {
+
+      beforeEach(function() {
+        const error = new Error('EHOSTDOWN');
+        error.code = 'EHOSTDOWN';
+
+        this.requestGetAsyncStub = m.sinon.stub(request, 'getAsync');
+        this.requestGetAsyncStub.returns(Bluebird.reject(error));
+      });
+
+      afterEach(function() {
+        this.requestGetAsyncStub.restore();
+      });
+
+      it('should resolve an empty array', function(done) {
+        s3Packages.getRemoteVersions(s3Packages.BUCKET_URL.PRODUCTION).then((versions) => {
+          m.chai.expect(versions).to.deep.equal([]);
+          done();
+        }).catch(done);
+      });
+
+    });
+
     describe('given ECONNRESET', function() {
 
       beforeEach(function() {


### PR DESCRIPTION
There's not much we can do if we can't connect to S3 to determine the
latest available versions when checking if we should show an update
notification dialog or not.

As with similar errors, lets swallow this particular one, and try again
the next time Etcher runs.

Change-Type: patch
Changelog-Entry: Fix `EHOSTDOWN` error at startup.
Fixes: https://github.com/resin-io/etcher/issues/1645
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>