### PR TITLE
upgrade(node-stream-zip): 1.3.4 -> 1.3.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4921,9 +4921,9 @@
       }
     },
     "node-stream-zip": {
-      "version": "1.3.4",
-      "from": "node-stream-zip@1.3.4",
-      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.4.tgz"
+      "version": "1.3.7",
+      "from": "node-stream-zip@1.3.7",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.7.tgz"
     },
     "node.extend": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mountutils": "1.2.2",
     "nan": "2.3.5",
     "node-ipc": "8.9.2",
-    "node-stream-zip": "1.3.4",
+    "node-stream-zip": "1.3.7",
     "path-is-inside": "1.0.2",
     "pretty-bytes": "1.0.4",
     "prop-types": "15.5.9",


### PR DESCRIPTION
This fixes RangeErrors occurring with some zip files.

**Changes:**

- Fixed compatibility with node.js v0.10
- Fix error unpacking archives with a special comment
- Fix descriptive error messages

Change-Type: patch
Changelog-Entry: Fix Etcher being unable to read certain zip files
Connects To: #1729 