### PR TITLE
fix(GUI): don't display hyphen in drive selection entry if no size

### DIFF
--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -15,8 +15,9 @@
           width="25"
           height="30">
         <div class="list-group-item-section list-group-item-section-expanded">
-          <h4 class="list-group-item-heading">{{ drive.description }} -
-            <span class="word-keep">{{ drive.size | closestUnit }}</span>
+          <h4 class="list-group-item-heading">
+            {{ drive.description }} <span class="word-keep"
+              ng-show="drive.size">- {{ drive.size | closestUnit }}</span>
           </h4>
           <p class="list-group-item-text">{{ drive.displayName }}</p>
 


### PR DESCRIPTION
Some drives, like usbboot USB devices, don't have a size associated with
them, which results in the drive selection widget showing a hyphen with
nothing at the side, which looks a bit weird.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>