### PR TITLE
fix: set debug env variable on remote electron process

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -47,6 +47,14 @@ const driveScanner = require('./modules/drive-scanner')
 const osDialog = require('./os/dialog')
 const exceptionReporter = require('./modules/exception-reporter')
 
+// Enable debug information from all modules that use `debug`
+// See https://github.com/visionmedia/debug#browser-support
+//
+// Enable drivelist debugging information
+// See https://github.com/resin-io-modules/drivelist
+process.env.DRIVELIST_DEBUG = /drivelist|^\*$/i.test(electron.remote.process.env.DEBUG) ? '1' : ''
+window.localStorage.debug = electron.remote.process.env.DEBUG
+
 const app = angular.module('Etcher', [
   require('angular-ui-router'),
   require('angular-ui-bootstrap'),

--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -52,7 +52,7 @@ const exceptionReporter = require('./modules/exception-reporter')
 //
 // Enable drivelist debugging information
 // See https://github.com/resin-io-modules/drivelist
-process.env.DRIVELIST_DEBUG = /drivelist|^\*$/i.test(electron.remote.process.env.DEBUG) ? '1' : ''
+electron.remote.process.env.DRIVELIST_DEBUG = /drivelist|^\*$/i.test(electron.remote.process.env.DEBUG) ? '1' : ''
 window.localStorage.debug = electron.remote.process.env.DEBUG
 
 const app = angular.module('Etcher', [

--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -6,16 +6,6 @@
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/desktop.css">
     <link rel="stylesheet" type="text/css" href="css/angular.css">
-
-    <!-- Enable debug information from all modules that use `debug` -->
-    <!-- See https://github.com/visionmedia/debug#browser-support -->
-    <script>
-      // Enable drivelist debugging information
-      // See https://github.com/resin-io-modules/drivelist
-      process.env['DRIVELIST_DEBUG'] = /drivelist|^\*$/i.test(process.env['DEBUG']) ? '1' : '';
-      window.localStorage.debug = process.env['DEBUG'];
-    </script>
-
     <script src="./app.js"></script>
   </head>
   <body ng-app="Etcher">

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -27,6 +27,8 @@ const debug = require('debug')('sdk:usbboot')
 const usb = require('./usb')
 const protocol = require('./protocol')
 
+debug.enabled = true
+
 /**
  * @summary The name of this adaptor
  * @public

--- a/lib/start.js
+++ b/lib/start.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-process.env.DEBUG = `sdk:usbboot,${process.env.DEBUG}`
+process.env.DEBUG = `sdk:usbboot${process.env.DEBUG ? `,${process.env.DEBUG}` : ''}`
 
 // See http://electron.atom.io/docs/v0.37.7/api/environment-variables/#electronrunasnode
 //

--- a/lib/start.js
+++ b/lib/start.js
@@ -16,8 +16,6 @@
 
 'use strict'
 
-process.env.DEBUG = `sdk:usbboot${process.env.DEBUG ? `,${process.env.DEBUG}` : ''}`
-
 // See http://electron.atom.io/docs/v0.37.7/api/environment-variables/#electronrunasnode
 //
 // Notice that if running electron with `ELECTRON_RUN_AS_NODE`, the binary


### PR DESCRIPTION
We fix the DEBUG environment variable by setting it on the `electron.remote`
instead, and we also move the code to `lib/gui/app.js` and away from
`lib/gui/index.html`.

Changelog-Entry: Set the DEBUG environment variable on the remote
electron process.
Change-Type: patch