### PR TITLE
fix(usbboot): handle device disconnections

### DIFF
--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -376,8 +376,14 @@ exports.scan = (options) => {
 
       debug('Starting file server')
       return startFileServer(device, endpoint, options.files)
-    }).return(device).finally(() => {
-      device.close()
+    }).return(device).catch({
+      message: 'LIBUSB_TRANSFER_CANCELLED'
+    }, {
+      message: 'LIBUSB_ERROR_NO_DEVICE'
+    }, _.constant(null)).tap((result) => {
+      if (result) {
+        result.close()
+      }
     })
 
   // See http://bluebirdjs.com/docs/api/promise.map.html


### PR DESCRIPTION
This commit handles errors that can come up when unplugging the drive
halfway through the process. After tons of experimentation, the errors
than seem to occur are:

- `LIBUSB_TRANSFER_CANCELLED`
- `LIBUSB_ERROR_NO_DEVICE`

When these errors happen, we can omit the drive, and also not try to
close it, since given the device is no longer there, the close operation
bails out with a strange error message.

Change-Type: patch
Changelog-Entry: Gracefully handle scenarios where a USB drive is disconnected halfway through the usbboot procedure.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>