### PR TITLE
chore(package): Bump resin-corvus to 1.0.0-beta.29

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1015,7 +1015,8 @@
     "cross-spawn": {
       "version": "4.0.2",
       "from": "cross-spawn@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "dev": true
     },
     "cross-spawn-async": {
       "version": "2.2.5",
@@ -2679,8 +2680,7 @@
     "get-stream": {
       "version": "3.0.0",
       "from": "get-stream@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
     },
     "get-uri": {
       "version": "0.1.4",
@@ -3212,9 +3212,9 @@
       "dev": true
     },
     "is-electron": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "is-electron@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz"
     },
     "is-electron-renderer": {
       "version": "2.0.1",
@@ -4582,9 +4582,9 @@
       "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.6.0.tgz"
     },
     "mixpanel-browser": {
-      "version": "2.11.1",
+      "version": "2.13.0",
       "from": "mixpanel-browser@>=2.11.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.11.1.tgz"
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.13.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -8919,19 +8919,19 @@
       }
     },
     "resin-corvus": {
-      "version": "1.0.0-beta.28",
-      "from": "resin-corvus@1.0.0-beta.28",
-      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.28.tgz",
+      "version": "1.0.0-beta.29",
+      "from": "resin-corvus@1.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.29.tgz",
       "dependencies": {
-        "execa": {
-          "version": "0.5.1",
-          "from": "execa@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz"
+        "cross-spawn": {
+          "version": "5.1.0",
+          "from": "cross-spawn@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
         },
-        "get-stream": {
-          "version": "2.3.1",
-          "from": "get-stream@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz"
+        "execa": {
+          "version": "0.7.0",
+          "from": "execa@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz"
         },
         "lodash": {
           "version": "4.17.4",
@@ -8944,9 +8944,9 @@
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
         },
         "os-locale": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "from": "os-locale@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
         },
         "path-key": {
           "version": "2.0.1",
@@ -9187,6 +9187,16 @@
       "version": "1.0.5",
       "from": "setimmediate@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "from": "shebang-command@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.7.8",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "request": "2.81.0",
     "resin-cli-form": "1.4.1",
     "resin-cli-visuals": "1.3.1",
-    "resin-corvus": "1.0.0-beta.28",
+    "resin-corvus": "1.0.0-beta.29",
     "semver": "5.1.1",
     "sudo-prompt": "6.1.0",
     "trackjs": "2.3.1",


### PR DESCRIPTION
This updates `resin-corvus` to version 1.0.0-beta.29, switching
Mixpanel and Sentry analytics to HTTPS transports.

Changes:

- fix(sentry): Default to HTTPS transport
- fix(mixpanel): Use HTTPS transport
- test: Use standardjs for linting
- doc(README): Add CI & npm badges
- fix(ci): Fix Appveyor Node version matrix
- refactor: Ensure Node 4 compatibility

Change-Type: patch
Connects To: #1718