### PR TITLE
doc(CONTRIBUTING): Add libudev requirement to docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,6 +53,10 @@ The following MinGW packages are required:
 - [XCode](https://developer.apple.com/xcode/) or [XCode Command Line Tools],
 which can be installed by running `xcode-select --install`.
 
+#### Linux
+
+- `libudev-dev` for libusb (install with `sudo apt install libudev-dev` for example)
+
 ### Cloning the project
 
 ```sh


### PR DESCRIPTION
This adds `libudev-dev` to the list of requirements for Linux in `CONTRIBUTING.md`

Change-Type: patch
Connects To: #1771 