### PR TITLE
fix(GUI): make sure progress button is always rounded

### DIFF
--- a/lib/gui/components/progress-button/styles/_progress-button.scss
+++ b/lib/gui/components/progress-button/styles/_progress-button.scss
@@ -47,6 +47,8 @@ $progress-button-stripes-animation-duration: 1s;
 .progress-button {
   @extend .button;
   @extend .button-primary;
+  
+  overflow: hidden;
 
   &[active="true"] {
     background-color: $palette-theme-warning-background;

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6315,16 +6315,16 @@ body {
  *   <span class="progress-button__bar" style="width: 50%;"></span>
  * </button>
  */
-.progress-button[active="true"] {
-  background-color: #ff912f; }
-
-.progress-button .progress-button__bar {
-  background-color: #ff9e49; }
-
-.progress-button.progress-button--striped {
-  background-image: -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.25, #bd6415), color-stop(0.26, #fa9134), color-stop(0.5, #fa9134), color-stop(0.51, #bd6415), color-stop(0.75, #bd6415), color-stop(0.76, #fa9134), to(#fa9134)); }
-  .progress-button.progress-button--striped .progress-button__bar {
+.progress-button {
+  overflow: hidden; }
+  .progress-button[active="true"] {
+    background-color: #ff912f; }
+  .progress-button .progress-button__bar {
     background-color: #ff9e49; }
+  .progress-button.progress-button--striped {
+    background-image: -webkit-gradient(linear, 0 0, 100% 100%, color-stop(0.25, #bd6415), color-stop(0.26, #fa9134), color-stop(0.5, #fa9134), color-stop(0.51, #bd6415), color-stop(0.75, #bd6415), color-stop(0.76, #fa9134), to(#fa9134)); }
+    .progress-button.progress-button--striped .progress-button__bar {
+      background-color: #ff9e49; }
 
 .progress-button__content {
   position: relative;


### PR DESCRIPTION
At the moment the progress button which has slightly rounded corners allows the `__bar` to overflow. This causes the corners to become angular again which looks weird. I set the button's `overflow` to `hidden` to fix this issue.

*I wasn't able to test whether this fixes the issue for sure because I wasn't able to [make the development dependencies work](https://github.com/resin-io/etcher/blob/master/docs/CONTRIBUTING.md#developing) on my machine, but it should work.*