### PR TITLE
upgrade: mountutils to v1.2.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4783,9 +4783,9 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.2.1",
-      "from": "mountutils@1.2.1",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.2.1.tgz",
+      "version": "1.2.2",
+      "from": "mountutils@1.2.2",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.2.2.tgz",
       "dependencies": {
         "nan": {
           "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lzma-native": "1.5.2",
     "mbr": "1.1.2",
     "mime-types": "2.1.15",
-    "mountutils": "1.2.1",
+    "mountutils": "1.2.2",
     "nan": "2.3.5",
     "node-ipc": "8.9.2",
     "node-stream-zip": "1.3.4",


### PR DESCRIPTION
See: https://github.com/resin-io-modules/mountutils/pull/45
Change-Type: patch
Changelog-Entry: Retry ejection various times before giving up on Windows.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>