### PR TITLE
chore: fix CLI packaging snapshot relative directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ TARGET_ARCH_ELECTRON_BUILDER = $(shell ./scripts/build/architecture-convert.sh -
 PLATFORM_PKG = $(shell ./scripts/build/platform-convert.sh -r $(PLATFORM) -t pkg)
 ENTRY_POINT_CLI = lib/cli/etcher.js
 ETCHER_CLI_BINARY = $(APPLICATION_NAME_LOWERCASE)
-ifeq ($(TARGET_PLATFORM),win32)
+ifeq ($(PLATFORM),win32)
 ETCHER_CLI_BINARY = $(APPLICATION_NAME_LOWERCASE).exe
 endif
 
@@ -228,7 +228,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(PLATFORM)-$(
 	$(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(PLATFORM)-$(TARGET_ARCH)-app \
 	| $(BUILD_DIRECTORY)
 	mkdir $@
-	$(NPX) pkg --output $@/$(ETCHER_CLI_BINARY) -t node6-$(PLATFORM_PKG)-$(TARGET_ARCH) $</$(ENTRY_POINT_CLI)
+	cd $< && ../../$(NPX) pkg --output ../../$@/$(ETCHER_CLI_BINARY) -t node6-$(PLATFORM_PKG)-$(TARGET_ARCH) $(ENTRY_POINT_CLI)
 	./scripts/build/dependencies-npm-extract-addons.sh \
 		-d $</node_modules \
 		-o $@/node_modules


### PR DESCRIPTION
The current CLI releases are broken. Seems that `pkg` creates the
application snapshot based on the current working directory, so at the
moment, the snapshot gets created based on the root of the project,
rather than based on the dist/Etcher-cli-* directories, causing the
native add-ons to not be resolved correctly.

Fixes: https://github.com/resin-io/etcher/issues/1706
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>