### PR TITLE
refactor(image-stream): Remove Promise props resolve

### DIFF
--- a/lib/image-stream/handlers.js
+++ b/lib/image-stream/handlers.js
@@ -54,7 +54,7 @@ module.exports = {
    * @returns {Promise}
    */
   'application/x-bzip2': (imagePath, options) => {
-    return Bluebird.props({
+    return {
       path: imagePath,
       archiveExtension: fileExtensions.getLastFileExtension(imagePath),
       extension: fileExtensions.getPenultimateFileExtension(imagePath),
@@ -67,7 +67,7 @@ module.exports = {
         }
       },
       transform: unbzip2Stream()
-    })
+    }
   },
 
   /**
@@ -94,7 +94,7 @@ module.exports = {
         }
       })
     }).then((uncompressedSize) => {
-      return Bluebird.props({
+      return {
         path: imagePath,
         archiveExtension: fileExtensions.getLastFileExtension(imagePath),
         extension: fileExtensions.getPenultimateFileExtension(imagePath),
@@ -107,7 +107,7 @@ module.exports = {
           }
         },
         transform: zlib.createGunzip()
-      })
+      }
     })
   },
 
@@ -223,7 +223,7 @@ module.exports = {
    * @returns {Promise}
    */
   'application/octet-stream': (imagePath, options) => {
-    return Bluebird.props({
+    return {
       path: imagePath,
       extension: fileExtensions.getLastFileExtension(imagePath),
       stream: fs.createReadStream(imagePath),
@@ -235,7 +235,7 @@ module.exports = {
         }
       },
       transform: new PassThroughStream()
-    })
+    }
   }
 
 }


### PR DESCRIPTION
This removes `Bluebird.props()` from the image type handlers,
as it's just a remnant when some properties in the return value
were Promises that needed resolving.

Change-Type: patch
Connects To: #1724