### PR TITLE
feat(image-stream): Support .bin image extension

### DIFF
--- a/lib/image-stream/supported.js
+++ b/lib/image-stream/supported.js
@@ -54,6 +54,10 @@ module.exports = [
     type: 'image'
   },
   {
+    extension: 'bin',
+    type: 'image'
+  },
+  {
     extension: 'dsk',
     type: 'image'
   },

--- a/tests/shared/supported-formats.spec.js
+++ b/tests/shared/supported-formats.spec.js
@@ -31,7 +31,7 @@ describe('Shared: SupportedFormats', function () {
   describe('.getNonCompressedExtensions()', function () {
     it('should return the supported non compressed extensions', function () {
       const extensions = supportedFormats.getNonCompressedExtensions()
-      m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'dsk', 'hddimg', 'raw', 'dmg', 'sdcard', 'rpi-sdimg' ])
+      m.chai.expect(extensions).to.deep.equal([ 'img', 'iso', 'bin', 'dsk', 'hddimg', 'raw', 'dmg', 'sdcard', 'rpi-sdimg' ])
     })
   })
 


### PR DESCRIPTION
This adds support for selecting images with a `.bin` file extension.

Change-Type: minor
Connects To: #1739 