### PR TITLE
chore: add a publish-all make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,7 @@ TARGETS = \
 	package-cli \
 	cli-develop \
 	installers-all \
+	publish-all \
 	electron-develop
 
 changelog:
@@ -464,6 +465,7 @@ ifeq ($(RELEASE_TYPE),snapshot)
 		-k $(shell date +"%Y-%m-%d")))
 endif
 
+PUBLISHABLES += publish-aws-s3
 TARGETS += publish-aws-s3
 endif
 
@@ -478,6 +480,7 @@ publish-bintray-debian: $(PUBLISH_BINTRAY_DEBIAN)
 		-p $(BINTRAY_REPOSITORY_DEBIAN) \
 		-c $(BINTRAY_COMPONENT)))
 
+PUBLISHABLES += publish-bintray-debian
 TARGETS += publish-bintray-debian
 endif
 
@@ -492,8 +495,11 @@ publish-bintray-redhat: $(PUBLISH_BINTRAY_REDHAT)
 		-p $(BINTRAY_REPOSITORY_REDHAT) \
 		-c $(BINTRAY_COMPONENT)))
 
+PUBLISHABLES += publish-bintray-redhat
 TARGETS += publish-bintray-redhat
 endif
+
+publish-all: $(PUBLISHABLES)
 
 .PHONY: $(TARGETS)
 

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -48,8 +48,8 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
   ./scripts/build/docker/run-command.sh \
     -r "$ARGV_ARCHITECTURE" \
     -s "$(pwd)" \
-    -c "make installers-all"
+    -c "make publish-all"
 else
   ./scripts/build/check-dependency.sh make
-  make installers-all
+  make publish-all
 fi


### PR DESCRIPTION
The CI servers currently call `installers-all` to deploy snapshot
builds, however that target builds the installers, but doesn't call the
phony rules that actually publishes them.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>