### PR TITLE
fix(usbboot): handle LIBUSB_ERROR_NO_DEVICE when claiming a USB interface

### DIFF
--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -360,7 +360,17 @@ exports.scan = (options) => {
 
     const deviceInterface = device.interface(addresses.interface)
     debug(`Claiming interface: ${addresses.interface}`)
-    deviceInterface.claim()
+
+    try {
+      deviceInterface.claim()
+    } catch (error) {
+      if (error.message === 'LIBUSB_ERROR_NO_DEVICE') {
+        debug('Couldn\'t claim the interface. Assuming the device is gone')
+        return null
+      }
+
+      throw error
+    }
 
     const endpoint = deviceInterface.endpoint(addresses.endpoint)
 
@@ -383,5 +393,5 @@ exports.scan = (options) => {
   // See http://bluebirdjs.com/docs/api/promise.map.html
   }, {
     concurrency: 5
-  })
+  }).then(_.compact)
 }


### PR DESCRIPTION
Consider the following scenario:

- Usbboot runs successfully on a device
- Before the block device gets a chance to appear, we run usbboot again

If we're fast enough, usbboot will try to claim the device interface,
but then the drive might not be there anymore, causing a
`LIBUSB_ERROR_NO_DEVICE`.

This commit addresses that scenario, and simply ignores the drive.

Change-Type: patch
Changelog-Entry: Fix `LIBUSB_ERROR_NO_DEVICE` error at the end of usbboot.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>