### PR TITLE
fix(sdk): increase bulk transfer usb timeouts

### DIFF
--- a/lib/shared/sdk/usbboot/protocol.js
+++ b/lib/shared/sdk/usbboot/protocol.js
@@ -110,7 +110,8 @@ const USB_REQUEST_DELAY_MS = 1000
  * @type {Number}
  * @constant
  */
-const USB_BULK_TRANSFER_TIMEOUT_MS = 1000
+// In node-usb, 0 means "infinite" timeout
+const USB_BULK_TRANSFER_TIMEOUT_MS = 0
 
 /**
  * @summary The amount of bits to shift to the right on a control transfer index


### PR DESCRIPTION
We experienced timeouts when sending big files (ie ~14 MBs). Setting the
timeout to 0 makes the timeout infinite.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>