### PR TITLE
feat: bring usbboot into drive scanner

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -195,13 +195,13 @@ app.run(() => {
 })
 
 app.run(($timeout) => {
-  driveScanner.on('drives', (drives) => {
+  driveScanner.on('devices', (devices) => {
     // Safely trigger a digest cycle.
     // In some cases, AngularJS doesn't acknowledge that the
     // available drives list has changed, and incorrectly
     // keeps asking the user to "Connect a drive".
     $timeout(() => {
-      availableDrives.setDrives(drives)
+      availableDrives.setDrives(devices)
     })
   })
 

--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -10,7 +10,7 @@
       ng-dblclick="modal.selectDriveAndClose(drive)"
       ng-click="modal.toggleDrive(drive)">
         <div>
-          <h4 class="list-group-item-heading">{{ drive.description }} -
+          <h4 class="list-group-item-heading">{{ drive.description }} {{ drive.size ? ' - ' : '' }}
             <span class="word-keep">{{ drive.size | closestUnit }}</span>
           </h4>
           <p class="list-group-item-text">{{ drive.displayName }}</p>

--- a/lib/gui/modules/drive-scanner.js
+++ b/lib/gui/modules/drive-scanner.js
@@ -21,12 +21,59 @@ const _ = require('lodash')
 const EventEmitter = require('events').EventEmitter
 const drivelist = require('drivelist')
 const settings = require('../models/settings')
+const usbboot = require('../../shared/sdk/usbboot')
 
 const DRIVE_SCANNER_INTERVAL_MS = 2000
 const DRIVE_SCANNER_FIRST_SCAN_DELAY_MS = 0
 const emitter = new EventEmitter()
 
 /* eslint-disable lodash/prefer-lodash-method */
+
+/**
+ * @summary
+ *
+ * @param {Function} callback - two argument function callback of (err, result)
+ *
+ * @example
+ */
+const lister = (callback) => {
+  drivelist.list((driveError, drives) => {
+    if (driveError) {
+      return callback(driveError)
+    }
+
+    const typeDrives = _.map(drives, (drive) => {
+      return _.assign({}, drive, {
+        type: 'BLOCK_DEVICE'
+      })
+    })
+
+    return usbboot.scan().then((usbDevices) => {
+      const typeUsbDevices = _.map(usbDevices, (usbDevice) => {
+        const description = `Bus ${usbDevice.busNumber} / Address ${usbDevice.deviceAddress}`
+
+        return _.assign({}, usbDevice, {
+          type: 'USB_DEVICE',
+          description: usbDevice.name,
+          device: description,
+          displayName: description,
+          protected: false,
+          size: null,
+          system: false
+        })
+      })
+
+      callback(null, _.concat(typeUsbDevices, typeDrives))
+    }).catch((err) => {
+      const LIBUSB_TRANSFER_STALL = 4
+      if (err.errno === LIBUSB_TRANSFER_STALL) {
+        return callback(null, typeDrives)
+      }
+
+      return callback(err)
+    })
+  })
+}
 
 const availableDrives = Rx.Observable.timer(
   DRIVE_SCANNER_FIRST_SCAN_DELAY_MS,
@@ -36,15 +83,15 @@ const availableDrives = Rx.Observable.timer(
 /* eslint-enable lodash/prefer-lodash-method */
 
   .flatMap(() => {
-    return Rx.Observable.fromNodeCallback(drivelist.list)()
+    return Rx.Observable.fromNodeCallback(lister)()
   })
 
-  .map((drives) => {
+  .map((devices) => {
     if (settings.get('unsafeMode')) {
-      return drives
+      return devices
     }
 
-    return _.reject(drives, {
+    return _.reject(devices, {
       system: true
     })
   })
@@ -68,8 +115,8 @@ const availableDrives = Rx.Observable.timer(
  * });
  * ```
  */
-availableDrives.subscribe((drives) => {
-  emitter.emit('drives', drives)
+availableDrives.subscribe((devices) => {
+  emitter.emit('devices', devices)
 }, (error) => {
   emitter.emit('error', error)
 })

--- a/lib/shared/drive-constraints.js
+++ b/lib/shared/drive-constraints.js
@@ -144,6 +144,11 @@ exports.isSourceDrive = (drive, image) => {
 exports.isDriveLargeEnough = (drive, image) => {
   const driveSize = _.get(drive, [ 'size' ], UNKNOWN_SIZE)
 
+  // There is no driveSize information available
+  if (driveSize === null) {
+    return true
+  }
+
   if (_.get(image, [ 'size', 'final', 'estimation' ])) {
     // If the drive size is smaller than the original image size, and
     // the final image size is just an estimation, then we stop right

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This work is heavily based on https://github.com/raspberrypi/usbboot
+ * Copyright 2016 Raspberry Pi Foundation
+ */
+
+'use strict'
+
+const _ = require('lodash')
+const Bluebird = require('bluebird')
+const debug = require('debug')('sdk:usbboot')
+const usb = require('./usb')
+const protocol = require('./protocol')
+
+/**
+ * @summary Vendor ID of "Broadcom Corporation"
+ * @type {Number}
+ * @constant
+ */
+const USB_VENDOR_ID_BROADCOM_CORPORATION = 0x0a5c
+
+/**
+ * @summary List of usbboot capable devices
+ * @type {Object[]}
+ * @constant
+ */
+const USBBOOT_CAPABLE_USB_DEVICES = [
+
+  // BCM2835
+
+  {
+    vendorID: USB_VENDOR_ID_BROADCOM_CORPORATION,
+    productID: 0x2763
+  },
+
+  // BCM2837
+
+  {
+    vendorID: USB_VENDOR_ID_BROADCOM_CORPORATION,
+    productID: 0x2764
+  }
+
+]
+
+/**
+ * @summary The number of USB endpoint interfaces in devices with a BCM2835 SoC
+ * @type {Number}
+ * @constant
+ */
+const USB_ENDPOINT_INTERFACES_SOC_BCM2835 = 1
+
+/**
+ * @summary The delay to wait between each USB read/write operation
+ * @type {Number}
+ * @constant
+ * @description
+ * The USB bus seems to hang if we execute many operations at
+ * the same time.
+ */
+const USB_OPERATION_DELAY_MS = 1000
+
+/**
+ * @summary The USB device descriptor index of an empty property
+ * @type {Number}
+ * @constant
+ */
+const USB_DESCRIPTOR_NULL_INDEX = 0
+
+/**
+ * @summary Check if a node-usb device object is usbboot-capable
+ * @function
+ * @private
+ *
+ * @param {Object} device - device
+ * @returns {Boolean} whether the device is usbboot-capable
+ *
+ * @example
+ * if (isUsbBootCapableUSBDevice({ ... })) {
+ *   console.log('We can use usbboot on this device')
+ * }
+ */
+const isUsbBootCapableUSBDevice = (device) => {
+  return _.some(USBBOOT_CAPABLE_USB_DEVICES, {
+    vendorID: device.deviceDescriptor.idVendor,
+    productID: device.deviceDescriptor.idProduct
+  })
+}
+
+/**
+ * @summary Scan for usbboot USB capable devices
+ * @function
+ * @public
+ *
+ * @fulfil {Object[]} - USB devices
+ * @returns {Promise}
+ *
+ * @example
+ * usbboot.scan().each((device) => {
+ *   console.log(device)
+ * })
+ */
+exports.scan = () => {
+  /* eslint-disable lodash/prefer-lodash-method */
+  return usb.listDevices().filter(isUsbBootCapableUSBDevice).map((device) => {
+  /* eslint-enable lodash/prefer-lodash-method */
+
+    // We must keep the original device object from `node-usb`,
+    // since it has functions in its prototype we must use later on
+    const deviceWrapper = {
+      instance: device
+    }
+
+    // We need to open the device in order to access _configDescriptor
+    device.open()
+
+    // Handle 2837 where it can start with two interfaces, the first
+    // is mass storage the second is the vendor interface for programming
+
+    /* eslint-disable no-underscore-dangle */
+    if (device._configDescriptor.bNumInterfaces === USB_ENDPOINT_INTERFACES_SOC_BCM2835) {
+    /* eslint-enable no-underscore-dangle */
+      deviceWrapper.interface = 0
+      deviceWrapper.outEndpoint = 1
+    } else {
+      deviceWrapper.interface = 1
+      deviceWrapper.outEndpoint = 3
+    }
+
+    return usb.getDeviceName(device).then((name) => {
+      deviceWrapper.name = name
+      return deviceWrapper
+    }).finally(_.bind(device.close, device))
+  })
+}
+
+/**
+ * @summary Wait for a USB device
+ * @function
+ * @private
+ *
+ * @description
+ * This function returns the *first* device that matches
+ * the specified criteria.
+ *
+ * @param {Object} properties - properties of the expected device
+ * @param {Object} options - options
+ * @param {Number} options.retries - number of retries before giving up
+ * @param {Number} options.delay - milliseconds before each retry
+ * @fulfil {(Object|Undefined)} - device
+ * @returns {Promise}
+ *
+ * @example
+ * return waitForDevice({
+ *   deviceDescriptor: {
+ *     idVendor: 0x0a5c
+ *   }
+ * }, {
+ *   retries: 10,
+ *   delay: 500
+ * }).then((device) => {
+ *   if (device) {
+ *     console.log('Found!')
+ *   }
+ * })
+ */
+const waitForDevice = (properties, options) => {
+  return exports.scan().then((devices) => {
+    return _.find(devices, (device) => {
+      return _.matches(properties, device.instance)
+    })
+  }).then((device) => {
+    if (_.isNil(device) && options.retries) {
+      return Bluebird.delay(options.delay).then(() => {
+        const INTERVAL_DECREASE_FACTOR = 1
+        return waitForDevice(properties, {
+          retries: options.retries - INTERVAL_DECREASE_FACTOR,
+          delay: options.delay
+        })
+      })
+    }
+
+    return device
+  })
+}
+
+exports.flash = (device, options = {}) => {
+  debug('Opening device')
+  device.instance.open()
+
+  return usb.findInterface(device.instance, device.interface).then((deviceInterface) => {
+    debug(`Claiming interface: ${device.interface}`)
+    deviceInterface.claim()
+
+    const serialNumberIndex = device.instance.deviceDescriptor.iSerialNumber
+    debug(`Serial number index: ${serialNumberIndex}`)
+
+    return Bluebird.try(() => {
+      if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
+        debug('Writing bootcode')
+        debug(`Bootcode buffer length: ${options.bootcode.length}`)
+        const bootMessageBuffer = protocol.createBootMessageBuffer(options.bootcode.length)
+
+        return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).tap((endpoint) => {
+          debug('Writing boot message buffer to out endpoint')
+          return protocol.write(device, endpoint, bootMessageBuffer)
+        }).then((endpoint) => {
+          debug('Writing boot code buffer to out endpoint')
+          return protocol.write(device, endpoint, options.bootcode)
+        }).then(() => {
+          debug('Reading return code from device')
+          return protocol.read(device, protocol.RETURN_CODE_LENGTH)
+        }).then((data) => {
+          const returnCode = data.readInt32BE()
+          debug(`Received return code: ${returnCode}`)
+
+          if (returnCode !== protocol.RETURN_CODE_SUCCESS) {
+            throw new Error(`Couldn't write the bootcode, got return code ${returnCode} from device`)
+          }
+        }).delay(USB_OPERATION_DELAY_MS).then(() => {
+          debug('Waiting for device to come back')
+          return waitForDevice({
+            deviceDescriptor: {
+              idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
+              idProduct: 0x2764,
+              iSerialNumber: 1
+            }
+          }, {
+            retries: 5,
+            delay: 1000
+          })
+        }).then((newDevice) => {
+          if (_.isNil(newDevice)) {
+            throw new Error(`Device ${device.deviceDescriptor.idVendor}:${device.deviceDescriptor.idProduct} never came back`)
+          }
+
+          return exports.flash(newDevice, options)
+        })
+      }
+
+      debug('Starting file server')
+      return Bluebird.resolve()
+    }).then(() => {
+      return Bluebird
+        .fromCallback(_.bind(deviceInterface.release, deviceInterface))
+        .finally(_.bind(device.instance.close, device.instance))
+    })
+  })
+}

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -306,7 +306,7 @@ exports.flash = (device, options = {}) => {
         })
       }).then((newDevice) => {
         if (_.isNil(newDevice)) {
-          throw new Error(`Device ${device.deviceDescriptor.idVendor}:${device.deviceDescriptor.idProduct} never came back`)
+          throw new Error(`Device ${device.instance.deviceDescriptor.idVendor}:${device.instance.deviceDescriptor.idProduct} never came back`)
         }
 
         return exports.flash(newDevice, options)

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -155,9 +155,7 @@ exports.scan = () => {
  */
 const waitForDevice = (properties, options) => {
   return exports.scan().then((devices) => {
-    return _.find(devices, (device) => {
-      return _.matches(properties, device)
-    })
+    return _.find(devices, properties)
   }).then((device) => {
     if (_.isNil(device) && options.retries) {
       return Bluebird.delay(options.delay).then(() => {

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -118,33 +118,8 @@ exports.scan = () => {
   /* eslint-disable lodash/prefer-lodash-method */
   return usb.listDevices().filter(isUsbBootCapableUSBDevice).map((device) => {
   /* eslint-enable lodash/prefer-lodash-method */
-
-    // We must keep the original device object from `node-usb`,
-    // since it has functions in its prototype we must use later on
-    const deviceWrapper = {
-      instance: device
-    }
-
-    // We need to open the device in order to access _configDescriptor
-    device.open()
-
-    // Handle 2837 where it can start with two interfaces, the first
-    // is mass storage the second is the vendor interface for programming
-
-    /* eslint-disable no-underscore-dangle */
-    if (device._configDescriptor.bNumInterfaces === USB_ENDPOINT_INTERFACES_SOC_BCM2835) {
-    /* eslint-enable no-underscore-dangle */
-      deviceWrapper.interface = 0
-      deviceWrapper.outEndpoint = 1
-    } else {
-      deviceWrapper.interface = 1
-      deviceWrapper.outEndpoint = 3
-    }
-
-    return usb.getDeviceName(device).then((name) => {
-      deviceWrapper.name = name
-      return deviceWrapper
-    }).finally(_.bind(device.close, device))
+    device.name = `USB device (${device.deviceDescriptor.idVendor.toString(16)}:${device.deviceDescriptor.idProduct.toString(16)})`
+    return device
   })
 }
 
@@ -181,7 +156,7 @@ exports.scan = () => {
 const waitForDevice = (properties, options) => {
   return exports.scan().then((devices) => {
     return _.find(devices, (device) => {
-      return _.matches(properties, device.instance)
+      return _.matches(properties, device)
     })
   }).then((device) => {
     if (_.isNil(device) && options.retries) {
@@ -198,18 +173,8 @@ const waitForDevice = (properties, options) => {
   })
 }
 
-// TODO: Log vendor/product pair
-const openDevice = (device, interfaceAddress) => {
-  debug('Opening device')
-  device.open()
-  const deviceInterface = device.interface(interfaceAddress)
-  debug(`Claiming interface: ${interfaceAddress}`)
-  deviceInterface.claim()
-}
-
-// TODO: Log vendor/product pair
 const closeDevice = (device) => {
-  debug('Closing device')
+  debug(`Closing device: ${device.name}`)
   device.close()
 }
 
@@ -297,16 +262,35 @@ const startFileServer = (device, endpoint, files) => {
 }
 
 exports.flash = (device, options = {}) => {
-  const deviceName = `${device.instance.deviceDescriptor.idVendor}:${device.instance.deviceDescriptor.idProduct}`
-  openDevice(device.instance, device.interface)
-  const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
+  // We need to open the device in order to access _configDescriptor
+  debug(`Opening device: ${device.name}`)
+  device.open()
 
-  const serialNumberIndex = device.instance.deviceDescriptor.iSerialNumber
+  // Handle 2837 where it can start with two interfaces, the first
+  // is mass storage the second is the vendor interface for programming
+  const addresses = {}
+  /* eslint-disable no-underscore-dangle */
+  if (device._configDescriptor.bNumInterfaces === USB_ENDPOINT_INTERFACES_SOC_BCM2835) {
+  /* eslint-enable no-underscore-dangle */
+    addresses.interface = 0
+    addresses.endpoint = 1
+  } else {
+    addresses.interface = 1
+    addresses.endpoint = 3
+  }
+
+  const deviceInterface = device.interface(addresses.interface)
+  debug(`Claiming interface: ${addresses.interface}`)
+  deviceInterface.claim()
+
+  const endpoint = deviceInterface.endpoint(addresses.endpoint)
+
+  const serialNumberIndex = device.deviceDescriptor.iSerialNumber
   debug(`Serial number index: ${serialNumberIndex}`)
 
   if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
-    return writeBootCode(device.instance, endpoint, _.get(options.files, [ 'bootcode.bin' ]))
-      .finally(_.partial(closeDevice, device.instance))
+    return writeBootCode(device, endpoint, _.get(options.files, [ 'bootcode.bin' ]))
+      .finally(_.partial(closeDevice, device))
       .delay(USB_OPERATION_DELAY_MS).then(() => {
         debug('Waiting for device to come back')
         return waitForDevice({
@@ -321,7 +305,7 @@ exports.flash = (device, options = {}) => {
         })
       }).then((newDevice) => {
         if (_.isNil(newDevice)) {
-          throw new Error(`Device ${deviceName} never came back`)
+          throw new Error(`Device ${device.name} never came back`)
         }
 
         return exports.flash(newDevice, options)
@@ -329,6 +313,6 @@ exports.flash = (device, options = {}) => {
   }
 
   debug('Starting file server')
-  return startFileServer(device.instance, endpoint, options.files)
-    .finally(_.partial(closeDevice, device.instance))
+  return startFileServer(device, endpoint, options.files)
+    .finally(_.partial(closeDevice, device))
 }

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -220,10 +220,6 @@ const startFileServer = (device, files) => {
           debug('Sending error signal')
           return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
             return protocol.sendErrorSignal(device, endpoint)
-          }).then(() => {
-            if (fileMessage.fileName === 'fixup.dat') {
-              return true
-            }
           })
         }
 
@@ -249,11 +245,7 @@ const startFileServer = (device, files) => {
       }
 
       throw new Error(`Unrecognized command: ${fileMessage.command}`)
-    }).then((abort) => {
-      if (abort) {
-        debug('ABORT')
-        return
-      }
+    }).then(() => {
       return startFileServer(device, files)
     })
 }

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -208,31 +208,15 @@ const startFileServer = (device, files) => {
 
       if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_DONE) {
         debug('Done')
-        return
+        return Bluebird.resolve()
       }
 
-      if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_GET_FILE_SIZE) {
-        debug(`Getting the size of ${fileMessage.fileName}`)
-        const fileSize = _.get(files, [ fileMessage.fileName, 'length' ])
+      return Bluebird.try(() => {
+        if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_GET_FILE_SIZE) {
+          debug(`Getting the size of ${fileMessage.fileName}`)
+          const fileSize = _.get(files, [ fileMessage.fileName, 'length' ])
 
-        if (_.isNil(fileSize)) {
-          debug(`Couldn't find ${fileMessage.fileName}`)
-          debug('Sending error signal')
-          return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
-            return protocol.sendErrorSignal(device, endpoint)
-          })
-        }
-
-        debug(`Sending size: ${fileSize}`)
-        return protocol.sendBufferSize(device, fileSize)
-      }
-
-      if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_READ_FILE) {
-        debug(`Reading ${fileMessage.fileName}`)
-        return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
-          const fileBuffer = _.get(files, [ fileMessage.fileName ])
-
-          if (_.isNil(fileBuffer)) {
+          if (_.isNil(fileSize)) {
             debug(`Couldn't find ${fileMessage.fileName}`)
             debug('Sending error signal')
             return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
@@ -240,13 +224,29 @@ const startFileServer = (device, files) => {
             })
           }
 
-          return protocol.write(device, endpoint, fileBuffer)
-        })
-      }
+          debug(`Sending size: ${fileSize}`)
+          return protocol.sendBufferSize(device, fileSize)
+        }
 
-      throw new Error(`Unrecognized command: ${fileMessage.command}`)
-    }).then(() => {
-      return startFileServer(device, files)
+        if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_READ_FILE) {
+          debug(`Reading ${fileMessage.fileName}`)
+          return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
+            const fileBuffer = _.get(files, [ fileMessage.fileName ])
+
+            if (_.isNil(fileBuffer)) {
+              debug(`Couldn't find ${fileMessage.fileName}`)
+              debug('Sending error signal')
+              return protocol.sendErrorSignal(device, endpoint)
+            }
+
+            return protocol.write(device, endpoint, fileBuffer)
+          })
+        }
+
+        return Bluebird.reject(new Error(`Unrecognized command: ${fileMessage.command}`))
+      }).then(() => {
+        return startFileServer(device, files)
+      })
     })
 }
 

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -211,6 +211,8 @@ const startFileServer = (device, files) => {
         return Bluebird.resolve()
       }
 
+      const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
+
       return Bluebird.try(() => {
         if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_GET_FILE_SIZE) {
           debug(`Getting the size of ${fileMessage.fileName}`)
@@ -219,9 +221,7 @@ const startFileServer = (device, files) => {
           if (_.isNil(fileSize)) {
             debug(`Couldn't find ${fileMessage.fileName}`)
             debug('Sending error signal')
-            return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
-              return protocol.sendErrorSignal(device, endpoint)
-            })
+            return protocol.sendErrorSignal(device, endpoint)
           }
 
           debug(`Sending size: ${fileSize}`)
@@ -230,23 +230,28 @@ const startFileServer = (device, files) => {
 
         if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_READ_FILE) {
           debug(`Reading ${fileMessage.fileName}`)
-          return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
-            const fileBuffer = _.get(files, [ fileMessage.fileName ])
+          const fileBuffer = _.get(files, [ fileMessage.fileName ])
 
-            if (_.isNil(fileBuffer)) {
-              debug(`Couldn't find ${fileMessage.fileName}`)
-              debug('Sending error signal')
-              return protocol.sendErrorSignal(device, endpoint)
-            }
+          if (_.isNil(fileBuffer)) {
+            debug(`Couldn't find ${fileMessage.fileName}`)
+            debug('Sending error signal')
+            return protocol.sendErrorSignal(device, endpoint)
+          }
 
-            return protocol.write(device, endpoint, fileBuffer)
-          })
+          return protocol.write(device, endpoint, fileBuffer)
         }
 
         return Bluebird.reject(new Error(`Unrecognized command: ${fileMessage.command}`))
       }).then(() => {
+        debug('Starting again')
         return startFileServer(device, files)
       })
+    }).catch({
+      message: 'LIBUSB_ERROR_NO_DEVICE'
+    }, {
+      message: 'LIBUSB_ERROR_IO'
+    }, (error) => {
+      debug(`Done, given we got ${error.message}`)
     })
 }
 
@@ -268,10 +273,10 @@ exports.flash = (device, options = {}) => {
       debug(`Bootcode buffer length: ${bootCodeBuffer.length}`)
       const bootMessageBuffer = protocol.createBootMessageBuffer(bootCodeBuffer.length)
 
-      return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).tap((endpoint) => {
-        debug('Writing boot message buffer to out endpoint')
-        return protocol.write(device, endpoint, bootMessageBuffer)
-      }).then((endpoint) => {
+      const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
+
+      debug('Writing boot message buffer to out endpoint')
+      return protocol.write(device, endpoint, bootMessageBuffer).then(() => {
         debug('Writing boot code buffer to out endpoint')
         return protocol.write(device, endpoint, bootCodeBuffer)
       }).then(() => {
@@ -284,6 +289,9 @@ exports.flash = (device, options = {}) => {
         if (returnCode !== protocol.RETURN_CODE_SUCCESS) {
           throw new Error(`Couldn't write the bootcode, got return code ${returnCode} from device`)
         }
+      }).finally(() => {
+        debug('Closing device instance')
+        return device.instance.close()
       }).delay(USB_OPERATION_DELAY_MS).then(() => {
         debug('Waiting for device to come back')
         return waitForDevice({
@@ -306,10 +314,9 @@ exports.flash = (device, options = {}) => {
     }
 
     debug('Starting file server')
-    return startFileServer(device, options.files)
-  }).then(() => {
-    return Bluebird
-      .fromCallback(_.bind(deviceInterface.release, deviceInterface))
-      .finally(_.bind(device.instance.close, device.instance))
+    return startFileServer(device, options.files).then(() => {
+      debug('Closing new device instance')
+      device.instance.close()
+    })
   })
 }

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -198,12 +198,25 @@ const waitForDevice = (properties, options) => {
   })
 }
 
-const writeBootCode = (device, bootCodeBuffer) => {
+// TODO: Log vendor/product pair
+const openDevice = (device, interfaceAddress) => {
+  debug('Opening device')
+  device.open()
+  const deviceInterface = device.interface(interfaceAddress)
+  debug(`Claiming interface: ${interfaceAddress}`)
+  deviceInterface.claim()
+}
+
+// TODO: Log vendor/product pair
+const closeDevice = (device) => {
+  debug('Closing device')
+  device.close()
+}
+
+const writeBootCode = (device, endpoint, bootCodeBuffer) => {
   debug('Writing bootcode')
   debug(`Bootcode buffer length: ${bootCodeBuffer.length}`)
   const bootMessageBuffer = protocol.createBootMessageBuffer(bootCodeBuffer.length)
-
-  const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
 
   debug('Writing boot message buffer to out endpoint')
   return protocol.write(device, endpoint, bootMessageBuffer).then(() => {
@@ -222,7 +235,7 @@ const writeBootCode = (device, bootCodeBuffer) => {
   })
 }
 
-const startFileServer = (device, files) => {
+const startFileServer = (device, endpoint, files) => {
   debug('Listening for file messages')
   return protocol
     .read(device, protocol.FILE_MESSAGE_LENGTH)
@@ -246,8 +259,6 @@ const startFileServer = (device, files) => {
         debug('Done')
         return Bluebird.resolve()
       }
-
-      const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
 
       return Bluebird.try(() => {
         if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_GET_FILE_SIZE) {
@@ -280,51 +291,44 @@ const startFileServer = (device, files) => {
         return Bluebird.reject(new Error(`Unrecognized command: ${fileMessage.command}`))
       }).then(() => {
         debug('Starting again')
-        return startFileServer(device, files)
+        return startFileServer(device, endpoint, files)
       })
     })
 }
 
 exports.flash = (device, options = {}) => {
-  debug('Opening device')
-  device.instance.open()
-
-  const deviceInterface = device.instance.interface(device.interface)
-  debug(`Claiming interface: ${device.interface}`)
-  deviceInterface.claim()
+  const deviceName = `${device.instance.deviceDescriptor.idVendor}:${device.instance.deviceDescriptor.idProduct}`
+  openDevice(device.instance, device.interface)
+  const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
 
   const serialNumberIndex = device.instance.deviceDescriptor.iSerialNumber
   debug(`Serial number index: ${serialNumberIndex}`)
 
   if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
-    return writeBootCode(device, _.get(options.files, [ 'bootcode.bin' ])).finally(() => {
-      debug('Closing device instance')
-      return device.instance.close()
-    }).delay(USB_OPERATION_DELAY_MS).then(() => {
-      debug('Waiting for device to come back')
-      return waitForDevice({
-        deviceDescriptor: {
-          idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
-          idProduct: 0x2764,
-          iSerialNumber: 1
+    return writeBootCode(device.instance, endpoint, _.get(options.files, [ 'bootcode.bin' ]))
+      .finally(_.partial(closeDevice, device.instance))
+      .delay(USB_OPERATION_DELAY_MS).then(() => {
+        debug('Waiting for device to come back')
+        return waitForDevice({
+          deviceDescriptor: {
+            idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
+            idProduct: 0x2764,
+            iSerialNumber: 1
+          }
+        }, {
+          retries: 5,
+          delay: 1000
+        })
+      }).then((newDevice) => {
+        if (_.isNil(newDevice)) {
+          throw new Error(`Device ${deviceName} never came back`)
         }
-      }, {
-        retries: 5,
-        delay: 1000
-      })
-    }).then((newDevice) => {
-      if (_.isNil(newDevice)) {
-        const deviceName = `${device.instance.deviceDescriptor.idVendor}:${device.instance.deviceDescriptor.idProduct}`
-        throw new Error(`Device ${deviceName} never came back`)
-      }
 
-      return exports.flash(newDevice, options)
-    })
+        return exports.flash(newDevice, options)
+      })
   }
 
   debug('Starting file server')
-  return startFileServer(device, options.files).finally(() => {
-    debug('Closing new device instance')
-    device.instance.close()
-  })
+  return startFileServer(device.instance, endpoint, options.files)
+    .finally(_.partial(closeDevice, device.instance))
 }

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -198,6 +198,30 @@ const waitForDevice = (properties, options) => {
   })
 }
 
+const writeBootCode = (device, bootCodeBuffer) => {
+  debug('Writing bootcode')
+  debug(`Bootcode buffer length: ${bootCodeBuffer.length}`)
+  const bootMessageBuffer = protocol.createBootMessageBuffer(bootCodeBuffer.length)
+
+  const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
+
+  debug('Writing boot message buffer to out endpoint')
+  return protocol.write(device, endpoint, bootMessageBuffer).then(() => {
+    debug('Writing boot code buffer to out endpoint')
+    return protocol.write(device, endpoint, bootCodeBuffer)
+  }).then(() => {
+    debug('Reading return code from device')
+    return protocol.read(device, protocol.RETURN_CODE_LENGTH)
+  }).then((data) => {
+    const returnCode = data.readInt32LE()
+    debug(`Received return code: ${returnCode}`)
+
+    if (returnCode !== protocol.RETURN_CODE_SUCCESS) {
+      throw new Error(`Couldn't write the bootcode, got return code ${returnCode} from device`)
+    }
+  })
+}
+
 const startFileServer = (device, files) => {
   debug('Listening for file messages')
   return protocol
@@ -209,6 +233,7 @@ const startFileServer = (device, files) => {
     .catch({
       message: 'LIBUSB_TRANSFER_STALL'
     }, (error) => {
+      debug(`Got ${error.message} when reading a command, assuming everything is done`)
       return {
         command: protocol.FILE_MESSAGE_COMMAND_DONE
       }
@@ -271,57 +296,35 @@ exports.flash = (device, options = {}) => {
   const serialNumberIndex = device.instance.deviceDescriptor.iSerialNumber
   debug(`Serial number index: ${serialNumberIndex}`)
 
-  return Bluebird.try(() => {
-    if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
-      debug('Writing bootcode')
-      const bootCodeBuffer = _.get(options.files, [ 'bootcode.bin' ])
-      debug(`Bootcode buffer length: ${bootCodeBuffer.length}`)
-      const bootMessageBuffer = protocol.createBootMessageBuffer(bootCodeBuffer.length)
-
-      const endpoint = device.instance.interface(device.interface).endpoint(device.outEndpoint)
-
-      debug('Writing boot message buffer to out endpoint')
-      return protocol.write(device, endpoint, bootMessageBuffer).then(() => {
-        debug('Writing boot code buffer to out endpoint')
-        return protocol.write(device, endpoint, bootCodeBuffer)
-      }).then(() => {
-        debug('Reading return code from device')
-        return protocol.read(device, protocol.RETURN_CODE_LENGTH)
-      }).then((data) => {
-        const returnCode = data.readInt32LE()
-        debug(`Received return code: ${returnCode}`)
-
-        if (returnCode !== protocol.RETURN_CODE_SUCCESS) {
-          throw new Error(`Couldn't write the bootcode, got return code ${returnCode} from device`)
+  if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
+    return writeBootCode(device, _.get(options.files, [ 'bootcode.bin' ])).finally(() => {
+      debug('Closing device instance')
+      return device.instance.close()
+    }).delay(USB_OPERATION_DELAY_MS).then(() => {
+      debug('Waiting for device to come back')
+      return waitForDevice({
+        deviceDescriptor: {
+          idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
+          idProduct: 0x2764,
+          iSerialNumber: 1
         }
-      }).finally(() => {
-        debug('Closing device instance')
-        return device.instance.close()
-      }).delay(USB_OPERATION_DELAY_MS).then(() => {
-        debug('Waiting for device to come back')
-        return waitForDevice({
-          deviceDescriptor: {
-            idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
-            idProduct: 0x2764,
-            iSerialNumber: 1
-          }
-        }, {
-          retries: 5,
-          delay: 1000
-        })
-      }).then((newDevice) => {
-        if (_.isNil(newDevice)) {
-          throw new Error(`Device ${device.instance.deviceDescriptor.idVendor}:${device.instance.deviceDescriptor.idProduct} never came back`)
-        }
-
-        return exports.flash(newDevice, options)
+      }, {
+        retries: 5,
+        delay: 1000
       })
-    }
+    }).then((newDevice) => {
+      if (_.isNil(newDevice)) {
+        const deviceName = `${device.instance.deviceDescriptor.idVendor}:${device.instance.deviceDescriptor.idProduct}`
+        throw new Error(`Device ${deviceName} never came back`)
+      }
 
-    debug('Starting file server')
-    return startFileServer(device, options.files).then(() => {
-      debug('Closing new device instance')
-      device.instance.close()
+      return exports.flash(newDevice, options)
     })
+  }
+
+  debug('Starting file server')
+  return startFileServer(device, options.files).finally(() => {
+    debug('Closing new device instance')
+    device.instance.close()
   })
 }

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -198,66 +198,126 @@ const waitForDevice = (properties, options) => {
   })
 }
 
+const startFileServer = (device, files) => {
+  debug('Listening for file messages')
+  return protocol
+    .read(device, protocol.FILE_MESSAGE_LENGTH)
+    .then(protocol.parseFileMessageBuffer)
+    .then((fileMessage) => {
+      debug(`Received message: ${fileMessage.command} -> ${fileMessage.fileName}`)
+
+      if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_DONE) {
+        debug('Done')
+        return
+      }
+
+      if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_GET_FILE_SIZE) {
+        debug(`Getting the size of ${fileMessage.fileName}`)
+        const fileSize = _.get(files, [ fileMessage.fileName, 'length' ])
+
+        if (_.isNil(fileSize)) {
+          debug(`Couldn't find ${fileMessage.fileName}`)
+          debug('Sending error signal')
+          return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
+            return protocol.sendErrorSignal(device, endpoint)
+          }).then(() => {
+            if (fileMessage.fileName === 'fixup.dat') {
+              return true
+            }
+          })
+        }
+
+        debug(`Sending size: ${fileSize}`)
+        return protocol.sendBufferSize(device, fileSize)
+      }
+
+      if (fileMessage.command === protocol.FILE_MESSAGE_COMMAND_READ_FILE) {
+        debug(`Reading ${fileMessage.fileName}`)
+        return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
+          const fileBuffer = _.get(files, [ fileMessage.fileName ])
+
+          if (_.isNil(fileBuffer)) {
+            debug(`Couldn't find ${fileMessage.fileName}`)
+            debug('Sending error signal')
+            return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).then((endpoint) => {
+              return protocol.sendErrorSignal(device, endpoint)
+            })
+          }
+
+          return protocol.write(device, endpoint, fileBuffer)
+        })
+      }
+
+      throw new Error(`Unrecognized command: ${fileMessage.command}`)
+    }).then((abort) => {
+      if (abort) {
+        debug('ABORT')
+        return
+      }
+      return startFileServer(device, files)
+    })
+}
+
 exports.flash = (device, options = {}) => {
   debug('Opening device')
   device.instance.open()
 
-  return usb.findInterface(device.instance, device.interface).then((deviceInterface) => {
-    debug(`Claiming interface: ${device.interface}`)
-    deviceInterface.claim()
+  const deviceInterface = device.instance.interface(device.interface)
+  debug(`Claiming interface: ${device.interface}`)
+  deviceInterface.claim()
 
-    const serialNumberIndex = device.instance.deviceDescriptor.iSerialNumber
-    debug(`Serial number index: ${serialNumberIndex}`)
+  const serialNumberIndex = device.instance.deviceDescriptor.iSerialNumber
+  debug(`Serial number index: ${serialNumberIndex}`)
 
-    return Bluebird.try(() => {
-      if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
-        debug('Writing bootcode')
-        debug(`Bootcode buffer length: ${options.bootcode.length}`)
-        const bootMessageBuffer = protocol.createBootMessageBuffer(options.bootcode.length)
+  return Bluebird.try(() => {
+    if (serialNumberIndex === USB_DESCRIPTOR_NULL_INDEX) {
+      debug('Writing bootcode')
+      const bootCodeBuffer = _.get(options.files, [ 'bootcode.bin' ])
+      debug(`Bootcode buffer length: ${bootCodeBuffer.length}`)
+      const bootMessageBuffer = protocol.createBootMessageBuffer(bootCodeBuffer.length)
 
-        return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).tap((endpoint) => {
-          debug('Writing boot message buffer to out endpoint')
-          return protocol.write(device, endpoint, bootMessageBuffer)
-        }).then((endpoint) => {
-          debug('Writing boot code buffer to out endpoint')
-          return protocol.write(device, endpoint, options.bootcode)
-        }).then(() => {
-          debug('Reading return code from device')
-          return protocol.read(device, protocol.RETURN_CODE_LENGTH)
-        }).then((data) => {
-          const returnCode = data.readInt32BE()
-          debug(`Received return code: ${returnCode}`)
+      return usb.findEndpoint(device.instance, device.interface, device.outEndpoint).tap((endpoint) => {
+        debug('Writing boot message buffer to out endpoint')
+        return protocol.write(device, endpoint, bootMessageBuffer)
+      }).then((endpoint) => {
+        debug('Writing boot code buffer to out endpoint')
+        return protocol.write(device, endpoint, bootCodeBuffer)
+      }).then(() => {
+        debug('Reading return code from device')
+        return protocol.read(device, protocol.RETURN_CODE_LENGTH)
+      }).then((data) => {
+        const returnCode = data.readInt32LE()
+        debug(`Received return code: ${returnCode}`)
 
-          if (returnCode !== protocol.RETURN_CODE_SUCCESS) {
-            throw new Error(`Couldn't write the bootcode, got return code ${returnCode} from device`)
+        if (returnCode !== protocol.RETURN_CODE_SUCCESS) {
+          throw new Error(`Couldn't write the bootcode, got return code ${returnCode} from device`)
+        }
+      }).delay(USB_OPERATION_DELAY_MS).then(() => {
+        debug('Waiting for device to come back')
+        return waitForDevice({
+          deviceDescriptor: {
+            idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
+            idProduct: 0x2764,
+            iSerialNumber: 1
           }
-        }).delay(USB_OPERATION_DELAY_MS).then(() => {
-          debug('Waiting for device to come back')
-          return waitForDevice({
-            deviceDescriptor: {
-              idVendor: USB_VENDOR_ID_BROADCOM_CORPORATION,
-              idProduct: 0x2764,
-              iSerialNumber: 1
-            }
-          }, {
-            retries: 5,
-            delay: 1000
-          })
-        }).then((newDevice) => {
-          if (_.isNil(newDevice)) {
-            throw new Error(`Device ${device.deviceDescriptor.idVendor}:${device.deviceDescriptor.idProduct} never came back`)
-          }
-
-          return exports.flash(newDevice, options)
+        }, {
+          retries: 5,
+          delay: 1000
         })
-      }
+      }).then((newDevice) => {
+        if (_.isNil(newDevice)) {
+          throw new Error(`Device ${device.deviceDescriptor.idVendor}:${device.deviceDescriptor.idProduct} never came back`)
+        }
 
-      debug('Starting file server')
-      return Bluebird.resolve()
-    }).then(() => {
-      return Bluebird
-        .fromCallback(_.bind(deviceInterface.release, deviceInterface))
-        .finally(_.bind(device.instance.close, device.instance))
-    })
+        return exports.flash(newDevice, options)
+      })
+    }
+
+    debug('Starting file server')
+    return startFileServer(device, options.files)
+  }).then(() => {
+    return Bluebird
+      .fromCallback(_.bind(deviceInterface.release, deviceInterface))
+      .finally(_.bind(device.instance.close, device.instance))
   })
 }

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -203,6 +203,17 @@ const startFileServer = (device, files) => {
   return protocol
     .read(device, protocol.FILE_MESSAGE_LENGTH)
     .then(protocol.parseFileMessageBuffer)
+
+    // We get this error message when reading a command
+    // from the device when the communication has ended
+    .catch({
+      message: 'LIBUSB_TRANSFER_STALL'
+    }, (error) => {
+      return {
+        command: protocol.FILE_MESSAGE_COMMAND_DONE
+      }
+    })
+
     .then((fileMessage) => {
       debug(`Received message: ${fileMessage.command} -> ${fileMessage.fileName}`)
 
@@ -221,7 +232,7 @@ const startFileServer = (device, files) => {
           if (_.isNil(fileSize)) {
             debug(`Couldn't find ${fileMessage.fileName}`)
             debug('Sending error signal')
-            return protocol.sendErrorSignal(device, endpoint)
+            return protocol.sendErrorSignal(device)
           }
 
           debug(`Sending size: ${fileSize}`)
@@ -235,7 +246,7 @@ const startFileServer = (device, files) => {
           if (_.isNil(fileBuffer)) {
             debug(`Couldn't find ${fileMessage.fileName}`)
             debug('Sending error signal')
-            return protocol.sendErrorSignal(device, endpoint)
+            return protocol.sendErrorSignal(device)
           }
 
           return protocol.write(device, endpoint, fileBuffer)
@@ -246,12 +257,6 @@ const startFileServer = (device, files) => {
         debug('Starting again')
         return startFileServer(device, files)
       })
-    }).catch({
-      message: 'LIBUSB_ERROR_NO_DEVICE'
-    }, {
-      message: 'LIBUSB_ERROR_IO'
-    }, (error) => {
-      debug(`Done, given we got ${error.message}`)
     })
 }
 

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -204,10 +204,12 @@ const startFileServer = (device, endpoint, files) => {
     .read(device, protocol.FILE_MESSAGE_LENGTH)
     .then(protocol.parseFileMessageBuffer)
 
-    // We get this error message when reading a command
+    // We get these error messages when reading a command
     // from the device when the communication has ended
     .catch({
       message: 'LIBUSB_TRANSFER_STALL'
+    }, {
+      message: 'LIBUSB_TRANSFER_ERROR'
     }, (error) => {
       debug(`Got ${error.message} when reading a command, assuming everything is done`)
       return {

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -197,8 +197,14 @@ exports.write = (device, endpoint, buffer) => {
     })
 }
 
-exports.sendErrorSignal = (device, endpoint) => {
-  return exports.write(device, endpoint, NULL_BUFFER)
+exports.sendErrorSignal = (device) => {
+  // The original implementation sends a control transfer
+  // with the size of a null buffer, and then the null
+  // buffer itself, however sending the actual null buffer
+  // seems unnecessary, an in fact confuses `node-usb`,
+  // since the connection to the device is suddenly lost,
+  // but the module keeps waiting for it
+  return exports.sendBufferSize(device, NULL_BUFFER_SIZE)
 }
 
 /**

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -21,7 +21,6 @@
 
 'use strict'
 
-const Bluebird = require('bluebird')
 const _ = require('lodash')
 const usb = require('./usb')
 

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -186,9 +186,11 @@ exports.sendBufferSize = (device, size) => {
  */
 exports.write = (device, endpoint, buffer) => {
   return exports.sendBufferSize(device, buffer.length)
+
     // We get LIBUSB_TRANSFER_STALL sometimes
     // in future bulk transfers without this
     .delay(USB_REQUEST_DELAY_MS)
+
     .then(() => {
       return Bluebird.fromCallback((callback) => {
         endpoint.timeout = USB_BULK_TRANSFER_TIMEOUT_MS

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -22,6 +22,7 @@
 'use strict'
 
 const _ = require('lodash')
+const Bluebird = require('bluebird')
 const usb = require('./usb')
 
 // The equivalent of a NULL buffer, given that node-usb complains
@@ -105,6 +106,13 @@ const USBBOOT_MESSAGE_MAX_BUFFER_LENGTH = 0xffff
 const USB_REQUEST_DELAY_MS = 1000
 
 /**
+ * @summary The timeout for USB bulk transfers, in milliseconds
+ * @type {Number}
+ * @constant
+ */
+const USB_BULK_TRANSFER_TIMEOUT_MS = 1000
+
+/**
  * @summary The size of the usbboot file message
  * @type {Number}
  * @constant
@@ -178,7 +186,16 @@ exports.sendBufferSize = (device, size) => {
  */
 exports.write = (device, endpoint, buffer) => {
   return exports.sendBufferSize(device, buffer.length).then(() => {
-    return endpoint.transfer(buffer)
+    return Bluebird.fromCallback((callback) => {
+
+      // We need to manually set this to
+      // ensure the transfer goes correctly
+      endpoint.direction = 'out'
+      endpoint.transferType = usb.LIBUSB_TRANSFER_TYPE_BULK
+      endpoint.timeout = USB_BULK_TRANSFER_TIMEOUT_MS
+
+      return endpoint.transfer(buffer, callback)
+    })
 
   // The USB bus seems to hang if we don't wait
   // a bit after each write operation

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -164,7 +164,10 @@ exports.sendBufferSize = (device, size) => {
     wValue: size & USBBOOT_MESSAGE_MAX_BUFFER_LENGTH,
     wIndex: size >> 16
     /* eslint-enable no-bitwise */
-  })
+
+  // We get LIBUSB_TRANSFER_STALL sometimes
+  // in future bulk transfers without this
+  }).delay(USB_REQUEST_DELAY_MS)
 }
 
 /**
@@ -179,7 +182,7 @@ exports.sendBufferSize = (device, size) => {
  *
  * @example
  * usbboot.scan().then((devices) => {
- *   return protocol.write(devices[0], devices[0].interfaces[0].endpoints[1], Buffer.alloc(1)).then(() => {
+ *   return protocol.write(devices[0], devices[0].interface(0).endpoint(1), Buffer.alloc(1)).then(() => {
  *     console.log('Done!')
  *   })
  * })
@@ -187,7 +190,6 @@ exports.sendBufferSize = (device, size) => {
 exports.write = (device, endpoint, buffer) => {
   return exports.sendBufferSize(device, buffer.length).then(() => {
     return Bluebird.fromCallback((callback) => {
-
       // We need to manually set this to
       // ensure the transfer goes correctly
       endpoint.direction = 'out'

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -164,10 +164,7 @@ exports.sendBufferSize = (device, size) => {
     wValue: size & USBBOOT_MESSAGE_MAX_BUFFER_LENGTH,
     wIndex: size >> 16
     /* eslint-enable no-bitwise */
-
-  // We get LIBUSB_TRANSFER_STALL sometimes
-  // in future bulk transfers without this
-  }).delay(USB_REQUEST_DELAY_MS)
+  })
 }
 
 /**
@@ -188,20 +185,16 @@ exports.sendBufferSize = (device, size) => {
  * })
  */
 exports.write = (device, endpoint, buffer) => {
-  return exports.sendBufferSize(device, buffer.length).then(() => {
-    return Bluebird.fromCallback((callback) => {
-      // We need to manually set this to
-      // ensure the transfer goes correctly
-      endpoint.direction = 'out'
-      endpoint.transferType = usb.LIBUSB_TRANSFER_TYPE_BULK
-      endpoint.timeout = USB_BULK_TRANSFER_TIMEOUT_MS
-
-      return endpoint.transfer(buffer, callback)
+  return exports.sendBufferSize(device, buffer.length)
+    // We get LIBUSB_TRANSFER_STALL sometimes
+    // in future bulk transfers without this
+    .delay(USB_REQUEST_DELAY_MS)
+    .then(() => {
+      return Bluebird.fromCallback((callback) => {
+        endpoint.timeout = USB_BULK_TRANSFER_TIMEOUT_MS
+        endpoint.transfer(buffer, callback)
+      })
     })
-
-  // The USB bus seems to hang if we don't wait
-  // a bit after each write operation
-  }).delay(USB_REQUEST_DELAY_MS)
 }
 
 exports.sendErrorSignal = (device, endpoint) => {

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This work is heavily based on https://github.com/raspberrypi/usbboot
+ * Copyright 2016 Raspberry Pi Foundation
+ */
+
+'use strict'
+
+const Bluebird = require('bluebird')
+const usb = require('./usb')
+
+/**
+ * @summary The size of the boot message bootcode length section
+ * @type {Number}
+ * @constant
+ */
+const BOOT_MESSAGE_BOOTCODE_LENGTH_SIZE = 4
+
+/**
+ * @summary The offset of the boot message bootcode length section
+ * @type {Number}
+ * @constant
+ */
+const BOOT_MESSAGE_BOOTCODE_LENGTH_OFFSET = 0
+
+/**
+ * @summary The size of the boot message signature section
+ * @type {Number}
+ * @constant
+ */
+const BOOT_MESSAGE_SIGNATURE_SIZE = 20
+
+/**
+ * @summary The GET_STATUS usb control transfer request code
+ * @type {Number}
+ * @constant
+ * @description
+ * See http://www.jungo.com/st/support/documentation/windriver/811/wdusb_man_mhtml/node55.html#usb_standard_dev_req_codes
+ */
+const USB_REQUEST_CODE_GET_STATUS = 0
+
+/**
+ * @summary The maximum buffer length of a usbboot message
+ * @type {Number}
+ * @constant
+ */
+const USBBOOT_MESSAGE_MAX_BUFFER_LENGTH = 0xffff
+
+/**
+ * @summary The delay to wait between each USB read/write operation
+ * @type {Number}
+ * @constant
+ * @description
+ * The USB bus seems to hang if we execute many operations at
+ * the same time.
+ */
+const USB_REQUEST_DELAY_MS = 1000
+
+/**
+ * @summary The usbboot return code that represents success
+ * @type {Number}
+ * @constant
+ */
+exports.RETURN_CODE_SUCCESS = 0
+
+/**
+ * @summary The buffer length of the return code message
+ * @type {Number}
+ * @constant
+ */
+exports.RETURN_CODE_LENGTH = 4
+
+/**
+ * @summary Write a buffer to an OUT endpoint
+ * @function
+ * @private
+ *
+ * @param {Object} device - device
+ * @param {Object} endpoint - endpoint
+ * @param {Buffer} buffer - buffer
+ * @returns {Promise}
+ *
+ * @example
+ * usbboot.scan().then((devices) => {
+ *   return protocol.write(devices[0], devices[0].interfaces[0].endpoints[1], Buffer.alloc(1)).then(() => {
+ *     console.log('Done!')
+ *   })
+ * })
+ */
+exports.write = (device, endpoint, buffer) => {
+  if (buffer.length > USBBOOT_MESSAGE_MAX_BUFFER_LENGTH) {
+    return Bluebird.reject(`Can't transfer buffers larger than ${USBBOOT_MESSAGE_MAX_BUFFER_LENGTH} bytes`)
+  }
+
+  // The equivalent of a NULL buffer, given that node-usb complains
+  // if the daata argument is not an instance of Buffer
+  const NULL_BUFFER_SIZE = 0
+  const NULL_BUFFER = Buffer.alloc(NULL_BUFFER_SIZE)
+
+  return usb.performControlTransfer(device.instance, {
+    bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR,
+    bRequest: USB_REQUEST_CODE_GET_STATUS,
+    wValue: buffer.length,
+    data: NULL_BUFFER,
+
+    /* eslint-disable no-bitwise */
+    wIndex: buffer.length >> 16
+    /* eslint-enable no-bitwise */
+  }).then(() => {
+    return endpoint.transfer(buffer)
+
+  // The USB bus seems to hang if we don't wait
+  // a bit after each write operation
+  }).delay(USB_REQUEST_DELAY_MS)
+}
+
+/**
+ * @summary Read a buffer from a device
+ * @function
+ * @private
+ *
+ * @param {Object} device - device
+ * @param {Number} bytesToRead - bytes to read
+ * @fulfil {Buffer} - data
+ * @returns {Promise}
+ *
+ * @example
+ * usbboot.scan().then((devices) => {
+ *   return protocol.read(devices[0], 4).then((data) => {
+ *     console.log(data.readInt32BE())
+ *   })
+ * })
+ */
+exports.read = (device, bytesToRead) => {
+  if (bytesToRead > USBBOOT_MESSAGE_MAX_BUFFER_LENGTH) {
+    return Bluebird.reject(`Can't request buffers larger than ${USBBOOT_MESSAGE_MAX_BUFFER_LENGTH} bytes`)
+  }
+
+  return usb.performControlTransfer(device.instance, {
+    /* eslint-disable no-bitwise */
+    bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR | usb.LIBUSB_ENDPOINT_IN,
+    wIndex: bytesToRead >> 16,
+    /* eslint-enable no-bitwise */
+
+    wValue: bytesToRead,
+    bRequest: USB_REQUEST_CODE_GET_STATUS,
+    length: bytesToRead
+  })
+}
+
+/**
+ * @summary Create a boot message buffer
+ * @function
+ * @private
+ *
+ * @description
+ * This is based on the following data structure:
+ *
+ * typedef struct MESSAGE_S {
+ *   int length;
+ *   unsigned char signature[20];
+ * } boot_message_t;
+ *
+ * This needs to be sent to the out endpoint of the USB device
+ * as a 24 bytes big-endian buffer where:
+ *
+ * - The first 4 bytes contain the size of the bootcode.bin buffer
+ * - The remaining 20 bytes contain the boot signature, which
+ *   we don't make use of in this implementation
+ *
+ * @param {Buffer} bootCodeBufferLength - bootcode.bin buffer length
+ * @returns {Buffer} boot message buffer
+ *
+ * @example
+ * const bootMessageBuffer = protocol.createBootMessageBuffer(50216)
+ */
+exports.createBootMessageBuffer = (bootCodeBufferLength) => {
+  const bootMessageBufferSize = BOOT_MESSAGE_BOOTCODE_LENGTH_SIZE + BOOT_MESSAGE_SIGNATURE_SIZE
+
+  // Buffers are automatically filled with zero bytes
+  const bootMessageBuffer = Buffer.alloc(bootMessageBufferSize)
+
+  // The bootcode length should be stored in 4 big-endian bytes
+  bootMessageBuffer.writeInt32BE(bootCodeBufferLength, BOOT_MESSAGE_BOOTCODE_LENGTH_OFFSET)
+
+  return bootMessageBuffer
+}

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -155,7 +155,7 @@ exports.RETURN_CODE_SUCCESS = 0
 exports.RETURN_CODE_LENGTH = 4
 
 exports.sendBufferSize = (device, size) => {
-  return usb.performControlTransfer(device.instance, {
+  return usb.performControlTransfer(device, {
     bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR,
     bRequest: USB_REQUEST_CODE_GET_STATUS,
     data: NULL_BUFFER,
@@ -227,7 +227,7 @@ exports.sendErrorSignal = (device) => {
  * })
  */
 exports.read = (device, bytesToRead) => {
-  return usb.performControlTransfer(device.instance, {
+  return usb.performControlTransfer(device, {
     /* eslint-disable no-bitwise */
     bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR | usb.LIBUSB_ENDPOINT_IN,
     wValue: bytesToRead & USBBOOT_MESSAGE_MAX_BUFFER_LENGTH,

--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -22,7 +22,13 @@
 'use strict'
 
 const Bluebird = require('bluebird')
+const _ = require('lodash')
 const usb = require('./usb')
+
+// The equivalent of a NULL buffer, given that node-usb complains
+// if the daata argument is not an instance of Buffer
+const NULL_BUFFER_SIZE = 0
+const NULL_BUFFER = Buffer.alloc(NULL_BUFFER_SIZE)
 
 /**
  * @summary The size of the boot message bootcode length section
@@ -44,6 +50,34 @@ const BOOT_MESSAGE_BOOTCODE_LENGTH_OFFSET = 0
  * @constant
  */
 const BOOT_MESSAGE_SIGNATURE_SIZE = 20
+
+/**
+ * @summary The offset of the file message command section
+ * @type {Number}
+ * @constant
+ */
+const FILE_MESSAGE_COMMAND_OFFSET = 0
+
+/**
+ * @summary The size of the file message command section
+ * @type {Number}
+ * @constant
+ */
+const FILE_MESSAGE_COMMAND_LENGTH = 4
+
+/**
+ * @summary The offset of the file message file name section
+ * @type {Number}
+ * @constant
+ */
+const FILE_MESSAGE_FILE_NAME_OFFSET = FILE_MESSAGE_COMMAND_LENGTH
+
+/**
+ * @summary The size of the file message file name section
+ * @type {Number}
+ * @constant
+ */
+const FILE_MESSAGE_FILE_NAME_LENGTH = 256
 
 /**
  * @summary The GET_STATUS usb control transfer request code
@@ -72,6 +106,34 @@ const USBBOOT_MESSAGE_MAX_BUFFER_LENGTH = 0xffff
 const USB_REQUEST_DELAY_MS = 1000
 
 /**
+ * @summary The size of the usbboot file message
+ * @type {Number}
+ * @constant
+ */
+exports.FILE_MESSAGE_LENGTH = FILE_MESSAGE_COMMAND_LENGTH + FILE_MESSAGE_FILE_NAME_LENGTH
+
+/**
+ * @summary The "get file size" file message command name
+ * @type {String}
+ * @constant
+ */
+exports.FILE_MESSAGE_COMMAND_GET_FILE_SIZE = 'GetFileSize'
+
+/**
+ * @summary The "read file" file message command name
+ * @type {String}
+ * @constant
+ */
+exports.FILE_MESSAGE_COMMAND_READ_FILE = 'ReadFile'
+
+/**
+ * @summary The "done" file message command name
+ * @type {String}
+ * @constant
+ */
+exports.FILE_MESSAGE_COMMAND_DONE = 'Done'
+
+/**
  * @summary The usbboot return code that represents success
  * @type {Number}
  * @constant
@@ -84,6 +146,19 @@ exports.RETURN_CODE_SUCCESS = 0
  * @constant
  */
 exports.RETURN_CODE_LENGTH = 4
+
+exports.sendBufferSize = (device, size) => {
+  return usb.performControlTransfer(device.instance, {
+    bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR,
+    bRequest: USB_REQUEST_CODE_GET_STATUS,
+    data: NULL_BUFFER,
+
+    /* eslint-disable no-bitwise */
+    wValue: size & USBBOOT_MESSAGE_MAX_BUFFER_LENGTH,
+    wIndex: size >> 16
+    /* eslint-enable no-bitwise */
+  })
+}
 
 /**
  * @summary Write a buffer to an OUT endpoint
@@ -103,30 +178,16 @@ exports.RETURN_CODE_LENGTH = 4
  * })
  */
 exports.write = (device, endpoint, buffer) => {
-  if (buffer.length > USBBOOT_MESSAGE_MAX_BUFFER_LENGTH) {
-    return Bluebird.reject(`Can't transfer buffers larger than ${USBBOOT_MESSAGE_MAX_BUFFER_LENGTH} bytes`)
-  }
-
-  // The equivalent of a NULL buffer, given that node-usb complains
-  // if the daata argument is not an instance of Buffer
-  const NULL_BUFFER_SIZE = 0
-  const NULL_BUFFER = Buffer.alloc(NULL_BUFFER_SIZE)
-
-  return usb.performControlTransfer(device.instance, {
-    bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR,
-    bRequest: USB_REQUEST_CODE_GET_STATUS,
-    wValue: buffer.length,
-    data: NULL_BUFFER,
-
-    /* eslint-disable no-bitwise */
-    wIndex: buffer.length >> 16
-    /* eslint-enable no-bitwise */
-  }).then(() => {
+  return exports.sendBufferSize(device, buffer.length).then(() => {
     return endpoint.transfer(buffer)
 
   // The USB bus seems to hang if we don't wait
   // a bit after each write operation
   }).delay(USB_REQUEST_DELAY_MS)
+}
+
+exports.sendErrorSignal = (device, endpoint) => {
+  return exports.write(device, endpoint, NULL_BUFFER)
 }
 
 /**
@@ -147,17 +208,13 @@ exports.write = (device, endpoint, buffer) => {
  * })
  */
 exports.read = (device, bytesToRead) => {
-  if (bytesToRead > USBBOOT_MESSAGE_MAX_BUFFER_LENGTH) {
-    return Bluebird.reject(`Can't request buffers larger than ${USBBOOT_MESSAGE_MAX_BUFFER_LENGTH} bytes`)
-  }
-
   return usb.performControlTransfer(device.instance, {
     /* eslint-disable no-bitwise */
     bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR | usb.LIBUSB_ENDPOINT_IN,
+    wValue: bytesToRead & USBBOOT_MESSAGE_MAX_BUFFER_LENGTH,
     wIndex: bytesToRead >> 16,
     /* eslint-enable no-bitwise */
 
-    wValue: bytesToRead,
     bRequest: USB_REQUEST_CODE_GET_STATUS,
     length: bytesToRead
   })
@@ -199,4 +256,40 @@ exports.createBootMessageBuffer = (bootCodeBufferLength) => {
   bootMessageBuffer.writeInt32BE(bootCodeBufferLength, BOOT_MESSAGE_BOOTCODE_LENGTH_OFFSET)
 
   return bootMessageBuffer
+}
+
+exports.parseFileMessageBuffer = (fileMessageBuffer) => {
+  const commandCode = fileMessageBuffer.readInt32LE(FILE_MESSAGE_COMMAND_OFFSET)
+  const command = _.nth([
+    exports.FILE_MESSAGE_COMMAND_GET_FILE_SIZE,
+    exports.FILE_MESSAGE_COMMAND_READ_FILE,
+    exports.FILE_MESSAGE_COMMAND_DONE
+  ], commandCode)
+
+  if (_.isNil(command)) {
+    throw new Error(`Invalid file message command code: ${commandCode}`)
+  }
+
+  const fileName = _.chain(fileMessageBuffer.toString('ascii', FILE_MESSAGE_FILE_NAME_OFFSET))
+
+    // The parsed string will likely contain tons of trailing
+    // null bytes that we should get rid of for convenience
+    // See https://github.com/nodejs/node/issues/4775
+    .takeWhile((character) => {
+      return character !== '\0'
+    })
+    .join('')
+    .value()
+
+  // A blank file name can also mean "done"
+  if (_.isEmpty(fileName)) {
+    return {
+      command: exports.FILE_MESSAGE_COMMAND_DONE
+    }
+  }
+
+  return {
+    command,
+    fileName
+  }
 }

--- a/lib/shared/sdk/usbboot/usb.js
+++ b/lib/shared/sdk/usbboot/usb.js
@@ -119,6 +119,8 @@ exports.performControlTransfer = (device, options) => {
     return Bluebird.reject(new Error('You can define either data or length, but not both'))
   }
 
+  device.timeout = 1000
+
   return Bluebird.fromCallback((callback) => {
     device.controlTransfer(
       options.bmRequestType,
@@ -147,7 +149,7 @@ exports.performControlTransfer = (device, options) => {
  * })
  */
 exports.findInterface = (device, interfaceNumber) => {
-  const deviceInterface = device.interfaces[interfaceNumber]
+  const deviceInterface = device.interface(interfaceNumber)
 
   if (_.isNil(deviceInterface)) {
     return Bluebird.reject(new Error(`USB interface not found: ${interfaceNumber}`))
@@ -173,17 +175,16 @@ exports.findInterface = (device, interfaceNumber) => {
  * })
  */
 exports.findEndpoint = (device, interfaceNumber, endpointAddress) => {
-  return exports.findInterface(device, interfaceNumber).then((deviceInterface) => {
-    const endpoint = _.find(deviceInterface.endpoints, {
-      address: endpointAddress
-    })
-
-    if (_.isNil(endpoint)) {
-      throw new Error(`USB endpoint not found: ${device.outEndpoint}`)
-    }
-
-    return endpoint
+  const deviceInterface = device.interface(interfaceNumber)
+  const endpoint = _.find(deviceInterface.endpoints, {
+    address: endpointAddress
   })
+
+  if (_.isNil(endpoint)) {
+    return Bluebird.reject(new Error(`USB endpoint not found: ${device.outEndpoint}`))
+  }
+
+  return Bluebird.resolve(endpoint)
 }
 
 /**

--- a/lib/shared/sdk/usbboot/usb.js
+++ b/lib/shared/sdk/usbboot/usb.js
@@ -37,10 +37,18 @@ const usb = (() => {
 // Re-expose some `usb` constants
 _.each([
   'LIBUSB_REQUEST_TYPE_VENDOR',
-  'LIBUSB_ENDPOINT_IN'
+  'LIBUSB_ENDPOINT_IN',
+  'LIBUSB_TRANSFER_TYPE_BULK'
 ], (constant) => {
   exports[constant] = usb[constant]
 })
+
+/**
+ * @summary The timeout for USB control transfers, in milliseconds
+ * @type {Number}
+ * @constant
+ */
+const USB_CONTROL_TRANSFER_TIMEOUT = 1000
 
 /**
  * @summary List the available USB devices
@@ -119,7 +127,7 @@ exports.performControlTransfer = (device, options) => {
     return Bluebird.reject(new Error('You can define either data or length, but not both'))
   }
 
-  device.timeout = 1000
+  device.timeout = USB_CONTROL_TRANSFER_TIMEOUT
 
   return Bluebird.fromCallback((callback) => {
     device.controlTransfer(

--- a/lib/shared/sdk/usbboot/usb.js
+++ b/lib/shared/sdk/usbboot/usb.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const _ = require('lodash')
+const Bluebird = require('bluebird')
+
+// The USB module calls `libusb_init`, which will fail
+// if the device we're running in has no USB controller
+// plugged in (e.g. in certain CI services).
+// In order to workaround that, we need to return a
+// stub if such error occurs.
+const usb = (() => {
+  try {
+    return require('usb')
+  } catch (error) {
+    return {
+      getDeviceList: _.constant([])
+    }
+  }
+})()
+
+// Re-expose some `usb` constants
+_.each([
+  'LIBUSB_REQUEST_TYPE_VENDOR',
+  'LIBUSB_ENDPOINT_IN'
+], (constant) => {
+  exports[constant] = usb[constant]
+})
+
+/**
+ * @summary List the available USB devices
+ * @function
+ * @public
+ *
+ * @fulfil {Object[]} - usb devices
+ * @returns {Promise}
+ *
+ * @example
+ * usb.listDevices().each((device) => {
+ *   console.log(device)
+ * })
+ */
+exports.listDevices = () => {
+  return Bluebird.resolve(usb.getDeviceList())
+}
+
+/**
+ * @summary Get a USB device string from an index
+ * @function
+ * @public
+ *
+ * @param {Object} device - device
+ * @param {Number} index - string index
+ * @fulfil {String} - string
+ * @returns {Promise}
+ *
+ * @example
+ * usb.getDeviceStringFromIndex({ ... }, 5).then((string) => {
+ *   console.log(string)
+ * })
+ */
+exports.getDeviceStringFromIndex = (device, index) => {
+  return Bluebird.fromCallback((callback) => {
+    device.getStringDescriptor(index, callback)
+  })
+}
+
+/**
+ * @summary Perform a USB control transfer
+ * @function
+ * @public
+ *
+ * @description
+ * See http://libusb.sourceforge.net/api-1.0/group__syncio.html
+ *
+ * @param {Object} device - usb device
+ * @param {Object} options - options
+ * @param {Number} options.bmRequestType - the request type field for the setup packet
+ * @param {Number} options.bRequest - the request field for the setup packet
+ * @param {Number} options.wValue - the value field for the setup packet
+ * @param {Number} options.wIndex - the index field for the setup packet
+ * @param {Buffer} [options.data] - output data buffer (for OUT transfers)
+ * @param {Number} [options.length] - input data size (for IN transfers)
+ * @fulfil {(Buffer|Undefined)} - result
+ * @returns {Promise}
+ *
+ * @example
+ * const buffer = Buffer.alloc(512)
+ *
+ * usb.performControlTransfer({ ... }, {
+ *   bmRequestType: usb.LIBUSB_REQUEST_TYPE_VENDOR
+ *   bRequest: 0,
+ *   wValue: buffer.length & 0xffff,
+ *   wIndex: buffer.length >> 16,
+ *   data: Buffer.alloc(256)
+ * })
+ */
+exports.performControlTransfer = (device, options) => {
+  if (_.isNil(options.data) && _.isNil(options.length)) {
+    return Bluebird.reject(new Error('You must define either data or length'))
+  }
+
+  if (!_.isNil(options.data) && !_.isNil(options.length)) {
+    return Bluebird.reject(new Error('You can define either data or length, but not both'))
+  }
+
+  return Bluebird.fromCallback((callback) => {
+    device.controlTransfer(
+      options.bmRequestType,
+      options.bRequest,
+      options.wValue,
+      options.wIndex,
+      options.data || options.length,
+      callback
+    )
+  })
+}
+
+/**
+ * @summary Find a USB interface by its number
+ * @function
+ * @public
+ *
+ * @param {Object} device - usb device
+ * @param {Number} interfaceNumber - interface number
+ * @fulfil {Object} - interface
+ * @returns {Promise}
+ *
+ * @example
+ * usb.findInterface({ ... }, 2).then((interface) => {
+ *   interface.claim()
+ * })
+ */
+exports.findInterface = (device, interfaceNumber) => {
+  const deviceInterface = device.interfaces[interfaceNumber]
+
+  if (_.isNil(deviceInterface)) {
+    return Bluebird.reject(new Error(`USB interface not found: ${interfaceNumber}`))
+  }
+
+  return Bluebird.resolve(deviceInterface)
+}
+
+/**
+ * @summary Find a USB endpoint by its address
+ * @function
+ * @public
+ *
+ * @param {Object} device - usb device
+ * @param {Number} interfaceNumber - interface number
+ * @param {Number} endpointAddress - endpoint address
+ * @fulfil {Object} - endpoint
+ * @returns {Promise}
+ *
+ * @example
+ * usb.findEndpoint({ ... }, 2, 130).then((endpoint) => {
+ *   endpoint.transfer(Buffer.alloc(256))
+ * })
+ */
+exports.findEndpoint = (device, interfaceNumber, endpointAddress) => {
+  return exports.findInterface(device, interfaceNumber).then((deviceInterface) => {
+    const endpoint = _.find(deviceInterface.endpoints, {
+      address: endpointAddress
+    })
+
+    if (_.isNil(endpoint)) {
+      throw new Error(`USB endpoint not found: ${device.outEndpoint}`)
+    }
+
+    return endpoint
+  })
+}
+
+/**
+ * @summary Get a human friendly name for a USB device
+ * @function
+ * @public
+ *
+ * @description
+ * This function assumes the device is open.
+ *
+ * @param {Object} device - usb device
+ * @fulfil {String} - device name
+ * @returns {Promise}
+ *
+ * @example
+ * usb.getDeviceName({ ... }).then((name) => {
+ *   console.log(name)
+ * })
+ */
+exports.getDeviceName = (device) => {
+  return Bluebird.props({
+    manufacturer: exports.getDeviceStringFromIndex(device, device.deviceDescriptor.iManufacturer),
+    product: exports.getDeviceStringFromIndex(device, device.deviceDescriptor.iProduct)
+  }).tap((properties) => {
+    return `${properties.manufacturer} ${properties.product}`
+  })
+}

--- a/lib/shared/sdk/usbboot/usb.js
+++ b/lib/shared/sdk/usbboot/usb.js
@@ -38,7 +38,9 @@ const usb = (() => {
 _.each([
   'LIBUSB_REQUEST_TYPE_VENDOR',
   'LIBUSB_ENDPOINT_IN',
-  'LIBUSB_TRANSFER_TYPE_BULK'
+  'LIBUSB_TRANSFER_TYPE_BULK',
+  'LIBUSB_ERROR_NO_DEVICE',
+  'LIBUSB_ERROR_IO'
 ], (constant) => {
   exports[constant] = usb[constant]
 })
@@ -139,60 +141,6 @@ exports.performControlTransfer = (device, options) => {
       callback
     )
   })
-}
-
-/**
- * @summary Find a USB interface by its number
- * @function
- * @public
- *
- * @param {Object} device - usb device
- * @param {Number} interfaceNumber - interface number
- * @fulfil {Object} - interface
- * @returns {Promise}
- *
- * @example
- * usb.findInterface({ ... }, 2).then((interface) => {
- *   interface.claim()
- * })
- */
-exports.findInterface = (device, interfaceNumber) => {
-  const deviceInterface = device.interface(interfaceNumber)
-
-  if (_.isNil(deviceInterface)) {
-    return Bluebird.reject(new Error(`USB interface not found: ${interfaceNumber}`))
-  }
-
-  return Bluebird.resolve(deviceInterface)
-}
-
-/**
- * @summary Find a USB endpoint by its address
- * @function
- * @public
- *
- * @param {Object} device - usb device
- * @param {Number} interfaceNumber - interface number
- * @param {Number} endpointAddress - endpoint address
- * @fulfil {Object} - endpoint
- * @returns {Promise}
- *
- * @example
- * usb.findEndpoint({ ... }, 2, 130).then((endpoint) => {
- *   endpoint.transfer(Buffer.alloc(256))
- * })
- */
-exports.findEndpoint = (device, interfaceNumber, endpointAddress) => {
-  const deviceInterface = device.interface(interfaceNumber)
-  const endpoint = _.find(deviceInterface.endpoints, {
-    address: endpointAddress
-  })
-
-  if (_.isNil(endpoint)) {
-    return Bluebird.reject(new Error(`USB endpoint not found: ${device.outEndpoint}`))
-  }
-
-  return Bluebird.resolve(endpoint)
 }
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -56,8 +56,7 @@
     "abbrev": {
       "version": "1.1.0",
       "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
     },
     "acorn": {
       "version": "4.0.11",
@@ -229,8 +228,7 @@
     "aproba": {
       "version": "1.1.1",
       "from": "aproba@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
     },
     "arch": {
       "version": "2.1.0",
@@ -240,8 +238,7 @@
     "are-we-there-yet": {
       "version": "1.1.2",
       "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
     },
     "argparse": {
       "version": "1.0.7",
@@ -447,8 +444,7 @@
     "balanced-match": {
       "version": "0.4.2",
       "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base64-js": {
       "version": "0.0.8",
@@ -489,8 +485,7 @@
     "block-stream": {
       "version": "0.0.9",
       "from": "block-stream@*",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
     },
     "bloodline": {
       "version": "1.0.1",
@@ -599,8 +594,7 @@
     "brace-expansion": {
       "version": "1.1.6",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "braces": {
       "version": "1.8.5",
@@ -913,8 +907,7 @@
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.2",
@@ -951,8 +944,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "from": "console-control-strings@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1141,8 +1133,7 @@
     "deep-extend": {
       "version": "0.4.1",
       "from": "deep-extend@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1253,8 +1244,7 @@
     "delegates": {
       "version": "1.0.0",
       "from": "delegates@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
     },
     "detect-node": {
       "version": "2.0.3",
@@ -2592,14 +2582,17 @@
     "fs.realpath": {
       "version": "1.0.0",
       "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fstream": {
       "version": "1.0.11",
       "from": "fstream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "from": "fstream-ignore@>=1.0.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
     },
     "ftp": {
       "version": "0.3.10",
@@ -2624,8 +2617,7 @@
     "gauge": {
       "version": "2.7.3",
       "from": "gauge@>=2.7.1 <2.8.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz"
     },
     "gaze": {
       "version": "1.1.2",
@@ -2721,8 +2713,7 @@
     "glob": {
       "version": "7.1.1",
       "from": "glob@>=7.1.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
@@ -2836,8 +2827,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -2914,8 +2904,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "from": "has-unicode@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
     },
     "has-values": {
       "version": "0.1.4",
@@ -3086,8 +3075,7 @@
     "inflight": {
       "version": "1.0.6",
       "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
       "version": "2.0.1",
@@ -3097,8 +3085,7 @@
     "ini": {
       "version": "1.3.4",
       "from": "ini@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inquirer": {
       "version": "0.11.4",
@@ -4554,8 +4541,7 @@
     "minimatch": {
       "version": "3.0.3",
       "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
       "version": "1.2.0",
@@ -4590,13 +4576,11 @@
       "version": "0.5.1",
       "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
@@ -4900,6 +4884,23 @@
       "from": "node-ipc@8.9.2",
       "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-8.9.2.tgz"
     },
+    "node-pre-gyp": {
+      "version": "0.6.36",
+      "from": "node-pre-gyp@>=0.6.30 <0.7.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "from": "nopt@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+        },
+        "semver": {
+          "version": "5.4.1",
+          "from": "semver@>=5.3.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+        }
+      }
+    },
     "node-sass": {
       "version": "4.5.3",
       "from": "node-sass@4.5.3",
@@ -4958,13 +4959,11 @@
       "version": "4.0.2",
       "from": "npmlog@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-      "dev": true,
       "dependencies": {
         "set-blocking": {
           "version": "2.0.0",
           "from": "set-blocking@~2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
         }
       }
     },
@@ -8206,8 +8205,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "os-locale": {
       "version": "1.4.0",
@@ -8222,8 +8220,7 @@
     "osenv": {
       "version": "0.1.4",
       "from": "osenv@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "p-finally": {
       "version": "1.0.0",
@@ -8337,8 +8334,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -8622,8 +8618,7 @@
     "rc": {
       "version": "1.1.7",
       "from": "rc@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz"
     },
     "react": {
       "version": "15.5.4",
@@ -8987,8 +8982,7 @@
     "rimraf": {
       "version": "2.6.1",
       "from": "rimraf@>=2.5.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
     },
     "run-async": {
       "version": "0.1.0",
@@ -9490,8 +9484,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "from": "strip-json-comments@>=2.0.1 <2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     },
     "striptags": {
       "version": "2.2.1",
@@ -9612,8 +9605,12 @@
     "tar": {
       "version": "2.2.1",
       "from": "tar@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+    },
+    "tar-pack": {
+      "version": "3.4.0",
+      "from": "tar-pack@>=3.4.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
     },
     "tempfile": {
       "version": "1.1.1",
@@ -9891,6 +9888,11 @@
       "dev": true,
       "optional": true
     },
+    "uid-number": {
+      "version": "0.0.6",
+      "from": "uid-number@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+    },
     "uid2": {
       "version": "0.0.3",
       "from": "uid2@0.0.3",
@@ -9968,6 +9970,18 @@
       "from": "url-parse-lax@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "dev": true
+    },
+    "usb": {
+      "version": "1.3.0",
+      "from": "tessel/node-usb#1.3.0",
+      "resolved": "git://github.com/tessel/node-usb.git#38cc9cc75759e74f3d3ee8c79ca852395c3529b0",
+      "dependencies": {
+        "nan": {
+          "version": "2.6.2",
+          "from": "nan@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+        }
+      }
     },
     "user-home": {
       "version": "2.0.0",
@@ -10094,8 +10108,7 @@
     "wide-align": {
       "version": "1.1.0",
       "from": "wide-align@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
     },
     "widest-line": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "trackjs": "2.3.1",
     "udif": "0.10.0",
     "unbzip2-stream": "1.0.11",
+    "usb": "github:tessel/node-usb#1.3.0",
     "uuid": "3.0.1",
     "xml2js": "0.4.17",
     "yargs": "4.7.1",

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -20,6 +20,8 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libudev-dev \
+    libusb-1.0-0-dev \
     libx11-xcb1 \
     libnss3 \
     libxss1 \

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -19,6 +19,8 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libudev-dev \
+    libusb-1.0-0-dev \
     libx11-xcb1 \
     libnss3 \
     libxss1 \

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -22,6 +22,8 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libudev-dev \
+    libusb-1.0-0-dev \
     libx11-xcb1 \
     libnss3 \
     libxss1 \

--- a/test.js
+++ b/test.js
@@ -1,0 +1,17 @@
+const _ = require('lodash')
+const usbboot = require('./lib/shared/sdk/usbboot')
+const usb = require('usb')
+const fs = require('fs')
+
+usbboot.scan().then((devices) => {
+  console.log(devices[0].instance)
+  return usbboot.flash(_.first(devices), {
+    files: {
+      'bootcode.bin': fs.readFileSync('../usbboot/msd/bootcode.bin'),
+      'start.elf': fs.readFileSync('../usbboot/msd/start.elf')
+    }
+  })
+}).catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/test.js
+++ b/test.js
@@ -21,5 +21,5 @@ usbboot.scan().then((devices) => {
 
   setTimeout(() => {
     process.exit(1)
-  }, 500)
+  }, 1000)
 })

--- a/test.js
+++ b/test.js
@@ -11,7 +11,15 @@ usbboot.scan().then((devices) => {
       'start.elf': fs.readFileSync('../usbboot/msd/start.elf')
     }
   })
+}).then(() => {
+  console.log('Done')
 }).catch((error) => {
+  console.log('There was an error')
   console.error(error)
-  process.exit(1)
+  console.error(error.stack)
+  console.error(error.stacktrace)
+
+  setTimeout(() => {
+    process.exit(1)
+  }, 500)
 })

--- a/tests/gui/modules/drive-scanner.spec.js
+++ b/tests/gui/modules/drive-scanner.spec.js
@@ -33,8 +33,12 @@ describe('Browser: driveScanner', function () {
     })
 
     it('should emit an empty array', function (done) {
-      driveScanner.once('drives', function (drives) {
-        m.chai.expect(drives).to.deep.equal([])
+      driveScanner.once('devices', function (devices) {
+        // eslint-disable-next-line lodash/prefer-lodash-method
+        const driveDevices = devices.filter((device) => {
+          return device.type === 'BLOCK_DEVICE'
+        })
+        m.chai.expect(driveDevices).to.deep.equal([])
         driveScanner.stop()
         done()
       })
@@ -47,6 +51,7 @@ describe('Browser: driveScanner', function () {
     beforeEach(function () {
       this.drivelistStub = m.sinon.stub(drivelist, 'list')
       this.drivelistStub.yields(null, [ {
+        type: 'BLOCK_DEVICE',
         device: '/dev/sda',
         description: 'WDC WD10JPVX-75J',
         size: '931.5G',
@@ -64,7 +69,7 @@ describe('Browser: driveScanner', function () {
     })
 
     it('should emit an empty array', function (done) {
-      driveScanner.once('drives', function (drives) {
+      driveScanner.once('devices', function (drives) {
         m.chai.expect(drives).to.deep.equal([])
         driveScanner.stop()
         done()
@@ -89,6 +94,7 @@ describe('Browser: driveScanner', function () {
         this.drivelistStub = m.sinon.stub(drivelist, 'list')
         this.drivelistStub.yields(null, [
           {
+            type: 'BLOCK_DEVICE',
             device: '/dev/sda',
             displayName: '/dev/sda',
             description: 'WDC WD10JPVX-75J',
@@ -101,6 +107,7 @@ describe('Browser: driveScanner', function () {
             system: true
           },
           {
+            type: 'BLOCK_DEVICE',
             device: '/dev/sdb',
             displayName: '/dev/sdb',
             description: 'Foo',
@@ -113,6 +120,7 @@ describe('Browser: driveScanner', function () {
             system: false
           },
           {
+            type: 'BLOCK_DEVICE',
             device: '/dev/sdc',
             displayName: '/dev/sdc',
             description: 'Bar',
@@ -132,9 +140,10 @@ describe('Browser: driveScanner', function () {
       })
 
       it('should emit the non removable drives', function (done) {
-        driveScanner.once('drives', function (drives) {
+        driveScanner.once('devices', function (drives) {
           m.chai.expect(drives).to.deep.equal([
             {
+              type: 'BLOCK_DEVICE',
               device: '/dev/sdb',
               displayName: '/dev/sdb',
               description: 'Foo',
@@ -147,6 +156,7 @@ describe('Browser: driveScanner', function () {
               system: false
             },
             {
+              type: 'BLOCK_DEVICE',
               device: '/dev/sdc',
               displayName: '/dev/sdc',
               description: 'Bar',
@@ -184,6 +194,7 @@ describe('Browser: driveScanner', function () {
         this.drivelistStub = m.sinon.stub(drivelist, 'list')
         this.drivelistStub.yields(null, [
           {
+            type: 'BLOCK_DEVICE',
             device: '\\\\.\\PHYSICALDRIVE1',
             displayName: 'C:',
             description: 'WDC WD10JPVX-75J',
@@ -196,6 +207,7 @@ describe('Browser: driveScanner', function () {
             system: true
           },
           {
+            type: 'BLOCK_DEVICE',
             device: '\\\\.\\PHYSICALDRIVE2',
             displayName: '\\\\.\\PHYSICALDRIVE2',
             description: 'Foo',
@@ -204,6 +216,7 @@ describe('Browser: driveScanner', function () {
             system: false
           },
           {
+            type: 'BLOCK_DEVICE',
             device: '\\\\.\\PHYSICALDRIVE3',
             displayName: 'F:',
             description: 'Bar',
@@ -223,9 +236,10 @@ describe('Browser: driveScanner', function () {
       })
 
       it('should emit the non removable drives', function (done) {
-        driveScanner.once('drives', function (drives) {
+        driveScanner.once('devices', function (drives) {
           m.chai.expect(drives).to.deep.equal([
             {
+              type: 'BLOCK_DEVICE',
               device: '\\\\.\\PHYSICALDRIVE2',
               displayName: '\\\\.\\PHYSICALDRIVE2',
               description: 'Foo',
@@ -234,6 +248,7 @@ describe('Browser: driveScanner', function () {
               system: false
             },
             {
+              type: 'BLOCK_DEVICE',
               device: '\\\\.\\PHYSICALDRIVE3',
               displayName: 'F:',
               description: 'Bar',
@@ -260,6 +275,7 @@ describe('Browser: driveScanner', function () {
         this.drivelistStub = m.sinon.stub(drivelist, 'list')
         this.drivelistStub.yields(null, [
           {
+            type: 'BLOCK_DEVICE',
             device: '\\\\.\\PHYSICALDRIVE3',
             displayName: 'F:',
             description: 'Bar',
@@ -279,7 +295,7 @@ describe('Browser: driveScanner', function () {
       })
 
       it('should use the drive letter as the name', function (done) {
-        driveScanner.once('drives', function (drives) {
+        driveScanner.once('devices', function (drives) {
           m.chai.expect(drives).to.have.length(1)
           m.chai.expect(drives[0].displayName).to.equal('F:')
           driveScanner.stop()
@@ -295,6 +311,7 @@ describe('Browser: driveScanner', function () {
         this.drivesListStub = m.sinon.stub(drivelist, 'list')
         this.drivesListStub.yields(null, [
           {
+            type: 'BLOCK_DEVICE',
             device: '\\\\.\\PHYSICALDRIVE3',
             displayName: 'F:, G:, H:',
             description: 'Bar',
@@ -320,7 +337,7 @@ describe('Browser: driveScanner', function () {
       })
 
       it('should join all the mountpoints in `name`', function (done) {
-        driveScanner.once('drives', function (drives) {
+        driveScanner.once('devices', function (drives) {
           m.chai.expect(drives).to.have.length(1)
           m.chai.expect(drives[0].displayName).to.equal('F:, G:, H:')
           driveScanner.stop()
@@ -343,7 +360,7 @@ describe('Browser: driveScanner', function () {
     })
 
     it('should emit the error', function (done) {
-      driveScanner.on('error', function (error) {
+      driveScanner.once('error', function (error) {
         m.chai.expect(error).to.be.an.instanceof(Error)
         m.chai.expect(error.message).to.equal('scan error')
         driveScanner.stop()

--- a/tests/shared/sdk/usbboot.spec.js
+++ b/tests/shared/sdk/usbboot.spec.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const m = require('mochainon')
+const _ = require('lodash')
+const Bluebird = require('bluebird')
+const usb = require('../../../lib/shared/sdk/utils/usb')
+const usbboot = require('../../../lib/shared/sdk/usbboot')
+
+const createUSBDeviceStub = (options) => {
+  return {
+    deviceDescriptor: {
+      idVendor: options.vendorID,
+      idProduct: options.productID,
+      iManufacturer: options.manufacturerIndex,
+      iProduct: options.productIndex
+    },
+    _configDescriptor: {
+      bNumInterfaces: options.interfaces
+    },
+    open: _.noop,
+    close: _.noop,
+    getStringDescriptor: (index, callback) => {
+      callback(null, options.strings[index])
+    }
+  }
+}
+
+const BCM2835_STUB = createUSBDeviceStub({
+  vendorID: 0x0a5c,
+  productID: 0x2763,
+  manufacturerIndex: 1,
+  productIndex: 2,
+  interfaces: 1,
+  strings: [
+    null,
+    'Broadcom',
+    'BCM2708 Boot'
+  ]
+})
+
+const BCM2837_STUB = createUSBDeviceStub({
+  vendorID: 0x0a5c,
+  productID: 0x2764,
+  manufacturerIndex: 1,
+  productIndex: 2,
+  interfaces: 1,
+  strings: [
+    null,
+    'Broadcom',
+    'BCM2710 Boot'
+  ]
+})
+
+const UNSUPPORTED_DEVICE_STUB = createUSBDeviceStub({
+  vendorID: 0x9999,
+  productID: 0x2763,
+  manufacturerIndex: 1,
+  productIndex: 2,
+  interfaces: 2,
+  strings: [
+    null,
+    'FOO',
+    'X2763'
+  ]
+})
+
+describe('SDK: usbboot', function () {
+  describe('.scan()', function () {
+    describe('given no available USB devices', function () {
+      beforeEach(function () {
+        this.usbListDevicesStub = m.sinon.stub(usb, 'listDevices')
+        this.usbListDevicesStub.returns(Bluebird.resolve([]))
+      })
+
+      afterEach(function () {
+        this.usbListDevicesStub.restore()
+      })
+
+      it('should resolve an empty array', function () {
+        return usbboot.scan().then((devices) => {
+          m.chai.expect(devices).to.deep.equal([])
+        })
+      })
+    })
+
+    describe('given a non supported device', function () {
+      beforeEach(function () {
+        this.usbListDevicesStub = m.sinon.stub(usb, 'listDevices')
+        this.usbListDevicesStub.returns(Bluebird.resolve([
+          UNSUPPORTED_DEVICE_STUB
+        ]))
+      })
+
+      afterEach(function () {
+        this.usbListDevicesStub.restore()
+      })
+
+      it('should resolve an empty array', function () {
+        return usbboot.scan().then((devices) => {
+          m.chai.expect(devices).to.deep.equal([])
+        })
+      })
+    })
+
+    describe('given a supported and a non supported device', function () {
+      beforeEach(function () {
+        this.usbListDevicesStub = m.sinon.stub(usb, 'listDevices')
+        this.usbListDevicesStub.returns(Bluebird.resolve([
+          BCM2835_STUB,
+          UNSUPPORTED_DEVICE_STUB
+        ]))
+      })
+
+      afterEach(function () {
+        this.usbListDevicesStub.restore()
+      })
+
+      it('should only resolve the supported device', function () {
+        return usbboot.scan().then((devices) => {
+          m.chai.expect(devices.length).to.equal(1)
+          const device = _.first(devices)
+          m.chai.expect(device.name).to.equal('Broadcom BCM2708 Boot')
+        })
+      })
+    })
+
+    describe('given a BCM2835 device', function () {
+      beforeEach(function () {
+        this.usbListDevicesStub = m.sinon.stub(usb, 'listDevices')
+        this.usbListDevicesStub.returns(Bluebird.resolve([
+          BCM2835_STUB
+        ]))
+      })
+
+      afterEach(function () {
+        this.usbListDevicesStub.restore()
+      })
+
+      it('should resolve a friendly device object', function () {
+        return usbboot.scan().then((devices) => {
+          m.chai.expect(devices.length).to.equal(1)
+          const device = _.first(devices)
+          m.chai.expect(device.name).to.equal('Broadcom BCM2708 Boot')
+          m.chai.expect(device.interface).to.equal(0)
+          m.chai.expect(device.outEndpoint).to.equal(1)
+          m.chai.expect(device.instance).to.deep.equal(BCM2835_STUB)
+        })
+      })
+    })
+
+    describe('given a BCM2837 device', function () {
+      beforeEach(function () {
+        this.usbListDevicesStub = m.sinon.stub(usb, 'listDevices')
+        this.usbListDevicesStub.returns(Bluebird.resolve([
+          BCM2837_STUB
+        ]))
+      })
+
+      afterEach(function () {
+        this.usbListDevicesStub.restore()
+      })
+
+      it('should resolve a friendly device object', function () {
+        return usbboot.scan().then((devices) => {
+          m.chai.expect(devices.length).to.equal(1)
+          const device = _.first(devices)
+          m.chai.expect(device.name).to.equal('Broadcom BCM2710 Boot')
+          m.chai.expect(device.interface).to.equal(0)
+          m.chai.expect(device.outEndpoint).to.equal(1)
+          m.chai.expect(device.instance).to.deep.equal(BCM2837_STUB)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
We leverage the Etcher usbboot SDK and bring it into drive scanner.

Changelog-Entry: Bring usbboot into drive scanner.
Depends: https://github.com/resin-io/etcher/pull/1686