### PR TITLE
fix(sdk): set usbboot control transfer timeout to infinite

### DIFF
--- a/lib/shared/sdk/usbboot/usb.js
+++ b/lib/shared/sdk/usbboot/usb.js
@@ -46,6 +46,14 @@ _.each([
 })
 
 /**
+ * @summary The timeout for USB control transfers, in milliseconds
+ * @type {Number}
+ * @constant
+ */
+// In node-usb, 0 means "infinite" timeout
+const USB_CONTROL_TRANSFER_TIMEOUT_MS = 0
+
+/**
  * @summary List the available USB devices
  * @function
  * @public
@@ -123,6 +131,7 @@ exports.performControlTransfer = (device, options) => {
   }
 
   return Bluebird.fromCallback((callback) => {
+    device.timeout = USB_CONTROL_TRANSFER_TIMEOUT_MS
     device.controlTransfer(
       options.bmRequestType,
       options.bRequest,


### PR DESCRIPTION
Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>