### PR TITLE
chore: enforce single quotes in ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -265,6 +265,9 @@ rules:
   operator-assignment:
     - error
     - always
+  quotes:
+    - error
+    - single
   quote-props:
     - error
     - as-needed

--- a/tests/gui/components/svg-icon.spec.js
+++ b/tests/gui/components/svg-icon.spec.js
@@ -75,7 +75,7 @@ describe('Browser: SVGIcon', function () {
     it('should use an empty src if there is a parsererror', function () {
       // The following is invalid, because there's no closing tag for `foreignObject`
       const iconContents = '<svg><foreignObject></svg>'
-      const imgData = `data:image/svg+xml,`
+      const imgData = 'data:image/svg+xml,'
       $rootScope.iconContents = iconContents
 
       const element = $compile('<svg-icon path="iconContents">Resin.io</svg-icon>')($rootScope)


### PR DESCRIPTION
We recently adopted the standardjs guidelines ESLint, which doesn't seem
to enforce single quotes, even though the guidelines mention it.

See: https://github.com/resin-io/etcher/pull/1663#discussion_r131623802
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>