### PR TITLE
fix(usbboot): opening device debug message prints undefined

### DIFF
--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -337,7 +337,7 @@ exports.scan = (options) => {
     device.adaptor = exports.name
 
     // We need to open the device in order to access _configDescriptor
-    debug(`Opening device: ${device.name}`)
+    debug(`Opening device: ${device.displayName}`)
     device.open()
 
     // Ensures we don't wait forever if an issue occurs


### PR DESCRIPTION
We have a debug message that prints `device.name`, which is not a valid
property, and therefore the debug logs show `undefined` instead of the
USB id pair.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>