### PR TITLE
test(Makefile): Update codespell excludes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,7 +531,7 @@ lint-html:
 
 lint-spell:
 	codespell.py \
-		--skip *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,*.rpi-sdcard,.DS_Store \
+		--skip *.gz,*.bz2,*.xz,*.zip,*.img,*.dmg,*.iso,*.rpi-sdcard,.DS_Store,*.dtb,*.dtbo,*.dat,*.elf,*.bin,*.foo,xz-without-extension \
 		lib tests docs scripts Makefile *.md LICENSE
 
 lint: lint-js lint-sass lint-cpp lint-html lint-spell


### PR DESCRIPTION
This adds excludes for .dtb, .dtbo, .dat, .elf, .bin, .foo, and xz-without-extension
to reduce unnecessary warning output in `make lint`.

```
WARNING: Binary file: lib/blobs/usbboot/bcm2709-rpi-2-b.dtb
WARNING: Binary file: lib/blobs/usbboot/bcm2710-rpi-cm3.dtb
WARNING: Binary file: lib/blobs/usbboot/bcm2708-rpi-cm.dtb
WARNING: Binary file: lib/blobs/usbboot/bcm2708-rpi-b.dtb
WARNING: Binary file: lib/blobs/usbboot/bcm2710-rpi-3-b.dtb
WARNING: Binary file: lib/blobs/usbboot/bcm2708-rpi-0-w.dtb
WARNING: Binary file: lib/blobs/usbboot/bcm2708-rpi-b-plus.dtb
WARNING: Binary file: lib/blobs/usbboot/overlays/dwc2.dtbo
WARNING: Binary file: lib/blobs/usbboot/raspberrypi/fixup_cd.dat
WARNING: Binary file: lib/blobs/usbboot/raspberrypi/start_cd.elf
WARNING: Binary file: lib/blobs/usbboot/raspberrypi/bootcode.bin
WARNING: Binary file: tests/image-stream/data/unrecognized/xz-without-extension
WARNING: Binary file: tests/image-stream/data/unrecognized/xz-with-invalid-extension.foo
```

Change-Type: patch