### PR TITLE
fix(GUI): don't show the "too small" badge if the size is null

### DIFF
--- a/lib/shared/drive-constraints.js
+++ b/lib/shared/drive-constraints.js
@@ -389,7 +389,7 @@ exports.getDriveImageCompatibilityStatuses = (drive, image) => {
       type: exports.COMPATIBILITY_STATUS_TYPES.ERROR,
       message: exports.COMPATIBILITY_STATUS_MESSAGES.LOCKED
     })
-  } else if (!_.isNil(drive) && !exports.isDriveLargeEnough(drive, image)) {
+  } else if (!_.isNil(drive) && !_.isNil(drive.size) && !exports.isDriveLargeEnough(drive, image)) {
     statusList.push({
       type: exports.COMPATIBILITY_STATUS_TYPES.ERROR,
       message: exports.COMPATIBILITY_STATUS_MESSAGES.TOO_SMALL

--- a/tests/shared/drive-constraints.spec.js
+++ b/tests/shared/drive-constraints.spec.js
@@ -1021,6 +1021,18 @@ describe('Shared: DriveConstraints', function () {
       })
     })
 
+    describe('given the drive size is null', () => {
+      it('should not return the too small error', function () {
+        this.image.size.final.value = this.drive.size + 1
+        this.drive.size = null
+
+        const result = constraints.getDriveImageCompatibilityStatuses(this.drive, this.image)
+        const expectedTuples = []
+
+        expectStatusTypesAndMessagesToBe(result, expectedTuples)
+      })
+    })
+
     describe('given the drive is locked', () => {
       it('should return the locked drive error', function () {
         this.drive.protected = true


### PR DESCRIPTION
Some devices don't have a size, like USB devices in the usbboot adaptor.
The `.isDriveLargeEnough()` correctly returns `false` in this case,
however we don't want to show the `TOO SMALL` badge for aesthetics
purposes.

So if a drive has a size that equals `null`, we don't allow such drive
to be selected, and we don't show a badge for it.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>