### PR TITLE
style(usbboot): wait before scanning drives after the file server phase

### DIFF
--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -273,6 +273,11 @@ class USBBootAdapter extends EventEmitter {
       }
 
       result.progress = this.progress[result.raw]
+
+      if (result.progress === utils.PERCENTAGE_MAXIMUM) {
+        return Bluebird.delay(DEVICE_REBOOT_DELAY).return(result)
+      }
+
       return result
 
     // See http://bluebirdjs.com/docs/api/promise.map.html


### PR DESCRIPTION
This is a workaround to prevent the USB device from disappearing after
the file server phase, until the resulting block device comes up.

By adding a delay after the file server phase, we prevent the USB
scanner from getting triggered again, therefore keeping the current USB
device visible in the drive selector modal.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>