### PR TITLE
upgrade: drivelist to v5.1.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1304,9 +1304,9 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.1.4",
-      "from": "drivelist@5.1.4",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.1.4.tgz",
+      "version": "5.1.5",
+      "from": "drivelist@5.1.5",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.1.5.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "bootstrap-sass": "3.3.6",
     "chalk": "1.1.3",
     "command-join": "2.0.0",
-    "drivelist": "5.1.4",
+    "drivelist": "5.1.5",
     "electron-is-running-in-asar": "1.0.0",
     "etcher-image-write": "9.1.3",
     "file-type": "4.1.0",


### PR DESCRIPTION
See https://github.com/resin-io-modules/drivelist/pull/206

Change-Type: patch
Changelog-Entry: Fix "Couldn't scan the drives: An unknown error occurred" error when there is a drive locked with BitLocker.
Fixes: https://github.com/resin-io/etcher/issues/1687
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>