### PR TITLE
chore: fix build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ os:
   - osx
 
 before_install:
-  - if [ -f ${DOCKER_CACHE_FILE} ] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      gunzip -c ${DOCKER_CACHE_FILE} | docker load;
+  - if [ -f ${DOCKER_CACHE_FILE}.${TARGET_ARCH} ] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      gunzip -c ${DOCKER_CACHE_FILE}.${TARGET_ARCH} | docker load;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -68,9 +68,9 @@ install:
 script:
   - ./scripts/ci/test.sh -o $HOST_OS -r $TARGET_ARCH
   - ./scripts/ci/build-installers.sh -o $HOST_OS -r $TARGET_ARCH
-  - if [[ ${TRAVIS_BRANCH} == "master" ]] && [[ ${TRAVIS_PULL_REQUEST} == "false" ]]; then
+  - if [[ ${TRAVIS_BRANCH} == "master" ]] && [[ ${TRAVIS_PULL_REQUEST} == "false" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       mkdir -p $(dirname ${DOCKER_CACHE_FILE});
-      docker save $(docker history -q ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE};
+      docker save $(docker history -q ${DOCKER_REPOSITORY}:${TRAVIS_COMMIT} | grep -v '<missing>') | gzip > ${DOCKER_CACHE_FILE}.${TARGET_ARCH};
     fi
 
 deploy:

--- a/scripts/publish/bintray.sh
+++ b/scripts/publish/bintray.sh
@@ -95,17 +95,13 @@ PACKAGE_FILE_NAME=$(basename $ARGV_FILE)
 PACKAGE_NAME=${PACKAGE_FILE_NAME%.*}
 PACKAGE_ARCHITECTURE=$(./scripts/build/architecture-convert.sh -r "$ARGV_ARCHITECTURE" -t "$ARGV_TYPE")
 
-BINTRAY_HEADERS="--header \"X-Bintray-Override: 1\" --header \"X-Bintray-Publish: 1\""
-
-if [ "$ARGV_TYPE" == "debian" ]; then
-  BINTRAY_HEADERS="$BINTRAY_HEADERS --header \"X-Bintray-Debian-Distribution: $PACKAGE_DISTRIBUTION\""
-  BINTRAY_HEADERS="$BINTRAY_HEADERS --header \"X-Bintray-Debian-Component: $ARGV_COMPONENT\""
-  BINTRAY_HEADERS="$BINTRAY_HEADERS --header \"X-Bintray-Debian-Architecture: $PACKAGE_ARCHITECTURE\""
-fi
-
 curl --upload-file $ARGV_FILE \
   --user $BINTRAY_USER:$BINTRAY_API_KEY \
-  $BINTRAY_HEADERS \
+  --header "X-Bintray-Override: 1" \
+  --header "X-Bintray-Publish: 1" \
+  --header "X-Bintray-Debian-Distribution: $PACKAGE_DISTRIBUTION" \
+  --header "X-Bintray-Debian-Component: $ARGV_COMPONENT" \
+  --header "X-Bintray-Debian-Architecture: $PACKAGE_ARCHITECTURE" \
   https://api.bintray.com/content/$ARGV_ORGANIZATION/$ARGV_REPOSITORY/$ARGV_COMPONENT/$ARGV_VERSION/$PACKAGE_FILE_NAME
 
 echo "$ARGV_FILE has been uploaded successfully"


### PR DESCRIPTION
- Bintray deployments are broken because of some bash nested quoting
  issue
- Travis CI will attempt to cache Docker layers on macOS
- Docker caches from different architectures will override each other

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>