### PR TITLE
upgrade(package): Bump resin-corvus to beta.30

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8680,9 +8680,9 @@
       }
     },
     "raven-js": {
-      "version": "3.17.0",
+      "version": "3.19.1",
       "from": "raven-js@>=3.12.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.17.0.tgz"
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.19.1.tgz"
     },
     "rc": {
       "version": "1.1.7",
@@ -8983,9 +8983,9 @@
       }
     },
     "resin-corvus": {
-      "version": "1.0.0-beta.29",
-      "from": "resin-corvus@1.0.0-beta.29",
-      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.29.tgz",
+      "version": "1.0.0-beta.30",
+      "from": "resin-corvus@1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.30.tgz",
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "request": "2.81.0",
     "resin-cli-form": "1.4.1",
     "resin-cli-visuals": "1.3.1",
-    "resin-corvus": "1.0.0-beta.29",
+    "resin-corvus": "1.0.0-beta.30",
     "semver": "5.1.1",
     "sudo-prompt": "6.1.0",
     "trackjs": "2.3.1",


### PR DESCRIPTION
This updates resin-corvus to v1.0.0-beta.30, fixing an issue
with attempting to use https transport in browserland.

Change-Type: patch