### PR TITLE
feat: add drive multi-selection in store

### DIFF
--- a/lib/gui/app/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/app/components/drive-selector/controllers/drive-selector.js
@@ -118,6 +118,7 @@ module.exports = function (
           previouslySelected: selectionState.isCurrentDrive(drive.device)
         })
 
+        selectionState.deselectOtherDrives(drive.device)
         selectionState.toggleDrive(drive.device)
       }
     })
@@ -132,7 +133,7 @@ module.exports = function (
    * DriveSelectorController.closeModal();
    */
   this.closeModal = () => {
-    const selectedDrive = selectionState.getDrive()
+    const selectedDrive = selectionState.getCurrentDrive()
 
     // Sanity check to cover the case where a drive is selected,
     // the drive is then unplugged from the computer and the modal

--- a/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -38,7 +38,7 @@
         </div>
         <span class="list-group-item-section tick tick--success"
           ng-show="modal.constraints.isDriveValid(drive, modal.state.getImage())"
-          ng-disabled="!modal.state.isCurrentDrive(drive.device)"></span>
+          ng-disabled="!modal.state.isDriveSelected(drive.device)"></span>
     </li>
     <li class="list-group-item"
       ng-show="!modal.drives.hasAvailableDrives()">

--- a/lib/gui/app/pages/finish/controllers/finish.js
+++ b/lib/gui/app/pages/finish/controllers/finish.js
@@ -51,7 +51,7 @@ module.exports = function ($state) {
     if (!options.preserveImage) {
       selectionState.deselectImage()
     }
-    selectionState.deselectDrive()
+    selectionState.deselectAllDrives()
     analytics.logEvent('Restart', options)
     $state.go('main')
   }

--- a/lib/gui/app/pages/main/templates/main.tpl.html
+++ b/lib/gui/app/pages/main/templates/main.tpl.html
@@ -66,11 +66,11 @@
               'text-disabled': main.shouldDriveStepBeDisabled()
             }">
             <span class="drive-step step-name"
-              uib-tooltip="{{ main.selection.getDrive().description }} ({{ main.selection.getDrive().displayName }})">
+              uib-tooltip="{{ main.selection.getCurrentDrive().description }} ({{ main.selection.getCurrentDrive().displayName }})">
               <!-- middleEllipses errors on undefined, therefore fallback to empty string -->
-              {{ (main.selection.getDrive().description || "") | middleEllipses:11 }}
+              {{ (main.selection.getCurrentDrive().description || "") | middleEllipses:11 }}
             </span>
-            <span class="step-drive step-size">{{ main.selection.getDrive().size | closestUnit }}</span>
+            <span class="step-drive step-size">{{ main.selection.getCurrentDrive().size | closestUnit }}</span>
             <span class="step-drive step-warning glyphicon glyphicon-exclamation-sign"
               uib-tooltip="{{ main.constraints.getDriveImageCompatibilityStatuses(main.selection.getDrive(), main.selection.getImage())[0].message }}"
               ng-show="main.constraints.hasDriveImageCompatibilityStatus(main.selection.getDrive(), main.selection.getImage())"></span>
@@ -97,7 +97,7 @@
           percentage="main.state.getFlashState().percentage"
           striped="{{ main.state.getFlashState().type == 'check' }}"
           ng-attr-active="{{ main.state.isFlashing() }}"
-          ng-click="flash.flashImageToDrive(main.selection.getImage(), main.selection.getDrive())"
+          ng-click="flash.flashImageToDrive(main.selection.getImage(), main.selection.getCurrentDrive())"
           ng-disabled="main.shouldFlashStepBeDisabled() || main.state.getLastFlashErrorCode()">
             <span ng-bind="flash.getProgressButtonLabel()"></span>
         </progress-button>

--- a/lib/shared/models/selection-state.js
+++ b/lib/shared/models/selection-state.js
@@ -48,10 +48,38 @@ exports.selectDrive = (driveDevice) => {
  * selectionState.toggleDrive('/dev/disk2');
  */
 exports.toggleDrive = (driveDevice) => {
-  if (exports.isCurrentDrive(driveDevice)) {
-    exports.deselectDrive()
+  if (exports.isDriveSelected(driveDevice)) {
+    exports.deselectDrive(driveDevice)
   } else {
     exports.selectDrive(driveDevice)
+  }
+}
+
+/**
+ * @summary Deselect all other drives and keep the current drive's status
+ * @function
+ * @public
+ * @deprecated
+ *
+ * @description
+ * This is a temporary function during the transition to multi-writes,
+ * remove this and its uses when multi-selection should become user-facing.
+ *
+ * @param {String} driveDevice - drive device identifier
+ *
+ * @example
+ * console.log(selectionState.getSelectedDevices())
+ * > [ '/dev/disk1', '/dev/disk2', '/dev/disk3' ]
+ * selectionState.deselectOtherDrives('/dev/disk2')
+ * console.log(selectionState.getSelectedDevices())
+ * > [ '/dev/disk2' ]
+ */
+exports.deselectOtherDrives = (driveDevice) => {
+  if (exports.isDriveSelected(driveDevice)) {
+    const otherDevices = _.reject(exports.getSelectedDevices(), _.partial(_.isEqual, driveDevice))
+    _.each(otherDevices, exports.deselectDrive)
+  } else {
+    exports.deselectAllDrives()
   }
 }
 
@@ -82,19 +110,38 @@ exports.selectImage = (image) => {
 }
 
 /**
- * @summary Get drive
+ * @summary Get all selected drives' devices
+ * @function
+ * @public
+ *
+ * @returns {String[]} selected drives' devices
+ *
+ * @example
+ * for (driveDevice of selectionState.getSelectedDevices()) {
+ *   console.log(driveDevice)
+ * }
+ * > '/dev/disk1'
+ * > '/dev/disk2'
+ */
+exports.getSelectedDevices = () => {
+  return store.getState().getIn([ 'selection', 'devices' ]).toJS()
+}
+
+/**
+ * @summary Get the head of the list of selected drives
  * @function
  * @public
  *
  * @returns {Object} drive
  *
  * @example
- * const drive = selectionState.getDrive();
+ * const drive = selectionState.getCurrentDrive();
+ * console.log(drive)
+ * > { device: '/dev/disk1', name: 'Flash drive', ... }
  */
-exports.getDrive = () => {
-  return _.find(availableDrives.getDrives(), {
-    device: store.getState().getIn([ 'selection', 'drive' ])
-  })
+exports.getCurrentDrive = () => {
+  const device = _.head(exports.getSelectedDevices())
+  return _.find(availableDrives.getDrives(), { device })
 }
 
 /**
@@ -252,7 +299,7 @@ exports.getImageRecommendedDriveSize = () => {
  * }
  */
 exports.hasDrive = () => {
-  return Boolean(exports.getDrive())
+  return Boolean(exports.getSelectedDevices().length)
 }
 
 /**
@@ -272,16 +319,22 @@ exports.hasImage = () => {
 }
 
 /**
- * @summary Remove drive
+ * @summary Remove drive from selection
  * @function
  * @public
  *
+ * @param {String} driveDevice - drive device identifier
+ *
  * @example
- * selectionState.deselectDrive();
+ * selectionState.deselectDrive('/dev/sdc');
+ *
+ * @example
+ * selectionState.deselectDrive('\\\\.\\PHYSICALDRIVE3');
  */
-exports.deselectDrive = () => {
+exports.deselectDrive = (driveDevice) => {
   store.dispatch({
-    type: store.Actions.DESELECT_DRIVE
+    type: store.Actions.DESELECT_DRIVE,
+    data: driveDevice
   })
 }
 
@@ -300,19 +353,28 @@ exports.deselectImage = () => {
 }
 
 /**
+ * @summary Unselect all drives
+ * @function
+ * @public
+ *
+ * @example
+ * selectionState.deselectAllDrives()
+ */
+exports.deselectAllDrives = () => {
+  _.each(exports.getSelectedDevices(), exports.deselectDrive)
+}
+
+/**
  * @summary Clear selections
  * @function
  * @public
  *
  * @example
  * selectionState.clear();
- *
- * @example
- * selectionState.clear({ preserveImage: true });
  */
 exports.clear = () => {
   exports.deselectImage()
-  exports.deselectDrive()
+  exports.deselectAllDrives()
 }
 
 /**
@@ -333,5 +395,29 @@ exports.isCurrentDrive = (driveDevice) => {
     return false
   }
 
-  return driveDevice === _.get(exports.getDrive(), [ 'device' ])
+  return driveDevice === _.get(exports.getCurrentDrive(), [ 'device' ])
+}
+
+/**
+ * @summary Check whether a given device is selected.
+ * @function
+ * @public
+ *
+ * @param {String} driveDevice - drive device identifier
+ * @returns {Boolean}
+ *
+ * @example
+ * const isSelected = selectionState.isDriveSelected('/dev/sdb')
+ *
+ * if (isSelected) {
+ *   selectionState.deselectDrive(driveDevice)
+ * }
+ */
+exports.isDriveSelected = (driveDevice) => {
+  if (!driveDevice) {
+    return false
+  }
+
+  const selectedDriveDevices = exports.getSelectedDevices()
+  return _.includes(selectedDriveDevices, driveDevice)
 }

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -82,7 +82,9 @@ const selectImageNoNilFields = [
  */
 const DEFAULT_STATE = Immutable.fromJS({
   availableDrives: [],
-  selection: {},
+  selection: {
+    devices: new Immutable.OrderedSet()
+  },
   isFlashing: false,
   flashResults: {},
   flashState: {
@@ -122,25 +124,20 @@ const ACTIONS = _.fromPairs(_.map([
 }))
 
 /**
- * @summary Find a drive from the list of available drives
+ * @summary Get available drives from the state
  * @function
- * @private
+ * @public
  *
- * @param {Object} state - application state
- * @param {String} device - drive device
- * @returns {(Object|Undefined)} drive
+ * @param {Object} state - state object
+ * @returns {Object} new state
  *
  * @example
- * const drive = findDrive(state, '/dev/disk2');
+ * const drives = getAvailableDrives(state)
+ * _.find(drives, { device: '/dev/sda' })
  */
-const findDrive = (state, device) => {
-  /* eslint-disable lodash/prefer-lodash-method */
-
-  return state.get('availableDrives').find((drive) => {
-    return drive.get('device') === device
-  })
-
-  /* eslint-enable lodash/prefer-lodash-method */
+const getAvailableDrives = (state) => {
+  // eslint-disable-next-line lodash/prefer-lodash-method
+  return state.get('availableDrives').toJS()
 }
 
 /**
@@ -160,6 +157,8 @@ const findDrive = (state, device) => {
 const storeReducer = (state = DEFAULT_STATE, action) => {
   switch (action.type) {
     case ACTIONS.SET_AVAILABLE_DRIVES: {
+      // Type: action.data : Array<DriveObject>
+
       if (!action.data) {
         throw errors.createError({
           title: 'Missing drives'
@@ -167,20 +166,20 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
       }
 
       // Convert object instances to plain objects
-      action.data = JSON.parse(JSON.stringify(action.data))
+      const drives = JSON.parse(JSON.stringify(action.data))
 
-      if (!_.isArray(action.data) || !_.every(action.data, _.isPlainObject)) {
+      if (!_.isArray(drives) || !_.every(drives, _.isPlainObject)) {
         throw errors.createError({
-          title: `Invalid drives: ${action.data}`
+          title: `Invalid drives: ${drives}`
         })
       }
 
-      const newState = state.set('availableDrives', Immutable.fromJS(action.data))
+      const newState = state.set('availableDrives', Immutable.fromJS(drives))
 
       const AUTOSELECT_DRIVE_COUNT = 1
-      const numberOfDrives = action.data.length
+      const numberOfDrives = drives.length
       if (numberOfDrives === AUTOSELECT_DRIVE_COUNT) {
-        const drive = _.first(action.data)
+        const [ drive ] = drives
 
         // Even if there's no image selected, we need to call several
         // drive/image related checks, and `{}` works fine with them
@@ -198,27 +197,42 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
           !constraints.isSystemDrive(drive)
 
         ])) {
+          // Auto-select this drive
           return storeReducer(newState, {
             type: ACTIONS.SELECT_DRIVE,
             data: drive.device
           })
         }
-      }
 
-      const selectedDevice = newState.getIn([ 'selection', 'drive' ])
-
-      if (selectedDevice && !_.find(action.data, {
-        device: selectedDevice
-      })) {
+        // Deselect this drive in case it still is selected
         return storeReducer(newState, {
-          type: ACTIONS.DESELECT_DRIVE
+          type: ACTIONS.DESELECT_DRIVE,
+          data: drive.device
         })
       }
 
-      return newState
+      const selectedDevices = newState.getIn([ 'selection', 'devices' ]).toJS()
+
+      // Remove selected drives that are stale, i.e. missing from availableDrives
+      return _.reduce(selectedDevices, (accState, device) => {
+        // Check whether the drive still exists in availableDrives
+        if (device && !_.find(drives, {
+          device
+        })) {
+          // Deselect this drive gone from availableDrives
+          return storeReducer(accState, {
+            type: ACTIONS.DESELECT_DRIVE,
+            data: device
+          })
+        }
+
+        return accState
+      }, newState)
     }
 
     case ACTIONS.SET_FLASH_STATE: {
+      // Type: action.data : FlashStateObject
+
       if (!state.get('isFlashing')) {
         throw errors.createError({
           title: 'Can\'t set the flashing state when not flashing'
@@ -264,6 +278,8 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
     }
 
     case ACTIONS.UNSET_FLASHING_FLAG: {
+      // Type: action.data : FlashResultsObject
+
       if (!action.data) {
         throw errors.createError({
           title: 'Missing results'
@@ -305,40 +321,46 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
     }
 
     case ACTIONS.SELECT_DRIVE: {
-      if (!action.data) {
+      // Type: action.data : String
+
+      const device = action.data
+
+      if (!device) {
         throw errors.createError({
           title: 'Missing drive'
         })
       }
 
-      if (!_.isString(action.data)) {
+      if (!_.isString(device)) {
         throw errors.createError({
-          title: `Invalid drive: ${action.data}`
+          title: `Invalid drive: ${device}`
         })
       }
 
-      const selectedDrive = findDrive(state, action.data)
+      const selectedDrive = _.find(getAvailableDrives(state), { device })
 
       if (!selectedDrive) {
         throw errors.createError({
-          title: `The drive is not available: ${action.data}`
+          title: `The drive is not available: ${device}`
         })
       }
 
-      if (selectedDrive.get('isReadOnly')) {
+      if (selectedDrive.isReadOnly) {
         throw errors.createError({
           title: 'The drive is write-protected'
         })
       }
 
       const image = state.getIn([ 'selection', 'image' ])
-      if (image && !constraints.isDriveLargeEnough(selectedDrive.toJS(), image.toJS())) {
+      if (image && !constraints.isDriveLargeEnough(selectedDrive, image.toJS())) {
         throw errors.createError({
           title: 'The drive is not large enough'
         })
       }
 
-      return state.setIn([ 'selection', 'drive' ], Immutable.fromJS(action.data))
+      const selectedDevices = state.getIn([ 'selection', 'devices' ])
+
+      return state.setIn([ 'selection', 'devices' ], selectedDevices.add(device))
     }
 
     // TODO(jhermsmeier): Consolidate these assertions
@@ -346,6 +368,8 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
     // place where all the image extension / format handling
     // takes place, to avoid having to check 2+ locations with different logic
     case ACTIONS.SELECT_IMAGE: {
+      // Type: action.data : ImageObject
+
       verifyNoNilFields(action.data, selectImageNoNilFields, 'image')
 
       if (!_.isString(action.data.path)) {
@@ -432,24 +456,41 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
         })
       }
 
-      const selectedDrive = findDrive(state, state.getIn([ 'selection', 'drive' ]))
+      const selectedDevices = state.getIn([ 'selection', 'devices' ])
 
-      return _.attempt(() => {
-        if (selectedDrive && !_.every([
-          constraints.isDriveValid(selectedDrive.toJS(), action.data),
-          constraints.isDriveSizeRecommended(selectedDrive.toJS(), action.data)
-        ])) {
-          return storeReducer(state, {
-            type: ACTIONS.DESELECT_DRIVE
+      // Remove image-incompatible drives from selection with `constraints.isDriveValid`
+      return _.reduce(selectedDevices.toJS(), (accState, device) => {
+        const drive = _.find(getAvailableDrives(state), { device })
+        if (!constraints.isDriveValid(drive, action.data) || !constraints.isDriveSizeRecommended(drive, action.data)) {
+          return storeReducer(accState, {
+            type: ACTIONS.DESELECT_DRIVE,
+            data: device
           })
         }
 
-        return state
-      }).setIn([ 'selection', 'image' ], Immutable.fromJS(action.data))
+        return accState
+      }, state).setIn([ 'selection', 'image' ], Immutable.fromJS(action.data))
     }
 
     case ACTIONS.DESELECT_DRIVE: {
-      return state.deleteIn([ 'selection', 'drive' ])
+      // Type: action.data : String
+
+      if (!action.data) {
+        throw errors.createError({
+          title: 'Missing drive'
+        })
+      }
+
+      if (!_.isString(action.data)) {
+        throw errors.createError({
+          title: `Invalid drive: ${action.data}`
+        })
+      }
+
+      const selectedDevices = state.getIn([ 'selection', 'devices' ])
+
+      // Remove drive from set in state
+      return state.setIn([ 'selection', 'devices' ], selectedDevices.delete(action.data))
     }
 
     case ACTIONS.DESELECT_IMAGE: {
@@ -457,6 +498,8 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
     }
 
     case ACTIONS.SET_SETTINGS: {
+      // Type: action.data : SettingsObject
+
       if (!action.data) {
         throw errors.createError({
           title: 'Missing settings'

--- a/tests/shared/models/available-drives.spec.js
+++ b/tests/shared/models/available-drives.spec.js
@@ -143,8 +143,7 @@ describe('Model: availableDrives', function () {
 
         describe('given no selected image and no selected drive', function () {
           beforeEach(function () {
-            selectionState.deselectDrive()
-            selectionState.deselectImage()
+            selectionState.clear()
           })
 
           it('should auto-select a single valid available drive', function () {
@@ -164,7 +163,7 @@ describe('Model: availableDrives', function () {
             ])
 
             m.chai.expect(selectionState.hasDrive()).to.be.true
-            m.chai.expect(selectionState.getDrive().device).to.equal('/dev/sdb')
+            m.chai.expect(selectionState.getCurrentDrive().device).to.equal('/dev/sdb')
           })
         })
 
@@ -176,7 +175,7 @@ describe('Model: availableDrives', function () {
               this.imagePath = '/mnt/bar/foo.img'
             }
 
-            selectionState.deselectDrive()
+            selectionState.clear()
             selectionState.selectImage({
               path: this.imagePath,
               extension: 'img',
@@ -240,7 +239,7 @@ describe('Model: availableDrives', function () {
               }
             ])
 
-            m.chai.expect(selectionState.getDrive()).to.deep.equal({
+            m.chai.expect(selectionState.getCurrentDrive()).to.deep.equal({
               device: '/dev/sdb',
               name: 'Foo',
               size: 2000000000,
@@ -420,7 +419,7 @@ describe('Model: availableDrives', function () {
         })
 
         afterEach(function () {
-          selectionState.deselectDrive()
+          selectionState.clear()
         })
 
         it('should be deleted if its not contained in the available drives anymore', function () {


### PR DESCRIPTION
We lay the foundation for multi-selecting drives by implementing it into
the `store` and relevant modules interacting with the `store`.

Changelog-Entry: Add drive multi-selection to the store.