### PR TITLE
refactor(sdk): add bus number, device address, and ids in usb devices

### DIFF
--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -361,25 +361,24 @@ exports.scan = (options) => {
   return usb.listDevices().filter(isUsbBootCapableUSBDevice).map((device) => {
   /* eslint-enable lodash/prefer-lodash-method */
 
-    const idPair = _.join([
-      usbIdToString(device.deviceDescriptor.idVendor),
-      usbIdToString(device.deviceDescriptor.idProduct)
-    ], ':')
+    // This is the only way we can unique identify devices
+    device.device = `${device.busNumber}:${device.deviceAddress}`
 
-    device.device = idPair
     device.displayName = 'Initializing device'
     device.description = 'Compute Module'
-    device.raw = idPair
+    device.raw = device.device
     device.size = null
     device.mountpoints = []
     device.protected = false
     device.system = false
     device.disabled = true
     device.icon = 'loading'
+    device.vendor = usbIdToString(device.deviceDescriptor.idVendor)
+    device.product = usbIdToString(device.deviceDescriptor.idProduct)
     device.adaptor = exports.name
 
     // We need to open the device in order to access _configDescriptor
-    debug(`Opening device: ${device.displayName}`)
+    debug(`Opening device: ${device.device} (${device.vendor}:${device.product})`)
     device.open()
 
     // Ensures we don't wait forever if an issue occurs


### PR DESCRIPTION
The combination of bus number and device address is the only way to
uniquely identify a USB device, so we'll use that for the `device` and
`raw` properties.

Also, we store the USB vendor and product IDs as properties of the
drives, since they will be handy when implementing the prepare function.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>