### PR TITLE
Add options check for drive flag with yes flag

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -134,6 +134,18 @@ module.exports = yargs
     return true
   })
 
+  // Assert that if the `yes` flag is provided, the `drive` flag is also provided.
+  .check((argv) => {
+    if (argv.yes && !argv.drive) {
+      throw errors.createUserError({
+        title: 'Missing drive',
+        description: 'You need to explicitly pass a drive when disabling interactively'
+      })
+    }
+
+    return true
+  })
+
   .options({
     help: {
       describe: 'show help',


### PR DESCRIPTION
Check for "invalid" CLI options? #1454

Add an options check for the `drive` flag to appear with the `yes` flag. If the `yes` flag appears without the `drive` flag then a user error will be thrown as shown below.

```bash
$ ./bin/etcher -y ~/Downloads/ubuntu.iso
Usage: bin/etcher [options] <image>

Options:
  --help, -h     show help  [boolean]
  --version, -v  show version number  [boolean]
  --drive, -d    drive  [string]
  --check, -c    validate write  [boolean] [default: true]
  --yes, -y      confirm non-interactively  [boolean]
  --unmount, -u  unmount on success  [boolean] [default: true]

Examples:
  bin/etcher raspberry-pi.img
  bin/etcher --no-check raspberry-pi.img
  bin/etcher -d /dev/disk2 ubuntu.iso
  bin/etcher -d /dev/disk2 -y rpi.img

Exit codes:
  0 - Success
  1 - General Error
  2 - Validation Error
  3 - Cancelled

If you need help, don't hesitate in contacting us at:

  GitHub: https://github.com/resin-io/etcher/issues/new
  Gitter: https://gitter.im/resin-io/etcher

Missing drive

You need to explicitly pass a drive when disabling interactively
```