### PR TITLE
chore: cache Travis CI docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
     - $HOME/Library/Caches/electron
     - $HOME/Library/Caches/electron-builder
     - $HOME/.pkg-cache
+    - $HOME/docker
     - node_modules
 
 services:
@@ -35,6 +36,7 @@ env:
     - CC="clang"
     - CXX="clang++"
     - HOMEBREW_NO_AUTO_UPDATE=1
+    - DOCKER_CACHE_FILE=$HOME/docker/cache.tar.gz
   matrix:
     - TARGET_ARCH=x64
     - TARGET_ARCH=x86
@@ -50,6 +52,9 @@ os:
   - osx
 
 before_install:
+  - if [ -f ${DOCKER_CACHE_FILE} ] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      gunzip -c ${DOCKER_CACHE_FILE} | docker load;
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export HOST_OS="darwin";
@@ -63,6 +68,10 @@ install:
 script:
   - ./scripts/ci/test.sh -o $HOST_OS -r $TARGET_ARCH
   - ./scripts/ci/build-installers.sh -o $HOST_OS -r $TARGET_ARCH
+  - if [[ ${TRAVIS_BRANCH} == "master" ]] && [[ ${TRAVIS_PULL_REQUEST} == "false" ]]; then
+      mkdir -p $(dirname ${DOCKER_CACHE_FILE});
+      docker save $(docker history -q ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE};
+    fi
 
 deploy:
   provider: script


### PR DESCRIPTION
Let's see if we can reduce the time it gets to build and test Etcher on
GNU/Linux.

See: https://giorgos.sealabs.net/docker-cache-on-travis-and-docker-112.html
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>