### PR TITLE
refactor(scripts): Update clean-shrinkwrap script

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,81 +4,66 @@
   "dependencies": {
     "@types/angular": {
       "version": "1.6.17",
-      "from": "@types/angular@>=1.6.16 <2.0.0",
       "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.17.tgz"
     },
     "@types/jquery": {
       "version": "2.0.43",
-      "from": "@types/jquery@*",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.43.tgz"
     },
     "@types/lodash": {
       "version": "4.14.64",
-      "from": "@types/lodash@*",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.64.tgz"
     },
     "@types/lodash.assign": {
       "version": "4.2.2",
-      "from": "@types/lodash.assign@>=4.2.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/@types/lodash.assign/-/lodash.assign-4.2.2.tgz"
     },
     "@types/lodash.frompairs": {
       "version": "4.0.2",
-      "from": "@types/lodash.frompairs@>=4.0.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/@types/lodash.frompairs/-/lodash.frompairs-4.0.2.tgz"
     },
     "@types/lodash.mapvalues": {
       "version": "4.6.2",
-      "from": "@types/lodash.mapvalues@>=4.6.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/@types/lodash.mapvalues/-/lodash.mapvalues-4.6.2.tgz"
     },
     "@types/lodash.some": {
       "version": "4.6.2",
-      "from": "@types/lodash.some@>=4.6.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz"
     },
     "@types/node": {
       "version": "7.0.46",
-      "from": "@types/node@>=7.0.18 <8.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.46.tgz",
       "dev": true
     },
     "@types/react": {
       "version": "15.0.24",
-      "from": "@types/react@>=15.0.23 <16.0.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.24.tgz"
     },
     "@types/react-dom": {
       "version": "15.5.0",
-      "from": "@types/react-dom@>=15.5.0 <16.0.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-15.5.0.tgz"
     },
     "7zip-bin": {
       "version": "2.1.0",
-      "from": "7zip-bin@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.1.0.tgz",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.0",
-      "from": "abbrev@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
     },
     "acorn": {
       "version": "4.0.11",
-      "from": "acorn@>=4.0.3 <5.0.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "from": "acorn@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "dev": true
         }
@@ -86,121 +71,100 @@
     },
     "agent-base": {
       "version": "1.0.2",
-      "from": "agent-base@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz",
       "dev": true
     },
     "ajv": {
       "version": "4.11.5",
-      "from": "ajv@>=4.9.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
       "dependencies": {
         "json-stable-stringify": {
           "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
         }
       }
     },
     "ajv-keywords": {
       "version": "1.5.1",
-      "from": "ajv-keywords@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "dev": true
     },
     "alter": {
       "version": "0.2.0",
-      "from": "alter@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
       "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
-      "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "dev": true
     },
     "angular": {
       "version": "1.6.3",
-      "from": "angular@1.6.3",
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.3.tgz"
     },
     "angular-if-state": {
       "version": "1.0.0",
-      "from": "angular-if-state@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/angular-if-state/-/angular-if-state-1.0.0.tgz",
       "dependencies": {
         "angular-ui-router": {
           "version": "0.3.2",
-          "from": "angular-ui-router@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.3.2.tgz"
         }
       }
     },
     "angular-middle-ellipses": {
       "version": "1.0.0",
-      "from": "angular-middle-ellipses@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/angular-middle-ellipses/-/angular-middle-ellipses-1.0.0.tgz"
     },
     "angular-mocks": {
       "version": "1.6.3",
-      "from": "angular-mocks@1.6.3",
       "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.3.tgz",
       "dev": true
     },
     "angular-moment": {
       "version": "1.0.1",
-      "from": "angular-moment@1.0.1",
       "resolved": "https://registry.npmjs.org/angular-moment/-/angular-moment-1.0.1.tgz"
     },
     "angular-seconds-to-date": {
       "version": "1.0.0",
-      "from": "angular-seconds-to-date@1.0.0",
       "resolved": "https://registry.npmjs.org/angular-seconds-to-date/-/angular-seconds-to-date-1.0.0.tgz"
     },
     "angular-ui-bootstrap": {
       "version": "2.5.0",
-      "from": "angular-ui-bootstrap@2.5.0",
       "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.0.tgz"
     },
     "angular-ui-router": {
       "version": "0.4.2",
-      "from": "angular-ui-router@0.4.2",
       "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.2.tgz"
     },
     "ansi-align": {
       "version": "2.0.0",
-      "from": "ansi-align@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.1.0",
-          "from": "string-width@^2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
         }
@@ -208,64 +172,52 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "any-promise": {
       "version": "1.3.0",
-      "from": "any-promise@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
     },
     "apple-data-compression": {
       "version": "0.1.0",
-      "from": "apple-data-compression@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.1.0.tgz"
     },
     "aproba": {
       "version": "1.1.1",
-      "from": "aproba@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
     },
     "arch": {
       "version": "2.1.0",
-      "from": "arch@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz"
     },
     "are-we-there-yet": {
       "version": "1.1.2",
-      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
     },
     "argparse": {
       "version": "1.0.7",
-      "from": "argparse@>=1.0.7 <2.0.0",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "dev": true
     },
     "arr-filter": {
       "version": "1.1.2",
-      "from": "arr-filter@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
       "dev": true,
       "dependencies": {
         "make-iterator": {
           "version": "1.0.0",
-          "from": "make-iterator@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
           "dev": true
         }
@@ -273,30 +225,25 @@
     },
     "arr-flatten": {
       "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
     },
     "array-slice": {
       "version": "0.2.3",
-      "from": "array-slice@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
       "dev": true
     },
     "array-sort": {
       "version": "0.1.2",
-      "from": "array-sort@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-0.1.2.tgz",
       "dev": true,
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "from": "kind-of@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "dev": true
         }
@@ -304,48 +251,40 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "dev": true
     },
     "asap": {
       "version": "2.0.5",
-      "from": "asap@>=2.0.3 <2.1.0",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
     },
     "asar": {
       "version": "0.10.0",
-      "from": "asar@0.10.0",
       "resolved": "https://registry.npmjs.org/asar/-/asar-0.10.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "glob": {
           "version": "6.0.4",
-          "from": "glob@>=6.0.4 <7.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "dev": true
         }
@@ -353,81 +292,67 @@
     },
     "asar-integrity": {
       "version": "0.1.1",
-      "from": "asar-integrity@0.1.1",
       "resolved": "https://registry.npmjs.org/asar-integrity/-/asar-integrity-0.1.1.tgz",
       "dev": true
     },
     "asn1": {
       "version": "0.1.11",
-      "from": "asn1@0.1.11",
       "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "dev": true
     },
     "assert-plus": {
       "version": "0.2.0",
-      "from": "assert-plus@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "dev": true
     },
     "ast-traverse": {
       "version": "0.1.1",
-      "from": "ast-traverse@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
       "dev": true
     },
     "ast-types": {
       "version": "0.9.6",
-      "from": "ast-types@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
       "dev": true
     },
     "async": {
       "version": "2.0.0",
-      "from": "async@>=2.0.0-rc.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.0.0.tgz",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "from": "async-foreach@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "autolinker": {
       "version": "0.15.3",
-      "from": "autolinker@>=0.15.0 <0.16.0",
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.6.0",
-      "from": "aws4@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
     },
     "babel-code-frame": {
       "version": "6.22.0",
-      "from": "babel-code-frame@>=6.16.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "dev": true,
       "dependencies": {
         "js-tokens": {
           "version": "3.0.2",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "dev": true
         }
@@ -435,13 +360,11 @@
     },
     "babel-runtime": {
       "version": "6.23.0",
-      "from": "babel-runtime@6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
-          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "dev": true
         }
@@ -449,35 +372,29 @@
     },
     "balanced-match": {
       "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "optional": true
     },
     "binary": {
       "version": "0.3.0",
-      "from": "binary@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "dev": true
     },
     "bindings": {
       "version": "1.2.1",
-      "from": "bindings@1.2.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
     },
     "bl": {
       "version": "0.9.5",
-      "from": "bl@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "dev": true
         }
@@ -485,7 +402,6 @@
     },
     "block-stream": {
       "version": "0.0.9",
-      "from": "block-stream@*",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
     },
     "blockmap": {
@@ -507,23 +423,19 @@
     },
     "bloodline": {
       "version": "1.0.1",
-      "from": "bloodline@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/bloodline/-/bloodline-1.0.1.tgz"
     },
     "bluebird": {
       "version": "3.4.1",
-      "from": "bluebird@3.4.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
     },
     "bluebird-lst": {
       "version": "1.0.2",
-      "from": "bluebird-lst@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.2.tgz",
       "dev": true,
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@>=3.5.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
           "dev": true
         }
@@ -536,47 +448,39 @@
     },
     "boom": {
       "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "bootstrap-sass": {
       "version": "3.3.6",
-      "from": "bootstrap-sass@3.3.6",
       "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.6.tgz"
     },
     "boxen": {
       "version": "1.1.0",
-      "from": "boxen@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@^3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@^2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.1.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@^4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
         }
@@ -584,283 +488,233 @@
     },
     "brace-expansion": {
       "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "braces": {
       "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "dev": true
     },
     "breakable": {
       "version": "1.0.0",
-      "from": "breakable@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
       "dev": true
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "from": "browser-stdout@1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "dev": true
     },
     "buffer-crc32": {
       "version": "0.2.5",
-      "from": "buffer-crc32@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
     "buffers": {
       "version": "0.1.1",
-      "from": "buffers@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "byline": {
       "version": "5.0.0",
-      "from": "byline@5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
       "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "dev": true
     },
     "callsites": {
       "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
-      "from": "camelcase@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "from": "camelcase@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         }
       }
     },
     "capture-stack-trace": {
       "version": "1.0.0",
-      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "from": "caseless@>=0.12.0 <0.13.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "dev": true
     },
     "chai": {
       "version": "3.5.0",
-      "from": "chai@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "dev": true
     },
     "chai-as-promised": {
       "version": "5.3.0",
-      "from": "chai-as-promised@>=5.1.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.3.0.tgz",
       "dev": true
     },
     "chai-datetime": {
       "version": "1.4.1",
-      "from": "chai-datetime@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.4.1.tgz",
       "dev": true
     },
     "chai-interface": {
       "version": "2.0.3",
-      "from": "chai-interface@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/chai-interface/-/chai-interface-2.0.3.tgz",
       "dev": true
     },
     "chai-string": {
       "version": "1.3.0",
-      "from": "chai-string@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.3.0.tgz",
       "dev": true
     },
     "chai-things": {
       "version": "0.2.0",
-      "from": "chai-things@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
       "dev": true
     },
     "chainsaw": {
       "version": "0.1.0",
-      "from": "chainsaw@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "chownr": {
       "version": "1.0.1",
-      "from": "chownr@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
     },
     "chromium-pickle-js": {
       "version": "0.1.0",
-      "from": "chromium-pickle-js@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
       "dev": true
     },
     "chs": {
       "version": "1.1.0",
-      "from": "chs@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/chs/-/chs-1.1.0.tgz"
     },
     "ci-info": {
       "version": "1.0.0",
-      "from": "ci-info@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
       "dev": true
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
       "dev": true
     },
     "cli-boxes": {
       "version": "1.0.0",
-      "from": "cli-boxes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-spinner": {
       "version": "0.2.6",
-      "from": "cli-spinner@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz"
     },
     "cli-width": {
       "version": "1.1.1",
-      "from": "cli-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
     },
     "cliui": {
       "version": "3.2.0",
-      "from": "cliui@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
     },
     "clone": {
       "version": "1.0.2",
-      "from": "clone@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
-      "from": "clone-stats@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "code-context": {
       "version": "0.5.3",
-      "from": "code-context@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/code-context/-/code-context-0.5.3.tgz",
       "dev": true
     },
     "code-point-at": {
       "version": "1.0.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "color-convert": {
       "version": "0.5.3",
-      "from": "color-convert@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "dev": true
     },
     "columnify": {
       "version": "1.5.4",
-      "from": "columnify@>=1.5.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz"
     },
     "combined-stream": {
       "version": "0.0.7",
-      "from": "combined-stream@>=0.0.5 <0.1.0",
       "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "dev": true
     },
     "command-join": {
       "version": "2.0.0",
-      "from": "command-join@2.0.0",
       "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz"
     },
     "commander": {
       "version": "2.8.1",
-      "from": "commander@>=2.8.1 <2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
     },
     "comment-parser": {
       "version": "0.4.0",
-      "from": "comment-parser@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
       "dev": true
     },
     "commoner": {
       "version": "0.10.8",
-      "from": "commoner@>=0.10.3 <0.11.0",
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@^2.5.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "esprima": {
           "version": "3.1.3",
-          "from": "esprima@~3.1.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.15 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dev": true
         },
         "recast": {
           "version": "0.11.23",
-          "from": "recast@>=0.11.17 <0.12.0",
           "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
           "dev": true
         }
@@ -868,36 +722,30 @@
     },
     "compare-version": {
       "version": "0.1.2",
-      "from": "compare-version@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
       "dev": true
     },
     "component-emitter": {
       "version": "1.1.2",
-      "from": "component-emitter@1.1.2",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.2",
-      "from": "concat-stream@>=1.5.1 <1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@~1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "dev": true
         }
@@ -905,52 +753,43 @@
     },
     "configstore": {
       "version": "3.1.0",
-      "from": "configstore@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
       "dev": true
     },
     "connective": {
       "version": "1.0.0",
-      "from": "connective@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/connective/-/connective-1.0.0.tgz",
       "dev": true
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "from": "console-control-strings@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
     },
     "contains-path": {
       "version": "0.1.0",
-      "from": "contains-path@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "dev": true
     },
     "cookie": {
       "version": "0.3.1",
-      "from": "cookie@0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
     },
     "cookiejar": {
       "version": "2.0.1",
-      "from": "cookiejar@2.0.1",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
       "dev": true
     },
     "core-js": {
       "version": "2.4.1",
-      "from": "core-js@>=2.4.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "crc": {
       "version": "3.4.4",
-      "from": "crc@>=3.4.4 <4.0.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
     },
     "crc32-stream": {
@@ -960,19 +799,16 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "from": "create-error-class@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "dev": true
     },
     "create-frame": {
       "version": "0.1.4",
-      "from": "create-frame@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/create-frame/-/create-frame-0.1.4.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "dev": true
         }
@@ -980,82 +816,68 @@
     },
     "cross-spawn": {
       "version": "4.0.2",
-      "from": "cross-spawn@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "dev": true
     },
     "cross-spawn-async": {
       "version": "2.2.5",
-      "from": "cross-spawn-async@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
       "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto-random-string": {
       "version": "1.0.0",
-      "from": "crypto-random-string@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "dev": true
     },
     "ctype": {
       "version": "0.5.3",
-      "from": "ctype@0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "dev": true
     },
     "cuint": {
       "version": "0.2.2",
-      "from": "cuint@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
       "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
     "cwd": {
       "version": "0.9.1",
-      "from": "cwd@>=0.9.1 <0.10.0",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
       "dev": true
     },
     "d": {
       "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "data-uri-to-buffer": {
       "version": "0.0.4",
-      "from": "data-uri-to-buffer@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz",
       "dev": true
     },
     "date.js": {
       "version": "0.3.1",
-      "from": "date.js@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.1.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "from": "debug@~0.7.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "dev": true
         }
@@ -1075,24 +897,20 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "decompress-zip": {
       "version": "0.1.0",
-      "from": "decompress-zip@0.1.0",
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
       "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.8 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "dev": true
         }
@@ -1100,13 +918,11 @@
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dev": true,
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@0.1.1",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "dev": true
         }
@@ -1114,76 +930,63 @@
     },
     "deep-extend": {
       "version": "0.4.1",
-      "from": "deep-extend@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "dev": true
     },
     "deep-map-keys": {
       "version": "1.2.0",
-      "from": "deep-map-keys@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/deep-map-keys/-/deep-map-keys-1.2.0.tgz"
     },
     "defaults": {
       "version": "1.0.3",
-      "from": "defaults@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "define-property": {
       "version": "0.2.5",
-      "from": "define-property@>=0.2.5 <0.3.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
       "dev": true
     },
     "defined": {
       "version": "1.0.0",
-      "from": "defined@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "dev": true
     },
     "defs": {
       "version": "1.1.1",
-      "from": "defs@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "dev": true
         },
         "cliui": {
           "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "dev": true
         },
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
           "dev": true
         },
         "window-size": {
           "version": "0.1.4",
-          "from": "window-size@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "dev": true
         },
         "yargs": {
           "version": "3.27.0",
-          "from": "yargs@>=3.27.0 <3.28.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
           "dev": true
         }
@@ -1191,13 +994,11 @@
     },
     "degenerator": {
       "version": "1.0.4",
-      "from": "degenerator@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "dev": true,
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
-          "from": "esprima@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "dev": true
         }
@@ -1205,13 +1006,11 @@
     },
     "del": {
       "version": "2.2.2",
-      "from": "del@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "dev": true,
       "dependencies": {
         "globby": {
           "version": "5.0.0",
-          "from": "globby@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "dev": true
         }
@@ -1219,46 +1018,38 @@
     },
     "delayed-stream": {
       "version": "0.0.5",
-      "from": "delayed-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
-      "from": "delegates@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
     },
     "detect-node": {
       "version": "2.0.3",
-      "from": "detect-node@>=2.0.3 <3.0.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz"
     },
     "detect-process": {
       "version": "1.0.4",
-      "from": "detect-process@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/detect-process/-/detect-process-1.0.4.tgz"
     },
     "detective": {
       "version": "4.5.0",
-      "from": "detective@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
       "dev": true
     },
     "diff": {
       "version": "1.4.0",
-      "from": "diff@1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "dev": true
     },
     "doctrine": {
       "version": "2.0.0",
-      "from": "doctrine@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@^1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         }
@@ -1293,55 +1084,45 @@
     },
     "dot-prop": {
       "version": "4.1.1",
-      "from": "dot-prop@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
       "dev": true
     },
     "drivelist": {
       "version": "5.2.4",
-      "from": "drivelist@5.2.4",
       "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.2.4.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.3.0",
-          "from": "bindings@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
         },
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         },
         "esprima": {
           "version": "4.0.0",
-          "from": "esprima@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
         },
         "js-yaml": {
           "version": "3.10.0",
-          "from": "js-yaml@>=3.10.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.16.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         },
         "nan": {
           "version": "2.7.0",
-          "from": "nan@>=2.7.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
         }
       }
     },
     "duplexer3": {
       "version": "0.1.4",
-      "from": "duplexer3@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "dev": true
     },
@@ -1352,31 +1133,26 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "optional": true
     },
     "electron": {
       "version": "1.7.9",
-      "from": "electron@1.7.9",
       "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.9.tgz",
       "dev": true,
       "dependencies": {
         "electron-download": {
           "version": "3.3.0",
-          "from": "electron-download@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
           "dev": true
         },
         "fs-extra": {
           "version": "0.30.0",
-          "from": "fs-extra@>=0.30.0 <0.31.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.4.1",
-          "from": "semver@>=5.3.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
           "dev": true
         }
@@ -1384,211 +1160,176 @@
     },
     "electron-builder": {
       "version": "19.9.1",
-      "from": "electron-builder@19.9.1",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.9.1.tgz",
       "dev": true,
       "dependencies": {
         "ajv": {
           "version": "5.2.0",
-          "from": "ajv@>=5.2.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
           "dev": true
         },
         "ajv-keywords": {
           "version": "2.1.0",
-          "from": "ajv-keywords@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@^3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "from": "balanced-match@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "from": "brace-expansion@>=1.1.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "dev": true
         },
         "chromium-pickle-js": {
           "version": "0.2.0",
-          "from": "chromium-pickle-js@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
           "dev": true
         },
         "debug": {
           "version": "2.6.8",
-          "from": "debug@2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "esprima": {
           "version": "3.1.3",
-          "from": "esprima@>=3.1.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "from": "execa@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "from": "get-stream@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "from": "hosted-git-info@>=2.4.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "js-yaml": {
           "version": "3.8.4",
-          "from": "js-yaml@>=3.8.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
           "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "from": "load-json-file@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "from": "normalize-package-data@>=2.3.8 <3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "from": "npm-run-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "from": "path-key@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "from": "path-type@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
-          "from": "read-pkg@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "from": "read-pkg-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@>=5.3.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.1.0",
-          "from": "string-width@^2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@^4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "dev": true
         },
         "which-module": {
           "version": "2.0.0",
-          "from": "which-module@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "dev": true
         },
         "yargs": {
           "version": "8.0.2",
-          "from": "yargs@>=8.0.2 <9.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "from": "yargs-parser@>=7.0.0 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "dev": true
         }
@@ -1596,19 +1337,16 @@
     },
     "electron-builder-http": {
       "version": "19.7.2",
-      "from": "electron-builder-http@19.7.2",
       "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-19.7.2.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         }
@@ -1616,19 +1354,16 @@
     },
     "electron-builder-util": {
       "version": "19.8.0",
-      "from": "electron-builder-util@19.8.0",
       "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-19.8.0.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         }
@@ -1636,43 +1371,36 @@
     },
     "electron-download-tf": {
       "version": "4.3.1",
-      "from": "electron-download-tf@4.3.1",
       "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "dev": true
         },
         "rc": {
           "version": "1.2.1",
-          "from": "rc@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@^5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         },
         "sumchecker": {
           "version": "2.0.2",
-          "from": "sumchecker@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
           "dev": true
         }
@@ -1680,24 +1408,20 @@
     },
     "electron-is-running-in-asar": {
       "version": "1.0.0",
-      "from": "electron-is-running-in-asar@1.0.0",
       "resolved": "https://registry.npmjs.org/electron-is-running-in-asar/-/electron-is-running-in-asar-1.0.0.tgz"
     },
     "electron-mocha": {
       "version": "3.3.0",
-      "from": "electron-mocha@3.3.0",
       "resolved": "https://registry.npmjs.org/electron-mocha/-/electron-mocha-3.3.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@^2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "fs-extra": {
           "version": "1.0.0",
-          "from": "fs-extra@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "dev": true
         }
@@ -1705,25 +1429,21 @@
     },
     "electron-osx-sign": {
       "version": "0.4.6",
-      "from": "electron-osx-sign@0.4.6",
       "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.6.tgz",
       "dev": true,
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@^3.4.7",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
           "dev": true
         },
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         }
@@ -1731,36 +1451,30 @@
     },
     "electron-publish": {
       "version": "19.8.0",
-      "from": "electron-publish@19.8.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.8.0.tgz",
       "dev": true
     },
     "electron-window": {
       "version": "0.8.1",
-      "from": "electron-window@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/electron-window/-/electron-window-0.8.1.tgz",
       "dev": true
     },
     "encoding": {
       "version": "0.1.12",
-      "from": "encoding@>=0.1.11 <0.2.0",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "end-of-stream": {
       "version": "1.4.0",
-      "from": "end-of-stream@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "dependencies": {
         "once": {
           "version": "1.4.0",
-          "from": "once@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
         }
       }
     },
     "ent": {
       "version": "2.2.0",
-      "from": "ent@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "dev": true
     },
@@ -1771,52 +1485,43 @@
     },
     "env-paths": {
       "version": "1.0.0",
-      "from": "env-paths@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.5",
-      "from": "es6-map@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "from": "d@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "dev": true
         },
         "es5-ext": {
           "version": "0.10.14",
-          "from": "es5-ext@>=0.10.14 <0.11.0",
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
           "dev": true
         },
         "es6-iterator": {
           "version": "2.0.1",
-          "from": "es6-iterator@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
           "dev": true
         },
         "es6-symbol": {
           "version": "3.1.1",
-          "from": "es6-symbol@>=3.1.1 <3.2.0",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "dev": true
         }
@@ -1824,37 +1529,31 @@
     },
     "es6-promise": {
       "version": "4.1.1",
-      "from": "es6-promise@>=4.0.5 <5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
       "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
-      "from": "es6-set@>=0.1.5 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "from": "d@1",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "dev": true
         },
         "es5-ext": {
           "version": "0.10.14",
-          "from": "es5-ext@~0.10.14",
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
           "dev": true
         },
         "es6-iterator": {
           "version": "2.0.1",
-          "from": "es6-iterator@~2.0.1",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
           "dev": true
         },
         "es6-symbol": {
           "version": "3.1.1",
-          "from": "es6-symbol@3.1.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "dev": true
         }
@@ -1862,34 +1561,28 @@
     },
     "es6-symbol": {
       "version": "3.1.0",
-      "from": "es6-symbol@>=3.1.0 <3.2.0",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
-      "from": "es6-weak-map@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
       "version": "1.8.1",
-      "from": "escodegen@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "dev": true,
       "dependencies": {
         "estraverse": {
           "version": "1.9.3",
-          "from": "estraverse@>=1.9.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "dev": true
         },
         "source-map": {
           "version": "0.2.0",
-          "from": "source-map@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "dev": true,
           "optional": true
@@ -1898,31 +1591,26 @@
     },
     "escope": {
       "version": "3.6.0",
-      "from": "escope@>=3.6.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "dev": true
     },
     "eslint": {
       "version": "3.19.0",
-      "from": "eslint@3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "dev": true,
       "dependencies": {
         "cli-width": {
           "version": "2.1.0",
-          "from": "cli-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
           "dev": true
         },
         "inquirer": {
           "version": "0.12.0",
-          "from": "inquirer@>=0.12.0 <0.13.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "dev": true
         }
@@ -1930,25 +1618,21 @@
     },
     "eslint-config-standard": {
       "version": "10.2.1",
-      "from": "eslint-config-standard@latest",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
       "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.1",
-      "from": "eslint-import-resolver-node@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         }
@@ -1956,19 +1640,16 @@
     },
     "eslint-module-utils": {
       "version": "2.1.1",
-      "from": "eslint-module-utils@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@^2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         }
@@ -1976,67 +1657,56 @@
     },
     "eslint-plugin-import": {
       "version": "2.7.0",
-      "from": "eslint-plugin-import@latest",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.6.8",
-          "from": "debug@>=2.6.8 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dev": true
         },
         "doctrine": {
           "version": "1.5.0",
-          "from": "doctrine@1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "from": "load-json-file@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "from": "path-type@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
-          "from": "read-pkg@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "from": "read-pkg-up@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "dev": true
         }
@@ -2044,49 +1714,41 @@
     },
     "eslint-plugin-jsdoc": {
       "version": "3.1.1",
-      "from": "eslint-plugin-jsdoc@latest",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.1.1.tgz",
       "dev": true
     },
     "eslint-plugin-lodash": {
       "version": "2.3.6",
-      "from": "eslint-plugin-lodash@2.3.6",
       "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-2.3.6.tgz",
       "dev": true
     },
     "eslint-plugin-node": {
       "version": "5.1.1",
-      "from": "eslint-plugin-node@latest",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.1.1.tgz",
       "dev": true,
       "dependencies": {
         "balanced-match": {
           "version": "1.0.0",
-          "from": "balanced-match@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "from": "brace-expansion@>=1.1.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "dev": true
         },
         "ignore": {
           "version": "3.3.3",
-          "from": "ignore@>=3.3.3 <4.0.0",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         }
@@ -2094,25 +1756,21 @@
     },
     "eslint-plugin-promise": {
       "version": "3.5.0",
-      "from": "eslint-plugin-promise@latest",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
       "dev": true
     },
     "eslint-plugin-standard": {
       "version": "3.0.1",
-      "from": "eslint-plugin-standard@latest",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
       "dev": true
     },
     "espree": {
       "version": "3.4.0",
-      "from": "espree@>=3.4.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "4.0.4",
-          "from": "acorn@4.0.4",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
           "dev": true
         }
@@ -2120,25 +1778,21 @@
     },
     "esprima": {
       "version": "2.7.2",
-      "from": "esprima@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
-      "from": "esquery@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "dev": true
     },
     "esrecurse": {
       "version": "4.1.0",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "dev": true,
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
-          "from": "estraverse@>=4.1.0 <4.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
           "dev": true
         }
@@ -2146,31 +1800,26 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "from": "event-emitter@>=0.3.5 <0.4.0",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "dev": true,
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "from": "d@1",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "dev": true
         },
         "es5-ext": {
           "version": "0.10.14",
-          "from": "es5-ext@~0.10.14",
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
           "dev": true
         }
@@ -2183,100 +1832,83 @@
     },
     "execa": {
       "version": "0.4.0",
-      "from": "execa@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
       "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "dev": true
     },
     "expand-range": {
       "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "dev": true
     },
     "expand-template": {
       "version": "1.0.3",
-      "from": "expand-template@1.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.0.3.tgz"
     },
     "expand-tilde": {
       "version": "1.2.2",
-      "from": "expand-tilde@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "dev": true
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extend-shallow": {
       "version": "2.0.1",
-      "from": "extend-shallow@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "dev": true
     },
     "extglob": {
       "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "dev": true
     },
     "extract-zip": {
       "version": "1.6.5",
-      "from": "extract-zip@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
       "dev": true,
       "dependencies": {
         "concat-stream": {
           "version": "1.6.0",
-          "from": "concat-stream@1.6.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dev": true
         },
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@>=2.0.3 <3.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dev": true
         },
         "ms": {
           "version": "0.7.1",
-          "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "dev": true
         },
         "yauzl": {
           "version": "2.4.1",
-          "from": "yauzl@2.4.1",
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
           "dev": true
         }
@@ -2284,70 +1916,58 @@
     },
     "extsprintf": {
       "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fast-deep-equal": {
       "version": "0.1.0",
-      "from": "fast-deep-equal@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "dev": true
     },
     "fbjs": {
       "version": "0.8.12",
-      "from": "fbjs@>=0.8.9 <0.9.0",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "from": "core-js@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
         }
       }
     },
     "fcopy-pre-bundled": {
       "version": "0.3.4",
-      "from": "fcopy-pre-bundled@0.3.4",
       "resolved": "https://registry.npmjs.org/fcopy-pre-bundled/-/fcopy-pre-bundled-0.3.4.tgz",
       "dev": true
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "from": "fd-slicer@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "figures": {
       "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
     },
     "file-contents": {
       "version": "0.2.4",
-      "from": "file-contents@>=0.2.4 <0.3.0",
       "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "from": "through2@^2.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@~4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "dev": true
         }
@@ -2355,43 +1975,36 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "from": "file-entry-cache@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dev": true
     },
     "file-exists": {
       "version": "1.0.0",
-      "from": "file-exists@1.0.0",
       "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-1.0.0.tgz",
       "dev": true
     },
     "file-name": {
       "version": "0.1.0",
-      "from": "file-name@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
       "dev": true
     },
     "file-stat": {
       "version": "0.1.3",
-      "from": "file-stat@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
-          "from": "lazy-cache@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "from": "through2@^2.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@~4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "dev": true
         }
@@ -2399,42 +2012,35 @@
     },
     "file-type": {
       "version": "4.1.0",
-      "from": "file-type@4.1.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.1.0.tgz"
     },
     "file-uri-to-path": {
       "version": "0.0.2",
-      "from": "file-uri-to-path@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz",
       "dev": true
     },
     "filename-regex": {
       "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
       "dev": true
     },
     "filendir": {
       "version": "1.0.0",
-      "from": "filendir@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/filendir/-/filendir-1.0.0.tgz",
       "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "dev": true
         }
@@ -2442,19 +2048,16 @@
     },
     "find-file-up": {
       "version": "0.1.3",
-      "from": "find-file-up@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
       "dev": true
     },
     "find-pkg": {
       "version": "0.1.2",
-      "from": "find-pkg@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
       "dev": true
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
     },
     "flat": {
@@ -2471,30 +2074,25 @@
     },
     "flat-cache": {
       "version": "1.2.2",
-      "from": "flat-cache@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "dev": true
     },
     "flexboxgrid": {
       "version": "6.3.0",
-      "from": "flexboxgrid@6.3.0",
       "resolved": "https://registry.npmjs.org/flexboxgrid/-/flexboxgrid-6.3.0.tgz"
     },
     "for-in": {
       "version": "0.1.8",
-      "from": "for-in@>=0.1.5 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "from": "for-own@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "dev": true
         }
@@ -2502,69 +2100,57 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "2.1.2",
-      "from": "form-data@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "dependencies": {
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@^1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@~1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         },
         "mime-db": {
           "version": "1.24.0",
-          "from": "mime-db@>=1.24.0 <1.25.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
         },
         "mime-types": {
           "version": "2.1.12",
-          "from": "mime-types@>=2.1.12 <3.0.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         }
       }
     },
     "formatio": {
       "version": "1.1.1",
-      "from": "formatio@1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "dev": true
     },
     "formidable": {
       "version": "1.0.14",
-      "from": "formidable@1.0.14",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
       "dev": true
     },
     "front-matter": {
       "version": "2.1.0",
-      "from": "front-matter@2.1.0",
       "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.0.tgz",
       "dev": true
     },
     "fs-exists-sync": {
       "version": "0.1.0",
-      "from": "fs-exists-sync@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "dev": true
     },
     "fs-extra": {
       "version": "3.0.1",
-      "from": "fs-extra@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "dev": true,
       "dependencies": {
         "jsonfile": {
           "version": "3.0.0",
-          "from": "jsonfile@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
           "dev": true
         }
@@ -2572,34 +2158,28 @@
     },
     "fs-extra-p": {
       "version": "4.3.0",
-      "from": "fs-extra-p@>=4.3.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.3.0.tgz",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fstream": {
       "version": "1.0.11",
-      "from": "fstream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
     },
     "fstream-ignore": {
       "version": "1.0.5",
-      "from": "fstream-ignore@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
     },
     "ftp": {
       "version": "0.3.10",
-      "from": "ftp@>=0.3.5 <0.4.0",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
       "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "dev": true
         }
@@ -2607,30 +2187,25 @@
     },
     "function-bind": {
       "version": "1.1.0",
-      "from": "function-bind@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "dev": true
     },
     "gauge": {
       "version": "2.7.3",
-      "from": "gauge@>=2.7.1 <2.8.0",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz"
     },
     "gaze": {
       "version": "1.1.2",
-      "from": "gaze@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "dev": true,
       "dependencies": {
         "globule": {
           "version": "1.1.0",
-          "from": "globule@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
           "dev": true
         },
         "lodash": {
           "version": "4.16.6",
-          "from": "lodash@>=4.16.4 <4.17.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
           "dev": true
         }
@@ -2638,111 +2213,92 @@
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "dev": true
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "dev": true
     },
     "get-object": {
       "version": "0.2.0",
-      "from": "get-object@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/get-object/-/get-object-0.2.0.tgz",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "get-stream": {
       "version": "3.0.0",
-      "from": "get-stream@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
     },
     "get-uri": {
       "version": "0.1.4",
-      "from": "get-uri@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-0.1.4.tgz",
       "dev": true
     },
     "get-value": {
       "version": "2.0.6",
-      "from": "get-value@>=2.0.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "dev": true
     },
     "getpass": {
       "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "git-config-path": {
       "version": "1.0.1",
-      "from": "git-config-path@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "dev": true
     },
     "git-repo-name": {
       "version": "0.6.0",
-      "from": "git-repo-name@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
       "dev": true
     },
     "github-from-package": {
       "version": "0.0.0",
-      "from": "github-from-package@0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
     },
     "glob": {
       "version": "7.1.1",
-      "from": "glob@>=7.1.0 <8.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "dev": true
     },
     "glob-parent": {
       "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "dev": true
     },
     "global-modules": {
       "version": "0.2.3",
-      "from": "global-modules@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "dev": true
     },
     "global-prefix": {
       "version": "0.1.5",
-      "from": "global-prefix@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "which": {
           "version": "1.2.12",
-          "from": "which@>=1.2.12 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
           "dev": true
         }
@@ -2750,31 +2306,26 @@
     },
     "globals": {
       "version": "9.16.0",
-      "from": "globals@>=9.14.0 <10.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
       "dev": true
     },
     "globby": {
       "version": "6.1.0",
-      "from": "globby@6.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "dev": true
     },
     "globule": {
       "version": "0.2.0",
-      "from": "globule@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.7 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dev": true,
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dev": true
             }
@@ -2782,19 +2333,16 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "dev": true
         },
         "lru-cache": {
           "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dev": true
         }
@@ -2802,13 +2350,11 @@
     },
     "gonzales-pe": {
       "version": "3.4.7",
-      "from": "gonzales-pe@3.4.7",
       "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "from": "minimist@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "dev": true
         }
@@ -2816,46 +2362,38 @@
     },
     "got": {
       "version": "6.7.1",
-      "from": "got@>=6.7.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "dev": true
     },
     "gpt": {
       "version": "1.0.0",
-      "from": "gpt@latest",
       "resolved": "https://registry.npmjs.org/gpt/-/gpt-1.0.0.tgz"
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.9.2",
-      "from": "growl@1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "dev": true
     },
     "handlebars": {
       "version": "4.0.6",
-      "from": "handlebars@>=4.0.5 <5.0.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
       "dev": true,
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@^1.4.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "dev": true
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dev": true
         }
@@ -2863,13 +2401,11 @@
     },
     "handlebars-helpers": {
       "version": "0.6.2",
-      "from": "handlebars-helpers@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/handlebars-helpers/-/handlebars-helpers-0.6.2.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "dev": true
         }
@@ -2877,56 +2413,46 @@
     },
     "har-schema": {
       "version": "1.0.5",
-      "from": "har-schema@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
     },
     "har-validator": {
       "version": "4.2.1",
-      "from": "har-validator@>=4.2.1 <4.3.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-flag": {
       "version": "1.0.0",
-      "from": "has-flag@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "from": "has-unicode@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
     },
     "has-values": {
       "version": "0.1.4",
-      "from": "has-values@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
       "dev": true
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "helper-date": {
       "version": "0.2.3",
-      "from": "helper-date@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/helper-date/-/helper-date-0.2.3.tgz",
       "dev": true,
       "dependencies": {
         "moment": {
           "version": "2.17.1",
-          "from": "moment@>=2.17.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
           "dev": true
         }
@@ -2934,19 +2460,16 @@
     },
     "helper-markdown": {
       "version": "0.2.1",
-      "from": "helper-markdown@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/helper-markdown/-/helper-markdown-0.2.1.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "dev": true
         }
@@ -2954,47 +2477,39 @@
     },
     "helper-md": {
       "version": "0.2.1",
-      "from": "helper-md@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/helper-md/-/helper-md-0.2.1.tgz",
       "dev": true
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "home-path": {
       "version": "1.0.5",
-      "from": "home-path@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
       "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
-      "from": "homedir-polyfill@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "dev": true
     },
     "hosted-git-info": {
       "version": "2.1.5",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
     },
     "html-angular-validate": {
       "version": "0.1.9",
-      "from": "html-angular-validate@0.1.9",
       "resolved": "https://registry.npmjs.org/html-angular-validate/-/html-angular-validate-0.1.9.tgz",
       "dev": true,
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@~1.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "dev": true
         },
         "xmlbuilder": {
           "version": "8.2.2",
-          "from": "xmlbuilder@>=8.2.2 <8.3.0",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
           "dev": true
         }
@@ -3002,7 +2517,6 @@
     },
     "html-tag": {
       "version": "0.2.1",
-      "from": "html-tag@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-0.2.1.tgz",
       "dev": true
     },
@@ -3013,148 +2527,122 @@
     },
     "http-proxy-agent": {
       "version": "0.2.7",
-      "from": "http-proxy-agent@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-0.2.7.tgz",
       "dev": true
     },
     "http-signature": {
       "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "https-proxy-agent": {
       "version": "0.3.6",
-      "from": "https-proxy-agent@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.15",
-      "from": "iconv-lite@>=0.4.5 <0.5.0",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
     },
     "ignore": {
       "version": "3.2.6",
-      "from": "ignore@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz",
       "dev": true
     },
     "immutable": {
       "version": "3.8.1",
-      "from": "immutable@3.8.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz"
     },
     "import-lazy": {
       "version": "2.1.0",
-      "from": "import-lazy@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
-      "from": "in-publish@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "index-of": {
       "version": "0.2.0",
-      "from": "index-of@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inquirer": {
       "version": "0.11.4",
-      "from": "inquirer@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.3.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "inquirer-dynamic-list": {
       "version": "1.0.0",
-      "from": "inquirer-dynamic-list@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/inquirer-dynamic-list/-/inquirer-dynamic-list-1.0.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "from": "bluebird@^2.10.2",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "interpret": {
       "version": "1.0.3",
-      "from": "interpret@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
       "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ip": {
       "version": "1.1.5",
-      "from": "ip@>=1.1.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "dev": true
     },
     "is": {
       "version": "3.2.1",
-      "from": "is@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
       "dev": true
     },
     "is-absolute": {
       "version": "0.2.6",
-      "from": "is-absolute@>=0.2.6 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "from": "is-accessor-descriptor@>=0.1.6 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-buffer": {
@@ -3165,30 +2653,25 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-ci": {
       "version": "1.0.10",
-      "from": "is-ci@>=1.0.10 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "from": "is-data-descriptor@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.5",
-      "from": "is-descriptor@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "dev": true
         }
@@ -3196,36 +2679,30 @@
     },
     "is-dotfile": {
       "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "dev": true
     },
     "is-electron": {
       "version": "2.1.0",
-      "from": "is-electron@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz"
     },
     "is-electron-renderer": {
       "version": "2.0.1",
-      "from": "is-electron-renderer@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "dev": true
     },
     "is-even": {
       "version": "0.1.1",
-      "from": "is-even@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-even/-/is-even-0.1.1.tgz",
       "dev": true,
       "dependencies": {
         "is-number": {
           "version": "1.1.2",
-          "from": "is-number@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
           "dev": true
         }
@@ -3233,41 +2710,34 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "is-extendable@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "from": "is-finite@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
-      "from": "is-glob@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.16.0",
-      "from": "is-my-json-valid@>=2.13.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "dev": true,
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@^4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "dev": true
         }
@@ -3275,31 +2745,26 @@
     },
     "is-npm": {
       "version": "1.0.0",
-      "from": "is-npm@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "dev": true
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
-      "from": "is-obj@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "dev": true
     },
     "is-odd": {
       "version": "0.1.1",
-      "from": "is-odd@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-0.1.1.tgz",
       "dev": true,
       "dependencies": {
         "is-number": {
           "version": "1.1.2",
-          "from": "is-number@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
           "dev": true
         }
@@ -3307,104 +2772,86 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "dev": true
     },
     "is-phantom": {
       "version": "1.0.1",
-      "from": "is-phantom@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-phantom/-/is-phantom-1.0.1.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
-      "from": "is-promise@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "is-redirect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
-      "from": "is-relative@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
-      "from": "is-retry-allowed@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-unc-path": {
       "version": "0.1.2",
-      "from": "is-unc-path@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "from": "is-valid-glob@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "dev": true
     },
     "is-windows": {
       "version": "0.2.0",
-      "from": "is-windows@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "dev": true
     },
@@ -3416,46 +2863,38 @@
     },
     "isbinaryfile": {
       "version": "3.0.2",
-      "from": "isbinaryfile@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
       "dev": true
     },
     "isexe": {
       "version": "1.1.2",
-      "from": "isexe@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
       "version": "0.2.0",
-      "from": "isobject@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
       "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
-      "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jodid25519": {
       "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "optional": true
     },
     "js-base64": {
       "version": "2.1.9",
-      "from": "js-base64@>=2.1.8 <3.0.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "dev": true
     },
     "js-message": {
       "version": "1.0.5",
-      "from": "js-message@>=1.0.5",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz"
     },
     "js-queue": {
@@ -3465,146 +2904,121 @@
     },
     "js-tokens": {
       "version": "1.0.3",
-      "from": "js-tokens@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz"
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@>=3.4.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
-      "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "from": "json-schema@0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "from": "json-schema-traverse@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
       "version": "3.3.2",
-      "from": "json3@3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "from": "json5@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "from": "jsonfile@>=2.3.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "from": "jsonpointer@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.0",
-      "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "kind-of": {
       "version": "3.1.0",
-      "from": "kind-of@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "dev": true
     },
     "klaw": {
       "version": "1.3.1",
-      "from": "klaw@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
-      "from": "latest-version@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "dev": true
     },
     "lcid": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "dev": true
     },
     "list-item": {
       "version": "1.1.1",
-      "from": "list-item@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
       "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "load-json-file@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.4",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         }
       }
     },
     "locate-path": {
       "version": "2.0.0",
-      "from": "locate-path@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@^3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "dev": true
         }
@@ -3612,28 +3026,23 @@
     },
     "lodash": {
       "version": "4.13.1",
-      "from": "lodash@4.13.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
     },
     "lodash-deep": {
       "version": "2.0.0",
-      "from": "lodash-deep@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/lodash-deep/-/lodash-deep-2.0.0.tgz"
     },
     "lodash-es": {
       "version": "4.13.1",
-      "from": "lodash-es@>=4.2.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.13.1.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "dev": true,
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
-          "from": "lodash.keys@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "dev": true
         }
@@ -3641,804 +3050,651 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.0.9",
-      "from": "lodash.assign@>=4.0.3 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
     },
     "lodash.capitalize": {
       "version": "4.2.1",
-      "from": "lodash.capitalize@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "dev": true
     },
     "lodash.cond": {
       "version": "4.5.2",
-      "from": "lodash.cond@>=4.3.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
-      "from": "lodash.create@3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "dev": true
     },
     "lodash.filter": {
       "version": "4.6.0",
-      "from": "lodash.filter@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
       "dev": true
     },
     "lodash.findkey": {
       "version": "4.6.0",
-      "from": "lodash.findkey@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
       "dev": true
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "from": "lodash.foreach@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "dev": true
     },
     "lodash.frompairs": {
       "version": "4.0.1",
-      "from": "lodash.frompairs@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz"
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "from": "lodash.includes@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "dev": true
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "from": "lodash.isempty@>=4.1.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "dev": true
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
-      "from": "lodash.kebabcase@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "dev": true
     },
     "lodash.keys": {
       "version": "4.0.7",
-      "from": "lodash.keys@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "from": "lodash.mapvalues@>=4.6.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz"
     },
     "lodash.mergewith": {
       "version": "4.6.0",
-      "from": "lodash.mergewith@>=4.6.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "dev": true
     },
     "lodash.partition": {
       "version": "4.6.0",
-      "from": "lodash.partition@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
       "dev": true
     },
     "lodash.rest": {
       "version": "4.0.3",
-      "from": "lodash.rest@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
     },
     "lodash.some": {
       "version": "4.6.0",
-      "from": "lodash.some@>=4.6.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
     },
     "lodash.trim": {
       "version": "4.5.1",
-      "from": "lodash.trim@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
       "dev": true
     },
     "logging-helpers": {
       "version": "0.4.0",
-      "from": "logging-helpers@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/logging-helpers/-/logging-helpers-0.4.0.tgz",
       "dev": true
     },
     "lolex": {
       "version": "1.3.2",
-      "from": "lolex@1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "dev": true
     },
     "loose-envify": {
       "version": "1.2.0",
-      "from": "loose-envify@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "from": "lowercase-keys@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
       "dev": true
     },
     "lru-cache": {
       "version": "4.0.1",
-      "from": "lru-cache@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz"
     },
     "lsmod": {
       "version": "1.0.0",
-      "from": "lsmod@1.0.0",
       "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz"
     },
     "lzma-native": {
       "version": "1.5.2",
-      "from": "lzma-native@1.5.2",
       "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-1.5.2.tgz",
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "node-pre-gyp": {
           "version": "0.6.29",
-          "from": "node-pre-gyp@0.6.29",
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.9",
-              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "aproba": {
               "version": "1.0.4",
-              "from": "aproba@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
             },
             "are-we-there-yet": {
               "version": "1.1.2",
-              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
             },
             "asn1": {
               "version": "0.2.3",
-              "from": "asn1@>=0.2.3 <0.3.0",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
             },
             "assert-plus": {
               "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.4.1",
-              "from": "aws4@>=1.2.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
             },
             "balanced-match": {
               "version": "0.4.1",
-              "from": "balanced-match@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
             },
             "bl": {
               "version": "1.1.2",
-              "from": "bl@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
                 }
               }
             },
             "block-stream": {
               "version": "0.0.9",
-              "from": "block-stream@*",
               "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "brace-expansion": {
               "version": "1.1.5",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
             },
             "code-point-at": {
               "version": "1.0.0",
-              "from": "code-point-at@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
             },
             "concat-map": {
               "version": "0.0.1",
-              "from": "concat-map@0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "from": "console-control-strings@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
             },
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "dashdash": {
               "version": "1.14.0",
-              "from": "dashdash@>=1.12.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 }
               }
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
             },
             "deep-extend": {
               "version": "0.4.1",
-              "from": "deep-extend@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             },
             "delegates": {
               "version": "1.0.0",
-              "from": "delegates@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "from": "ecc-jsbn@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
               "optional": true
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "extsprintf": {
               "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
               "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc4",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "fstream": {
               "version": "1.0.10",
-              "from": "fstream@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
             },
             "fstream-ignore": {
               "version": "1.0.5",
-              "from": "fstream-ignore@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
             },
             "gauge": {
               "version": "2.6.0",
-              "from": "gauge@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
             },
             "generate-function": {
               "version": "2.0.0",
-              "from": "generate-function@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
               "version": "1.2.0",
-              "from": "generate-object-property@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
             },
             "getpass": {
               "version": "0.1.6",
-              "from": "getpass@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 }
               }
             },
             "glob": {
               "version": "7.0.5",
-              "from": "glob@>=7.0.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
             },
             "graceful-fs": {
               "version": "4.1.4",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
             },
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
             },
             "has-color": {
               "version": "0.1.7",
-              "from": "has-color@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
             },
             "has-unicode": {
               "version": "2.0.1",
-              "from": "has-unicode@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
             },
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
             },
             "inflight": {
               "version": "1.0.5",
-              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
             },
             "is-my-json-valid": {
               "version": "2.13.1",
-              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
             },
             "is-property": {
               "version": "1.0.2",
-              "from": "is-property@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "jodid25519": {
               "version": "1.0.2",
-              "from": "jodid25519@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
               "optional": true
             },
             "jsbn": {
               "version": "0.1.0",
-              "from": "jsbn@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
               "optional": true
             },
             "json-schema": {
               "version": "0.2.2",
-              "from": "json-schema@0.2.2",
               "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "jsonpointer": {
               "version": "2.0.0",
-              "from": "jsonpointer@2.0.0",
               "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
             },
             "jsprim": {
               "version": "1.3.0",
-              "from": "jsprim@>=1.2.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
             },
             "mime-db": {
               "version": "1.23.0",
-              "from": "mime-db@>=1.23.0 <1.24.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
             },
             "mime-types": {
               "version": "2.1.11",
-              "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
             },
             "minimatch": {
               "version": "3.0.2",
-              "from": "minimatch@>=3.0.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz"
             },
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
             },
             "npmlog": {
               "version": "3.1.2",
-              "from": "npmlog@>=3.1.2 <3.2.0",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
             },
             "number-is-nan": {
               "version": "1.0.0",
-              "from": "number-is-nan@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "object-assign": {
               "version": "4.1.0",
-              "from": "object-assign@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "pinkie": {
               "version": "2.0.4",
-              "from": "pinkie@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "from": "pinkie-promise@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "qs": {
               "version": "6.1.0",
-              "from": "qs@>=6.1.0 <6.2.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
             },
             "rc": {
               "version": "1.1.6",
-              "from": "rc@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "2.1.4",
-              "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
             },
             "request": {
               "version": "2.72.0",
-              "from": "request@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz"
             },
             "rimraf": {
               "version": "2.5.2",
-              "from": "rimraf@>=2.5.0 <2.6.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
             },
             "semver": {
               "version": "5.2.0",
-              "from": "semver@>=5.2.0 <5.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
             },
             "set-blocking": {
               "version": "2.0.0",
-              "from": "set-blocking@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
             },
             "signal-exit": {
               "version": "3.0.0",
-              "from": "signal-exit@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             },
             "sshpk": {
               "version": "1.8.3",
-              "from": "sshpk@>=1.7.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 }
               }
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "string-width": {
               "version": "1.0.1",
-              "from": "string-width@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             },
             "tar": {
               "version": "2.2.1",
-              "from": "tar@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
             },
             "tar-pack": {
               "version": "3.1.4",
-              "from": "tar-pack@>=3.1.0 <3.2.0",
               "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
             },
             "tough-cookie": {
               "version": "2.2.2",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             },
             "tweetnacl": {
               "version": "0.13.3",
-              "from": "tweetnacl@>=0.13.0 <0.14.0",
               "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
               "optional": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "from": "uid-number@>=0.0.6 <0.1.0",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             },
             "verror": {
               "version": "1.3.6",
-              "from": "verror@1.3.6",
               "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
             },
             "wide-align": {
               "version": "1.1.0",
-              "from": "wide-align@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
             },
             "wrappy": {
               "version": "1.0.2",
-              "from": "wrappy@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -4447,36 +3703,30 @@
     },
     "macaddress": {
       "version": "0.2.8",
-      "from": "macaddress@>=0.2.7 <0.3.0",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "dev": true
     },
     "make-dir": {
       "version": "1.0.0",
-      "from": "make-dir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
       "dev": true
     },
     "make-iterator": {
       "version": "0.2.1",
-      "from": "make-iterator@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "markdown": {
       "version": "0.5.0",
-      "from": "markdown@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
       "dev": true,
       "dependencies": {
         "nopt": {
           "version": "2.1.2",
-          "from": "nopt@>=2.1.1 <2.2.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
           "dev": true
         }
@@ -4484,83 +3734,68 @@
     },
     "markdown-utils": {
       "version": "0.7.3",
-      "from": "markdown-utils@>=0.7.3 <0.8.0",
       "resolved": "https://registry.npmjs.org/markdown-utils/-/markdown-utils-0.7.3.tgz",
       "dev": true
     },
     "mbr": {
       "version": "1.1.2",
-      "from": "mbr@latest",
       "resolved": "https://registry.npmjs.org/mbr/-/mbr-1.1.2.tgz"
     },
     "mem": {
       "version": "1.1.0",
-      "from": "mem@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.7.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
     },
     "merge": {
       "version": "1.2.0",
-      "from": "merge@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "dev": true
     },
     "methods": {
       "version": "1.0.1",
-      "from": "methods@1.0.1",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
       "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
-      "from": "micromatch@>=2.3.10 <3.0.0",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "dev": true
     },
     "mime": {
       "version": "1.3.6",
-      "from": "mime@>=1.3.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
       "dev": true
     },
     "mime-db": {
       "version": "1.27.0",
-      "from": "mime-db@>=1.27.0 <1.28.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
     },
     "mime-types": {
       "version": "2.1.15",
-      "from": "mime-types@2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
     },
     "mimic-fn": {
       "version": "1.1.0",
-      "from": "mimic-fn@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mixin-deep": {
       "version": "1.2.0",
-      "from": "mixin-deep@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.2.0.tgz",
       "dev": true,
       "dependencies": {
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "dev": true
         }
@@ -4595,139 +3830,116 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "mkpath": {
       "version": "0.1.0",
-      "from": "mkpath@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
       "dev": true
     },
     "mksnapshot": {
       "version": "0.1.0",
-      "from": "mksnapshot@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.1.0.tgz",
       "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "assert-plus@>=0.1.5 <0.2.0",
-          "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "dev": true
         },
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "dev": true
         },
         "bluebird": {
           "version": "2.11.0",
-          "from": "bluebird@>=2.9.30 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "dev": true
         },
         "caseless": {
           "version": "0.9.0",
-          "from": "caseless@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
           "dev": true
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.8.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "form-data": {
           "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dev": true
         },
         "fs-extra": {
           "version": "0.18.2",
-          "from": "fs-extra@0.18.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.2.tgz",
           "dev": true
         },
         "graceful-fs": {
           "version": "3.0.11",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "dev": true
         },
         "har-validator": {
           "version": "1.8.0",
-          "from": "har-validator@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "dev": true
         },
         "hawk": {
           "version": "2.3.1",
-          "from": "hawk@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
           "dev": true
         },
         "http-signature": {
           "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "http://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
           "dev": true
         },
         "mime-db": {
           "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "dev": true
         },
         "mime-types": {
           "version": "2.0.14",
-          "from": "mime-types@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "dev": true
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.6.0",
-          "from": "oauth-sign@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
           "dev": true
         },
         "qs": {
           "version": "2.4.2",
-          "from": "qs@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
           "dev": true
         },
         "request": {
           "version": "2.55.0",
-          "from": "request@2.55.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "dev": true
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "dev": true
         }
@@ -4735,37 +3947,31 @@
     },
     "mocha": {
       "version": "3.2.0",
-      "from": "mocha@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@2.9.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.0.5",
-          "from": "glob@7.0.5",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "dev": true
         },
         "ms": {
           "version": "0.7.1",
-          "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dev": true
         }
@@ -4773,28 +3979,23 @@
     },
     "mochainon": {
       "version": "1.0.0",
-      "from": "mochainon@1.0.0",
       "resolved": "https://registry.npmjs.org/mochainon/-/mochainon-1.0.0.tgz",
       "dev": true
     },
     "moment": {
       "version": "2.13.0",
-      "from": "moment@>=2.8.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "moment-duration-format": {
       "version": "1.3.0",
-      "from": "moment-duration-format@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
       "version": "1.2.2",
-      "from": "mountutils@1.2.2",
       "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.2.2.tgz",
       "dependencies": {
         "nan": {
           "version": "2.6.2",
-          "from": "nan@>=2.5.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
         }
       }
@@ -4807,65 +4008,54 @@
     },
     "multistream": {
       "version": "2.1.0",
-      "from": "multistream@2.1.0",
       "resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.0.tgz",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "nan": {
       "version": "2.3.5",
-      "from": "nan@2.3.5",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
     },
     "natives": {
       "version": "1.1.0",
-      "from": "natives@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "from": "natural-compare@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "dev": true
     },
     "netmask": {
       "version": "1.0.6",
-      "from": "netmask@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "dev": true
     },
     "ngcomponent": {
       "version": "3.0.1",
-      "from": "ngcomponent@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/ngcomponent/-/ngcomponent-3.0.1.tgz",
       "dependencies": {
         "lodash.assign": {
           "version": "4.2.0",
-          "from": "lodash.assign@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
         }
       }
     },
     "nock": {
       "version": "9.0.9",
-      "from": "nock@9.0.9",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.9.tgz",
       "dev": true,
       "dependencies": {
         "deep-equal": {
           "version": "1.0.1",
-          "from": "deep-equal@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
           "dev": true
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.17.2 <4.18.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "dev": true
         }
@@ -4873,29 +4063,24 @@
     },
     "node-abi": {
       "version": "2.1.1",
-      "from": "node-abi@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz"
     },
     "node-emoji": {
       "version": "1.5.1",
-      "from": "node-emoji@>=1.5.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.1.tgz",
       "dev": true
     },
     "node-fetch": {
       "version": "1.6.3",
-      "from": "node-fetch@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
     "node-gyp": {
       "version": "3.5.0",
-      "from": "node-gyp@3.5.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
       "dev": true,
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "from": "semver@~5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         }
@@ -4908,36 +4093,30 @@
     },
     "node-pre-gyp": {
       "version": "0.6.36",
-      "from": "node-pre-gyp@>=0.6.30 <0.7.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
       "dependencies": {
         "nopt": {
           "version": "4.0.1",
-          "from": "nopt@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
         },
         "semver": {
           "version": "5.4.1",
-          "from": "semver@>=5.3.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
         }
       }
     },
     "node-sass": {
       "version": "4.5.3",
-      "from": "node-sass@4.5.3",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
       "dev": true,
       "dependencies": {
         "cross-spawn": {
           "version": "3.0.1",
-          "from": "cross-spawn@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "dev": true
         },
         "lodash.assign": {
           "version": "4.2.0",
-          "from": "lodash.assign@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
           "dev": true
         }
@@ -4945,148 +4124,123 @@
     },
     "node-stream-zip": {
       "version": "1.3.7",
-      "from": "node-stream-zip@1.3.7",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.3.7.tgz"
     },
     "node.extend": {
       "version": "1.1.6",
-      "from": "node.extend@>=1.1.5 <1.2.0",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
       "dev": true
     },
     "noop-logger": {
       "version": "0.1.1",
-      "from": "noop-logger@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz"
     },
     "nopt": {
       "version": "3.0.6",
-      "from": "nopt@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "dev": true
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
-      "from": "normalize-path@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
       "dev": true
     },
     "npm-run-path": {
       "version": "1.0.0",
-      "from": "npm-run-path@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
       "dev": true
     },
     "npmlog": {
       "version": "4.0.2",
-      "from": "npmlog@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
       "dependencies": {
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@~2.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
         }
       }
     },
     "npx": {
       "version": "5.2.0",
-      "from": "npx@5.2.0",
       "resolved": "https://registry.npmjs.org/npx/-/npx-5.2.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "from": "ansi-align@^2.0.0",
           "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "from": "ansi-regex@2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "from": "ansi-styles@2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "dev": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "from": "balanced-match@0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "dev": true
         },
         "bluebird": {
           "version": "3.5.0",
-          "from": "bluebird@3.5.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
           "dev": true
         },
         "boxen": {
           "version": "1.1.0",
-          "from": "boxen@^1.0.0",
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "from": "brace-expansion@1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "dev": true
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "from": "builtin-modules@1.1.1",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "from": "builtins@1.0.3",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "from": "camelcase@4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "from": "capture-stack-trace@^1.0.0",
           "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "from": "cli-boxes@^1.0.0",
           "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
           "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "from": "cliui@3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "dev": true,
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dev": true
             }
@@ -5094,25 +4248,21 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "from": "code-point-at@1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "dev": true
         },
         "configstore": {
           "version": "3.1.0",
-          "from": "configstore@^3.0.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
           "dev": true,
           "dependencies": {
             "dot-prop": {
               "version": "4.1.1",
-              "from": "dot-prop@^4.1.0",
               "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
               "dev": true
             }
@@ -5120,109 +4270,91 @@
         },
         "create-error-class": {
           "version": "3.0.2",
-          "from": "create-error-class@^3.0.0",
           "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "from": "cross-spawn@4.0.2",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "dev": true
         },
         "cross-spawn-async": {
           "version": "2.2.5",
-          "from": "cross-spawn-async@^2.1.1",
           "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
           "dev": true
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "from": "crypto-random-string@^1.0.0",
           "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "from": "decamelize@1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "dev": true
         },
         "deep-extend": {
           "version": "0.4.2",
-          "from": "deep-extend@~0.4.0",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
           "dev": true
         },
         "dotenv": {
           "version": "4.0.0",
-          "from": "dotenv@^4.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "from": "duplexer3@^0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "dev": true
         },
         "error-ex": {
           "version": "1.3.1",
-          "from": "error-ex@1.3.1",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "from": "execa@0.5.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "dev": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "from": "fs.realpath@1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "from": "get-caller-file@1.0.2",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "from": "get-stream@2.3.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         },
         "got": {
           "version": "6.7.1",
-          "from": "got@^6.7.1",
           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "dev": true,
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "from": "get-stream@^3.0.0",
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "dev": true
             }
@@ -5230,235 +4362,196 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "dev": true
         },
         "has-ansi": {
           "version": "2.0.0",
-          "from": "has-ansi@2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.4.2",
-          "from": "hosted-git-info@2.4.2",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
           "dev": true
         },
         "import-lazy": {
           "version": "2.1.0",
-          "from": "import-lazy@^2.1.0",
           "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "from": "imurmurhash@0.1.4",
           "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "from": "inflight@1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "dev": true
         },
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "from": "ini@1.3.4",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "from": "invert-kv@1.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "from": "is-arrayish@0.2.1",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "from": "is-builtin-module@1.0.0",
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "from": "is-fullwidth-code-point@1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "dev": true
         },
         "is-npm": {
           "version": "1.0.0",
-          "from": "is-npm@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "from": "is-obj@1.0.1",
           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
           "dev": true
         },
         "is-redirect": {
           "version": "1.0.0",
-          "from": "is-redirect@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
           "dev": true
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "from": "is-retry-allowed@^1.0.0",
           "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "from": "is-stream@1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "from": "isexe@2.0.0",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
           "dev": true
         },
         "latest-version": {
           "version": "3.1.0",
-          "from": "latest-version@^3.0.0",
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
           "dev": true
         },
         "lcid": {
           "version": "1.0.0",
-          "from": "lcid@1.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "from": "load-json-file@2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "dev": true
         },
         "locate-path": {
           "version": "2.0.0",
-          "from": "locate-path@2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.0",
-          "from": "lowercase-keys@^1.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
           "dev": true
         },
         "lru-cache": {
           "version": "4.0.2",
-          "from": "lru-cache@4.0.2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
           "dev": true
         },
         "make-dir": {
           "version": "1.0.0",
-          "from": "make-dir@^1.0.0",
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "from": "mem@1.1.0",
           "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
           "dev": true
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "from": "mimic-fn@1.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.8",
-          "from": "normalize-package-data@2.3.8",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
           "dev": true
         },
         "npm": {
           "version": "5.0.3",
-          "from": "npm@5.0.3",
           "resolved": "https://registry.npmjs.org/npm/-/npm-5.0.3.tgz",
           "dev": true,
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "from": "abbrev@~1.1.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
               "dev": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "from": "ansi-regex@~2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
-              "from": "ansicolors@~0.3.2",
               "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "from": "ansistyles@~0.1.3",
               "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
               "dev": true
             },
             "aproba": {
               "version": "1.1.2",
-              "from": "aproba@1.1.2",
               "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "from": "archy@~1.0.0",
               "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
               "dev": true
             },
             "bluebird": {
               "version": "3.5.0",
-              "from": "bluebird@~3.5.0",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
               "dev": true
             },
             "cacache": {
               "version": "9.2.8",
-              "from": "cacache@9.2.8",
               "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.8.tgz",
               "dev": true,
               "dependencies": {
                 "y18n": {
                   "version": "3.2.1",
-                  "from": "y18n@^3.2.1",
                   "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
                   "dev": true
                 }
@@ -5466,43 +4559,36 @@
             },
             "call-limit": {
               "version": "1.1.0",
-              "from": "call-limit@~1.1.0",
               "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "from": "chownr@~1.0.1",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "from": "cmd-shim@~2.0.2",
               "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
               "dev": true
             },
             "columnify": {
               "version": "1.5.4",
-              "from": "columnify@~1.5.4",
               "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
               "dev": true,
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.1",
-                  "from": "wcwidth@^1.0.0",
                   "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
                   "dev": true,
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "from": "defaults@^1.0.3",
                       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                       "dev": true,
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "from": "clone@^1.0.2",
                           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                           "dev": true
                         }
@@ -5514,13 +4600,11 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "from": "config-chain@~1.1.11",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
               "dev": true,
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@~1.2.1",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                   "dev": true
                 }
@@ -5528,25 +4612,21 @@
             },
             "debuglog": {
               "version": "1.0.1",
-              "from": "debuglog@*",
               "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
               "dev": true
             },
             "detect-indent": {
               "version": "5.0.0",
-              "from": "detect-indent",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
               "dev": true
             },
             "dezalgo": {
               "version": "1.0.3",
-              "from": "dezalgo@~1.0.3",
               "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
               "dev": true,
               "dependencies": {
                 "asap": {
                   "version": "2.0.5",
-                  "from": "asap@^2.0.0",
                   "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
                   "dev": true
                 }
@@ -5554,61 +4634,51 @@
             },
             "editor": {
               "version": "1.0.0",
-              "from": "editor@~1.0.0",
               "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.10",
-              "from": "fs-vacuum@~1.2.10",
               "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
               "dev": true
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
-              "from": "fs-write-stream-atomic@~1.0.10",
               "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
               "dev": true
             },
             "fstream": {
               "version": "1.0.11",
-              "from": "fstream@~1.0.11",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
               "dev": true
             },
             "fstream-npm": {
               "version": "1.2.1",
-              "from": "fstream-npm@latest",
               "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
               "dev": true,
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "from": "fstream-ignore@^1.0.0",
                   "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
                   "dev": true,
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
-                      "from": "minimatch@^3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                       "dev": true,
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "from": "brace-expansion@^1.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                           "dev": true,
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@^0.4.1",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "dev": true
                             }
@@ -5622,37 +4692,31 @@
             },
             "glob": {
               "version": "7.1.2",
-              "from": "glob@7.1.2",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "dev": true,
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "fs.realpath@^1.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                   "dev": true
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@^3.0.4",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@^0.4.1",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "dev": true
                         }
@@ -5662,7 +4726,6 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "path-is-absolute@^1.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "dev": true
                 }
@@ -5670,61 +4733,51 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "from": "graceful-fs@~4.1.11",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
               "dev": true
             },
             "has-unicode": {
               "version": "2.0.1",
-              "from": "has-unicode@~2.0.1",
               "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.4.2",
-              "from": "hosted-git-info@~2.4.2",
               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "from": "iferr@~0.1.5",
               "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "from": "imurmurhash@*",
               "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
               "dev": true
             },
             "inflight": {
               "version": "1.0.6",
-              "from": "inflight@~1.0.6",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dev": true
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@~2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@~1.3.4",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
               "dev": true
             },
             "init-package-json": {
               "version": "1.10.1",
-              "from": "init-package-json@~1.10.1",
               "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
               "dev": true,
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
-                  "from": "promzard@^0.3.0",
                   "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
                   "dev": true
                 }
@@ -5732,19 +4785,16 @@
             },
             "JSONStream": {
               "version": "1.3.1",
-              "from": "JSONStream@~1.3.1",
               "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
               "dev": true,
               "dependencies": {
                 "jsonparse": {
                   "version": "1.3.0",
-                  "from": "jsonparse@^1.2.0",
                   "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
                   "dev": true
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.2.7 <3",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "dev": true
                 }
@@ -5752,37 +4802,31 @@
             },
             "lazy-property": {
               "version": "1.0.0",
-              "from": "lazy-property@~1.0.0",
               "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
               "dev": true
             },
             "lockfile": {
               "version": "1.0.3",
-              "from": "lockfile@~1.0.3",
               "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
               "dev": true
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "from": "lodash._baseindexof@*",
               "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
               "dev": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "from": "lodash._baseuniq@~4.6.0",
               "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
               "dev": true,
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
-                  "from": "lodash._createset@~4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
                   "dev": true
                 },
                 "lodash._root": {
                   "version": "3.0.1",
-                  "from": "lodash._root@~3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                   "dev": true
                 }
@@ -5790,73 +4834,61 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@*",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
               "dev": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "from": "lodash._cacheindexof@*",
               "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
               "dev": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "from": "lodash._createcache@*",
               "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
               "dev": true
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "from": "lodash._getnative@*",
               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
               "dev": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "from": "lodash.clonedeep@~4.5.0",
               "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
               "dev": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@*",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
               "dev": true
             },
             "lodash.union": {
               "version": "4.6.0",
-              "from": "lodash.union@~4.6.0",
               "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
               "dev": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "from": "lodash.uniq@~4.5.0",
               "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
               "dev": true
             },
             "lodash.without": {
               "version": "4.4.0",
-              "from": "lodash.without@~4.4.0",
               "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
               "dev": true
             },
             "lru-cache": {
               "version": "4.0.2",
-              "from": "lru-cache@~4.0.2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
               "dev": true,
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "from": "pseudomap@^1.0.1",
                   "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "from": "yallist@^2.0.0",
                   "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
                   "dev": true
                 }
@@ -5864,19 +4896,16 @@
             },
             "mississippi": {
               "version": "1.3.0",
-              "from": "mississippi@~1.3.0",
               "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
               "dev": true,
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "from": "concat-stream@^1.5.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@^0.0.6",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "dev": true
                     }
@@ -5884,19 +4913,16 @@
                 },
                 "duplexify": {
                   "version": "3.5.0",
-                  "from": "duplexify@^3.4.2",
                   "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "from": "end-of-stream@1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@~1.3.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dev": true
                         }
@@ -5904,7 +4930,6 @@
                     },
                     "stream-shift": {
                       "version": "1.0.0",
-                      "from": "stream-shift@^1.0.0",
                       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
                       "dev": true
                     }
@@ -5912,31 +4937,26 @@
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "from": "end-of-stream@^1.1.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
                   "dev": true
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
-                  "from": "flush-write-stream@^1.0.0",
                   "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
                   "dev": true
                 },
                 "from2": {
                   "version": "2.3.0",
-                  "from": "from2@^2.1.0",
                   "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
                   "dev": true
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
-                  "from": "parallel-transform@^1.1.0",
                   "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "from": "cyclist@~0.2.2",
                       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
                       "dev": true
                     }
@@ -5944,25 +4964,21 @@
                 },
                 "pump": {
                   "version": "1.0.2",
-                  "from": "pump@^1.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
                   "dev": true
                 },
                 "pumpify": {
                   "version": "1.3.5",
-                  "from": "pumpify@^1.3.3",
                   "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
                   "dev": true
                 },
                 "stream-each": {
                   "version": "1.2.0",
-                  "from": "stream-each@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "from": "stream-shift@^1.0.0",
                       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
                       "dev": true
                     }
@@ -5970,13 +4986,11 @@
                 },
                 "through2": {
                   "version": "2.0.3",
-                  "from": "through2@^2.0.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
                   "dev": true,
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@~4.0.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "dev": true
                     }
@@ -5986,13 +5000,11 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@~0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "dev": true
                 }
@@ -6000,19 +5012,16 @@
             },
             "move-concurrently": {
               "version": "1.0.1",
-              "from": "move-concurrently@~1.0.1",
               "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
               "dev": true,
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
-                  "from": "copy-concurrently@^1.0.0",
                   "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
                   "dev": true
                 },
                 "run-queue": {
                   "version": "1.0.3",
-                  "from": "run-queue@^1.0.3",
                   "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
                   "dev": true
                 }
@@ -6020,31 +5029,26 @@
             },
             "node-gyp": {
               "version": "3.6.2",
-              "from": "node-gyp@3.6.2",
               "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
               "dev": true,
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@^3.0.2",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@^0.4.1",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "dev": true
                         }
@@ -6054,7 +5058,6 @@
                 },
                 "nopt": {
                   "version": "3.0.6",
-                  "from": "nopt@2 || 3",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                   "dev": true
                 }
@@ -6062,25 +5065,21 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "from": "nopt@~4.0.1",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.3.8",
-              "from": "normalize-package-data@~2.3.8",
               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
               "dev": true,
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "from": "is-builtin-module@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "from": "builtin-modules@^1.0.0",
                       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                       "dev": true
                     }
@@ -6090,37 +5089,31 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "from": "npm-cache-filename@~1.0.2",
               "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
               "dev": true
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "from": "npm-install-checks@~3.0.0",
               "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
               "dev": true
             },
             "npm-package-arg": {
               "version": "5.1.1",
-              "from": "npm-package-arg@latest",
               "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.1.tgz",
               "dev": true
             },
             "npm-registry-client": {
               "version": "8.3.0",
-              "from": "npm-registry-client@~8.3.0",
               "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.3.0.tgz",
               "dev": true,
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
-                  "from": "concat-stream@^1.5.2",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@^0.0.6",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                       "dev": true
                     }
@@ -6130,25 +5123,21 @@
             },
             "npm-user-validate": {
               "version": "1.0.0",
-              "from": "npm-user-validate@latest",
               "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
               "dev": true
             },
             "npmlog": {
               "version": "4.1.0",
-              "from": "npmlog@latest",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
               "dev": true,
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
-                  "from": "are-we-there-yet@~1.1.2",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "from": "delegates@^1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                       "dev": true
                     }
@@ -6156,49 +5145,41 @@
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "from": "console-control-strings@~1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.7.4",
-                  "from": "gauge@~2.7.1",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "object-assign": {
                       "version": "4.1.1",
-                      "from": "object-assign@^4.1.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "from": "signal-exit@^3.0.0",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "from": "string-width@^1.0.1",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "dev": true,
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "from": "code-point-at@^1.0.0",
                           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "from": "is-fullwidth-code-point@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                           "dev": true,
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "from": "number-is-nan@^1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                               "dev": true
                             }
@@ -6208,7 +5189,6 @@
                     },
                     "wide-align": {
                       "version": "1.1.0",
-                      "from": "wide-align@^1.1.0",
                       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
                       "dev": true
                     }
@@ -6216,7 +5196,6 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "from": "set-blocking@~2.0.0",
                   "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                   "dev": true
                 }
@@ -6224,31 +5203,26 @@
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@~1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dev": true
             },
             "opener": {
               "version": "1.4.3",
-              "from": "opener@~1.4.3",
               "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
               "dev": true
             },
             "osenv": {
               "version": "0.1.4",
-              "from": "osenv@~0.1.4",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
               "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "from": "os-homedir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "from": "os-tmpdir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                   "dev": true
                 }
@@ -6256,31 +5230,26 @@
             },
             "pacote": {
               "version": "2.7.30",
-              "from": "pacote@2.7.30",
               "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.30.tgz",
               "dev": true,
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.11",
-                  "from": "make-fetch-happen@^2.4.11",
                   "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.11.tgz",
                   "dev": true,
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.1.0",
-                      "from": "agentkeepalive@^3.1.0",
                       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.1.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
-                          "from": "humanize-ms@^1.2.0",
                           "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
                           "dev": true,
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "from": "ms@^2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                               "dev": true
                             }
@@ -6290,25 +5259,21 @@
                     },
                     "http-cache-semantics": {
                       "version": "3.7.3",
-                      "from": "http-cache-semantics@^3.7.3",
                       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.7.3.tgz",
                       "dev": true
                     },
                     "http-proxy-agent": {
                       "version": "1.0.0",
-                      "from": "http-proxy-agent@^1.0.0",
                       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "agent-base": {
                           "version": "2.1.1",
-                          "from": "agent-base@2",
                           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
                           "dev": true,
                           "dependencies": {
                             "semver": {
                               "version": "5.0.3",
-                              "from": "semver@~5.0.1",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                               "dev": true
                             }
@@ -6316,13 +5281,11 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "from": "debug@2",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                           "dev": true,
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "from": "ms@2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                               "dev": true
                             }
@@ -6330,7 +5293,6 @@
                         },
                         "extend": {
                           "version": "3.0.1",
-                          "from": "extend@3",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                           "dev": true
                         }
@@ -6338,19 +5300,16 @@
                     },
                     "https-proxy-agent": {
                       "version": "1.0.0",
-                      "from": "https-proxy-agent@^1.0.0",
                       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "agent-base": {
                           "version": "2.1.1",
-                          "from": "agent-base@2",
                           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
                           "dev": true,
                           "dependencies": {
                             "semver": {
                               "version": "5.0.3",
-                              "from": "semver@~5.0.1",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                               "dev": true
                             }
@@ -6358,13 +5317,11 @@
                         },
                         "debug": {
                           "version": "2.6.8",
-                          "from": "debug@2",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                           "dev": true,
                           "dependencies": {
                             "ms": {
                               "version": "2.0.0",
-                              "from": "ms@2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                               "dev": true
                             }
@@ -6372,7 +5329,6 @@
                         },
                         "extend": {
                           "version": "3.0.1",
-                          "from": "extend@3",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                           "dev": true
                         }
@@ -6380,19 +5336,16 @@
                     },
                     "node-fetch-npm": {
                       "version": "2.0.1",
-                      "from": "node-fetch-npm@^2.0.0",
                       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
                       "dev": true,
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
-                          "from": "encoding@^0.1.11",
                           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                           "dev": true,
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.17",
-                              "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
                               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
                               "dev": true
                             }
@@ -6400,13 +5353,11 @@
                         },
                         "json-parse-helpfulerror": {
                           "version": "1.0.3",
-                          "from": "json-parse-helpfulerror@^1.0.3",
                           "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
                           "dev": true,
                           "dependencies": {
                             "jju": {
                               "version": "1.3.0",
-                              "from": "jju@^1.1.0",
                               "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
                               "dev": true
                             }
@@ -6416,19 +5367,16 @@
                     },
                     "socks-proxy-agent": {
                       "version": "2.1.0",
-                      "from": "socks-proxy-agent@^2.0.0",
                       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "agent-base": {
                           "version": "2.1.1",
-                          "from": "agent-base@2",
                           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
                           "dev": true,
                           "dependencies": {
                             "semver": {
                               "version": "5.0.3",
-                              "from": "semver@~5.0.1",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
                               "dev": true
                             }
@@ -6436,25 +5384,21 @@
                         },
                         "extend": {
                           "version": "3.0.1",
-                          "from": "extend@3",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                           "dev": true
                         },
                         "socks": {
                           "version": "1.1.10",
-                          "from": "socks@~1.1.5",
                           "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
                           "dev": true,
                           "dependencies": {
                             "ip": {
                               "version": "1.1.5",
-                              "from": "ip@^1.1.4",
                               "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
                               "dev": true
                             },
                             "smart-buffer": {
                               "version": "1.1.15",
-                              "from": "smart-buffer@^1.0.13",
                               "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
                               "dev": true
                             }
@@ -6466,25 +5410,21 @@
                 },
                 "minimatch": {
                   "version": "3.0.4",
-                  "from": "minimatch@^3.0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.7",
-                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@^0.4.1",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "dev": true
                         }
@@ -6494,19 +5434,16 @@
                 },
                 "npm-pick-manifest": {
                   "version": "1.0.3",
-                  "from": "npm-pick-manifest@^1.0.3",
                   "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.3.tgz",
                   "dev": true
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "from": "promise-retry@^1.1.1",
                   "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
                   "dev": true,
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "from": "err-code@^1.0.0",
                       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
                       "dev": true
                     }
@@ -6514,13 +5451,11 @@
                 },
                 "protoduck": {
                   "version": "4.0.0",
-                  "from": "protoduck@^4.0.0",
                   "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "genfun": {
                       "version": "4.0.1",
-                      "from": "genfun@^4.0.1",
                       "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
                       "dev": true
                     }
@@ -6528,19 +5463,16 @@
                 },
                 "tar-fs": {
                   "version": "1.15.2",
-                  "from": "tar-fs@^1.15.1",
                   "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.2.tgz",
                   "dev": true,
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
-                      "from": "pump@^1.0.0",
                       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
                       "dev": true,
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
-                          "from": "end-of-stream@^1.1.0",
                           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
                           "dev": true
                         }
@@ -6550,25 +5482,21 @@
                 },
                 "tar-stream": {
                   "version": "1.5.4",
-                  "from": "tar-stream@^1.5.2",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
-                      "from": "bl@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
                       "dev": true
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "from": "end-of-stream@^1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
                       "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@^4.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "dev": true
                     }
@@ -6578,25 +5506,21 @@
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "from": "path-is-inside@~1.0.2",
               "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
               "dev": true
             },
             "promise-inflight": {
               "version": "1.0.1",
-              "from": "promise-inflight@~1.0.1",
               "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
               "dev": true
             },
             "read": {
               "version": "1.0.7",
-              "from": "read@~1.0.7",
               "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
               "dev": true,
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.7",
-                  "from": "mute-stream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
                   "dev": true
                 }
@@ -6604,19 +5528,16 @@
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "from": "read-cmd-shim@~1.0.1",
               "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
               "dev": true
             },
             "read-installed": {
               "version": "4.0.3",
-              "from": "read-installed@~4.0.3",
               "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
               "dev": true,
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
-                  "from": "util-extend@^1.0.1",
                   "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
                   "dev": true
                 }
@@ -6624,19 +5545,16 @@
             },
             "read-package-json": {
               "version": "2.0.5",
-              "from": "read-package-json@~2.0.5",
               "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.5.tgz",
               "dev": true,
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "from": "json-parse-helpfulerror@^1.0.2",
                   "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
                   "dev": true,
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "from": "jju@^1.1.0",
                       "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
                       "dev": true
                     }
@@ -6646,43 +5564,36 @@
             },
             "read-package-tree": {
               "version": "5.1.6",
-              "from": "read-package-tree@5.1.6",
               "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
               "dev": true
             },
             "readable-stream": {
               "version": "2.2.10",
-              "from": "readable-stream@2.2.10",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
               "dev": true,
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@~1.0.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@~1.0.6",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "1.0.1",
-                  "from": "string_decoder@~1.0.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "dev": true
                 }
@@ -6690,43 +5601,36 @@
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "from": "readdir-scoped-modules@*",
               "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
               "dev": true
             },
             "request": {
               "version": "2.81.0",
-              "from": "request@~2.81.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
               "dev": true,
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.6.0",
-                  "from": "aws4@^1.2.1",
                   "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
                   "dev": true
                 },
                 "caseless": {
                   "version": "0.12.0",
-                  "from": "caseless@~0.12.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@~1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dev": true,
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                       "dev": true
                     }
@@ -6734,25 +5638,21 @@
                 },
                 "extend": {
                   "version": "3.0.1",
-                  "from": "extend@~3.0.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                   "dev": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@~0.6.1",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.1.4",
-                  "from": "form-data@~2.1.1",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
                   "dev": true,
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "from": "asynckit@^0.4.0",
                       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                       "dev": true
                     }
@@ -6760,31 +5660,26 @@
                 },
                 "har-validator": {
                   "version": "4.2.1",
-                  "from": "har-validator@~4.2.1",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
                   "dev": true,
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
-                      "from": "ajv@^4.9.1",
                       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                       "dev": true,
                       "dependencies": {
                         "co": {
                           "version": "4.6.0",
-                          "from": "co@^4.6.0",
                           "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
                           "dev": true
                         },
                         "json-stable-stringify": {
                           "version": "1.0.1",
-                          "from": "json-stable-stringify@^1.0.1",
                           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                           "dev": true,
                           "dependencies": {
                             "jsonify": {
                               "version": "0.0.0",
-                              "from": "jsonify@~0.0.0",
                               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                               "dev": true
                             }
@@ -6794,7 +5689,6 @@
                     },
                     "har-schema": {
                       "version": "1.0.5",
-                      "from": "har-schema@^1.0.5",
                       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
                       "dev": true
                     }
@@ -6802,31 +5696,26 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "from": "hawk@~3.1.3",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dev": true,
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "dev": true
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                       "dev": true
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                       "dev": true
                     }
@@ -6834,43 +5723,36 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "from": "http-signature@~1.1.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                   "dev": true,
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "from": "assert-plus@^0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.4.0",
-                      "from": "jsprim@^1.2.2",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                           "dev": true
                         },
                         "extsprintf": {
                           "version": "1.0.2",
-                          "from": "extsprintf@1.0.2",
                           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "from": "json-schema@0.2.3",
                           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "from": "verror@1.3.6",
                           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                           "dev": true
                         }
@@ -6878,65 +5760,55 @@
                     },
                     "sshpk": {
                       "version": "1.13.0",
-                      "from": "sshpk@^1.7.0",
                       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "from": "asn1@~0.2.3",
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@^1.0.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.1",
-                          "from": "bcrypt-pbkdf@^1.0.0",
                           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                           "dev": true,
                           "optional": true
                         },
                         "dashdash": {
                           "version": "1.14.1",
-                          "from": "dashdash@^1.12.0",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                           "dev": true
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "from": "ecc-jsbn@~0.1.1",
                           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                           "dev": true,
                           "optional": true
                         },
                         "getpass": {
                           "version": "0.1.7",
-                          "from": "getpass@^0.1.1",
                           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                           "dev": true
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "from": "jodid25519@^1.0.0",
                           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                           "dev": true,
                           "optional": true
                         },
                         "jsbn": {
                           "version": "0.1.1",
-                          "from": "jsbn@~0.1.0",
                           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.5",
-                          "from": "tweetnacl@~0.14.0",
                           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                           "dev": true,
                           "optional": true
@@ -6947,31 +5819,26 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "from": "is-typedarray@~1.0.0",
                   "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@~0.1.2",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.1",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
-                  "from": "mime-types@~2.1.7",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                   "dev": true,
                   "dependencies": {
                     "mime-db": {
                       "version": "1.27.0",
-                      "from": "mime-db@~1.27.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
                       "dev": true
                     }
@@ -6979,43 +5846,36 @@
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "from": "oauth-sign@~0.8.1",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
                   "dev": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
-                  "from": "performance-now@^0.2.0",
                   "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
                   "dev": true
                 },
                 "qs": {
                   "version": "6.4.0",
-                  "from": "qs@~6.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
                   "dev": true
                 },
                 "safe-buffer": {
                   "version": "5.0.1",
-                  "from": "safe-buffer@^5.0.1",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.2",
-                  "from": "tough-cookie@~2.3.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                   "dev": true,
                   "dependencies": {
                     "punycode": {
                       "version": "1.4.1",
-                      "from": "punycode@^1.4.1",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                       "dev": true
                     }
@@ -7023,7 +5883,6 @@
                 },
                 "tunnel-agent": {
                   "version": "0.6.0",
-                  "from": "tunnel-agent@^0.6.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                   "dev": true
                 }
@@ -7031,79 +5890,66 @@
             },
             "retry": {
               "version": "0.10.1",
-              "from": "retry@~0.10.1",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
               "dev": true
             },
             "rimraf": {
               "version": "2.6.1",
-              "from": "rimraf@~2.6.1",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
               "dev": true
             },
             "safe-buffer": {
               "version": "5.1.0",
-              "from": "safe-buffer@latest",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "from": "semver@~5.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "from": "sha@~2.0.1",
               "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
               "dev": true
             },
             "slide": {
               "version": "1.1.6",
-              "from": "slide@~1.1.6",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.1",
-              "from": "sorted-object@~2.0.1",
               "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
               "dev": true
             },
             "sorted-union-stream": {
               "version": "2.1.3",
-              "from": "sorted-union-stream@~2.1.3",
               "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
               "dev": true,
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
-                  "from": "from2@^1.3.0",
                   "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
-                      "from": "readable-stream@~1.1.10",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                       "dev": true,
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "dev": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "dev": true
                         }
@@ -7113,13 +5959,11 @@
                 },
                 "stream-iterate": {
                   "version": "1.2.0",
-                  "from": "stream-iterate@^1.1.0",
                   "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "from": "stream-shift@^1.0.0",
                       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
                       "dev": true
                     }
@@ -7129,25 +5973,21 @@
             },
             "ssri": {
               "version": "4.1.5",
-              "from": "ssri@4.1.5",
               "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.5.tgz",
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@~3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dev": true
             },
             "tar": {
               "version": "2.2.1",
-              "from": "tar@~2.2.1",
               "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "dev": true,
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
                   "dev": true
                 }
@@ -7155,31 +5995,26 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "text-table@~0.2.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "from": "uid-number@0.0.6",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "from": "umask@~1.1.0",
               "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
               "dev": true
             },
             "unique-filename": {
               "version": "1.1.0",
-              "from": "unique-filename@~1.1.0",
               "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
               "dev": true,
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
-                  "from": "unique-slug@^2.0.0",
                   "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
                   "dev": true
                 }
@@ -7187,49 +6022,41 @@
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@~1.0.0",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
               "dev": true
             },
             "update-notifier": {
               "version": "2.1.0",
-              "from": "update-notifier@~2.1.0",
               "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.1.0.tgz",
               "dev": true,
               "dependencies": {
                 "boxen": {
                   "version": "1.0.0",
-                  "from": "boxen@^1.0.0",
                   "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "ansi-align": {
                       "version": "1.1.0",
-                      "from": "ansi-align@^1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "from": "string-width@^1.0.1",
                           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                           "dev": true,
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "from": "code-point-at@^1.0.0",
                               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "from": "is-fullwidth-code-point@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                               "dev": true,
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                                   "dev": true
                                 }
@@ -7241,25 +6068,21 @@
                     },
                     "camelcase": {
                       "version": "4.1.0",
-                      "from": "camelcase@^4.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
                       "dev": true
                     },
                     "cli-boxes": {
                       "version": "1.0.0",
-                      "from": "cli-boxes@^1.0.0",
                       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
                       "dev": true
                     },
                     "string-width": {
                       "version": "2.0.0",
-                      "from": "string-width@^2.0.0",
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "is-fullwidth-code-point": {
                           "version": "2.0.0",
-                          "from": "is-fullwidth-code-point@^2.0.0",
                           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                           "dev": true
                         }
@@ -7267,49 +6090,41 @@
                     },
                     "term-size": {
                       "version": "0.1.1",
-                      "from": "term-size@^0.1.0",
                       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
                       "dev": true,
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
-                          "from": "execa@^0.4.0",
                           "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
                           "dev": true,
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
-                              "from": "cross-spawn-async@^2.1.1",
                               "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "from": "is-stream@^1.1.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
                               "dev": true
                             },
                             "npm-run-path": {
                               "version": "1.0.0",
-                              "from": "npm-run-path@^1.0.0",
                               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
                               "dev": true
                             },
                             "object-assign": {
                               "version": "4.1.1",
-                              "from": "object-assign@^4.0.1",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                               "dev": true
                             },
                             "path-key": {
                               "version": "1.0.0",
-                              "from": "path-key@^1.0.0",
                               "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
                               "dev": true
                             },
                             "strip-eof": {
                               "version": "1.0.0",
-                              "from": "strip-eof@^1.0.0",
                               "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
                               "dev": true
                             }
@@ -7319,31 +6134,26 @@
                     },
                     "widest-line": {
                       "version": "1.0.0",
-                      "from": "widest-line@^1.0.0",
                       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
-                          "from": "string-width@^1.0.1",
                           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                           "dev": true,
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "from": "code-point-at@^1.0.0",
                               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                               "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "from": "is-fullwidth-code-point@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                               "dev": true,
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                                   "dev": true
                                 }
@@ -7357,31 +6167,26 @@
                 },
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@^1.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dev": true,
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "from": "ansi-styles@^2.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                       "dev": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@^1.0.2",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                       "dev": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dev": true
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@^2.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "dev": true
                     }
@@ -7389,19 +6194,16 @@
                 },
                 "configstore": {
                   "version": "3.0.0",
-                  "from": "configstore@^3.0.0",
                   "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
-                      "from": "dot-prop@^4.1.0",
                       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
                       "dev": true,
                       "dependencies": {
                         "is-obj": {
                           "version": "1.0.1",
-                          "from": "is-obj@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
                           "dev": true
                         }
@@ -7409,13 +6211,11 @@
                     },
                     "unique-string": {
                       "version": "1.0.0",
-                      "from": "unique-string@^1.0.0",
                       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
                       "dev": true,
                       "dependencies": {
                         "crypto-random-string": {
                           "version": "1.0.0",
-                          "from": "crypto-random-string@^1.0.0",
                           "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
                           "dev": true
                         }
@@ -7423,7 +6223,6 @@
                     },
                     "write-file-atomic": {
                       "version": "1.3.4",
-                      "from": "write-file-atomic@^1.1.2",
                       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
                       "dev": true
                     }
@@ -7431,37 +6230,31 @@
                 },
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "is-npm@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
                   "dev": true
                 },
                 "latest-version": {
                   "version": "3.1.0",
-                  "from": "latest-version@^3.0.0",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
                   "dev": true,
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
-                      "from": "package-json@^4.0.0",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
                       "dev": true,
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
-                          "from": "got@^6.7.1",
                           "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
                           "dev": true,
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
-                              "from": "create-error-class@^3.0.0",
                               "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
                               "dev": true,
                               "dependencies": {
                                 "capture-stack-trace": {
                                   "version": "1.0.0",
-                                  "from": "capture-stack-trace@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
                                   "dev": true
                                 }
@@ -7469,67 +6262,56 @@
                             },
                             "duplexer3": {
                               "version": "0.1.4",
-                              "from": "duplexer3@^0.1.4",
                               "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
                               "dev": true
                             },
                             "get-stream": {
                               "version": "3.0.0",
-                              "from": "get-stream@^3.0.0",
                               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                               "dev": true
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "from": "is-redirect@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
                               "dev": true
                             },
                             "is-retry-allowed": {
                               "version": "1.1.0",
-                              "from": "is-retry-allowed@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
                               "dev": true
                             },
                             "is-stream": {
                               "version": "1.1.0",
-                              "from": "is-stream@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
                               "dev": true
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "lowercase-keys@^1.0.0",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
                               "dev": true
                             },
                             "safe-buffer": {
                               "version": "5.0.1",
-                              "from": "safe-buffer@^5.0.1",
                               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
                               "dev": true
                             },
                             "timed-out": {
                               "version": "4.0.1",
-                              "from": "timed-out@^4.0.0",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
                               "dev": true
                             },
                             "unzip-response": {
                               "version": "2.0.1",
-                              "from": "unzip-response@^2.0.1",
                               "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
                               "dev": true
                             },
                             "url-parse-lax": {
                               "version": "1.0.0",
-                              "from": "url-parse-lax@^1.0.0",
                               "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
                               "dev": true,
                               "dependencies": {
                                 "prepend-http": {
                                   "version": "1.0.4",
-                                  "from": "prepend-http@^1.0.1",
                                   "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
                                   "dev": true
                                 }
@@ -7539,31 +6321,26 @@
                         },
                         "registry-auth-token": {
                           "version": "3.3.0",
-                          "from": "registry-auth-token@^3.0.1",
                           "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.0.tgz",
                           "dev": true,
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "from": "rc@^1.1.6",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
                               "dev": true,
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.1",
-                                  "from": "deep-extend@~0.4.0",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "from": "minimist@^1.2.0",
                                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "from": "strip-json-comments@~2.0.1",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                                   "dev": true
                                 }
@@ -7571,7 +6348,6 @@
                             },
                             "safe-buffer": {
                               "version": "5.0.1",
-                              "from": "safe-buffer@^5.0.1",
                               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
                               "dev": true
                             }
@@ -7579,31 +6355,26 @@
                         },
                         "registry-url": {
                           "version": "3.1.0",
-                          "from": "registry-url@^3.0.3",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
                           "dev": true,
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
-                              "from": "rc@^1.0.1",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
                               "dev": true,
                               "dependencies": {
                                 "deep-extend": {
                                   "version": "0.4.1",
-                                  "from": "deep-extend@~0.4.0",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
                                   "dev": true
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "from": "minimist@^1.2.0",
                                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                                   "dev": true
                                 },
                                 "strip-json-comments": {
                                   "version": "2.0.1",
-                                  "from": "strip-json-comments@~2.0.1",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                                   "dev": true
                                 }
@@ -7617,19 +6388,16 @@
                 },
                 "lazy-req": {
                   "version": "2.0.0",
-                  "from": "lazy-req@^2.0.0",
                   "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
                   "dev": true
                 },
                 "semver-diff": {
                   "version": "2.1.0",
-                  "from": "semver-diff@^2.0.0",
                   "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
                   "dev": true
                 },
                 "xdg-basedir": {
                   "version": "3.0.0",
-                  "from": "xdg-basedir@^3.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
                   "dev": true
                 }
@@ -7637,25 +6405,21 @@
             },
             "uuid": {
               "version": "3.0.1",
-              "from": "uuid@~3.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "from": "validate-npm-package-license@*",
               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
               "dev": true,
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "from": "spdx-correct@~1.0.0",
                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                   "dev": true,
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.2",
-                      "from": "spdx-license-ids@^1.0.2",
                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
                       "dev": true
                     }
@@ -7663,7 +6427,6 @@
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.4",
-                  "from": "spdx-expression-parse@~1.0.0",
                   "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
                   "dev": true
                 }
@@ -7671,13 +6434,11 @@
             },
             "validate-npm-package-name": {
               "version": "3.0.0",
-              "from": "validate-npm-package-name@~3.0.0",
               "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
               "dev": true,
               "dependencies": {
                 "builtins": {
                   "version": "1.0.3",
-                  "from": "builtins@^1.0.3",
                   "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
                   "dev": true
                 }
@@ -7685,13 +6446,11 @@
             },
             "which": {
               "version": "1.2.14",
-              "from": "which@~1.2.14",
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
               "dev": true,
               "dependencies": {
                 "isexe": {
                   "version": "2.0.0",
-                  "from": "isexe@^2.0.0",
                   "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
                   "dev": true
                 }
@@ -7699,13 +6458,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "from": "wrappy@~1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "dev": true
             },
             "write-file-atomic": {
               "version": "2.1.0",
-              "from": "write-file-atomic@latest",
               "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
               "dev": true
             }
@@ -7713,151 +6470,126 @@
         },
         "npm-package-arg": {
           "version": "5.1.2",
-          "from": "npm-package-arg@5.1.2",
           "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "from": "npm-run-path@2.0.2",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "dev": true
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "from": "number-is-nan@1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "from": "once@1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "from": "os-homedir@1.0.2",
           "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "from": "os-locale@2.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "from": "os-tmpdir@1.0.2",
           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "dev": true
         },
         "osenv": {
           "version": "0.1.4",
-          "from": "osenv@0.1.4",
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "from": "p-finally@1.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "from": "p-limit@1.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "from": "p-locate@2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "from": "package-json@^4.0.0",
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "from": "parse-json@2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "from": "path-is-absolute@1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "from": "path-key@2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "from": "path-type@2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "dev": true
         },
         "pify": {
           "version": "2.3.0",
-          "from": "pify@2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "from": "pinkie@2.0.4",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "from": "pinkie-promise@2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "from": "prepend-http@^1.0.1",
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "from": "pseudomap@1.0.2",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
           "dev": true
         },
         "rc": {
           "version": "1.2.1",
-          "from": "rc@^1.1.6",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
           "dev": true,
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@^1.2.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "dev": true
             }
@@ -7865,109 +6597,91 @@
         },
         "read-pkg": {
           "version": "2.0.0",
-          "from": "read-pkg@2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "from": "read-pkg-up@2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "dev": true
         },
         "registry-auth-token": {
           "version": "3.3.1",
-          "from": "registry-auth-token@^3.0.1",
           "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
           "dev": true
         },
         "registry-url": {
           "version": "3.1.0",
-          "from": "registry-url@^3.0.3",
           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "from": "require-directory@2.1.1",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "from": "require-main-filename@1.0.1",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.1",
-          "from": "rimraf@^2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "dev": true
         },
         "safe-buffer": {
           "version": "5.1.0",
-          "from": "safe-buffer",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "from": "semver-diff@^2.0.0",
           "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@2.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "from": "signal-exit@3.0.2",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "from": "slide@^1.1.5",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "dev": true
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "from": "spdx-correct@1.0.2",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "from": "spdx-expression-parse@1.0.4",
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "from": "spdx-license-ids@1.2.2",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "dev": true,
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "from": "is-fullwidth-code-point@2.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
               "dev": true
             }
@@ -7975,55 +6689,46 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "from": "strip-ansi@3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "from": "strip-bom@3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "from": "strip-eof@1.0.0",
           "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "from": "strip-json-comments@2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "dev": true
         },
         "term-size": {
           "version": "0.1.1",
-          "from": "term-size@^0.1.0",
           "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
           "dev": true,
           "dependencies": {
             "execa": {
               "version": "0.4.0",
-              "from": "execa@^0.4.0",
               "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
               "dev": true
             },
             "npm-run-path": {
               "version": "1.0.0",
-              "from": "npm-run-path@^1.0.0",
               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
               "dev": true
             },
             "path-key": {
               "version": "1.0.0",
-              "from": "path-key@^1.0.0",
               "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
               "dev": true
             }
@@ -8031,67 +6736,56 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "from": "timed-out@^4.0.0",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "from": "unique-string@^1.0.0",
           "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "from": "unzip-response@^2.0.1",
           "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
           "dev": true
         },
         "update-notifier": {
           "version": "2.2.0",
-          "from": "update-notifier@2.2.0",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
           "dev": true
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "from": "url-parse-lax@^1.0.0",
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "from": "validate-npm-package-license@3.0.1",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "dev": true
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "from": "validate-npm-package-name@3.0.0",
           "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
           "dev": true
         },
         "which": {
           "version": "1.2.14",
-          "from": "which@1.2.14",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "dev": true
         },
         "which-module": {
           "version": "2.0.0",
-          "from": "which-module@2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "dev": true
         },
         "widest-line": {
           "version": "1.0.0",
-          "from": "widest-line@^1.0.0",
           "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
           "dev": true,
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@^1.0.1",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dev": true
             }
@@ -8099,13 +6793,11 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "from": "wrap-ansi@2.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "dev": true,
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dev": true
             }
@@ -8113,43 +6805,36 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "from": "wrappy@1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "from": "write-file-atomic@^2.0.0",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
           "dev": true
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "from": "xdg-basedir@^3.0.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
           "dev": true
         },
         "y18n": {
           "version": "3.2.1",
-          "from": "y18n@latest",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "from": "yallist@2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "dev": true
         },
         "yargs": {
           "version": "8.0.1",
-          "from": "yargs@8.0.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
           "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "from": "yargs-parser@7.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
           "dev": true
         }
@@ -8157,23 +6842,19 @@
     },
     "nugget": {
       "version": "2.0.1",
-      "from": "nugget@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.0",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-keys": {
@@ -8184,41 +6865,34 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "from": "object.omit@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "dev": true
     },
     "omit-empty": {
       "version": "0.4.1",
-      "from": "omit-empty@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/omit-empty/-/omit-empty-0.4.1.tgz",
       "dev": true
     },
     "once": {
       "version": "1.3.3",
-      "from": "once@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "onetime": {
       "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
-      "resolved": "http://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "dev": true
         }
@@ -8226,56 +6900,46 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.2 <0.9.0",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "os-locale": {
       "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "osenv": {
       "version": "0.1.4",
-      "from": "osenv@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "p-finally": {
       "version": "1.0.0",
-      "from": "p-finally@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
     },
     "p-limit": {
       "version": "1.1.0",
-      "from": "p-limit@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
       "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
-      "from": "p-locate@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "dev": true
     },
     "pac-proxy-agent": {
       "version": "0.2.0",
-      "from": "pac-proxy-agent@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "extend": {
           "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
           "dev": true
         }
@@ -8283,13 +6947,11 @@
     },
     "pac-resolver": {
       "version": "1.2.6",
-      "from": "pac-resolver@>=1.2.1 <1.3.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-1.2.6.tgz",
       "dev": true,
       "dependencies": {
         "co": {
           "version": "3.0.6",
-          "from": "co@>=3.0.6 <3.1.0",
           "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
           "dev": true
         }
@@ -8297,125 +6959,103 @@
     },
     "package": {
       "version": "1.0.1",
-      "from": "package@>=1.0.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
       "dev": true
     },
     "package-json": {
       "version": "4.0.1",
-      "from": "package-json@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "dev": true
     },
     "parse-author": {
       "version": "1.0.0",
-      "from": "parse-author@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-1.0.0.tgz",
       "dev": true
     },
     "parse-code-context": {
       "version": "0.1.3",
-      "from": "parse-code-context@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-0.1.3.tgz",
       "dev": true
     },
     "parse-color": {
       "version": "1.0.0",
-      "from": "parse-color@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
       "dev": true
     },
     "parse-git-config": {
       "version": "1.1.1",
-      "from": "parse-git-config@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
       "dev": true
     },
     "parse-github-url": {
       "version": "0.3.2",
-      "from": "parse-github-url@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-0.3.2.tgz",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "from": "parse-passwd@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "from": "path-is-inside@1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
     },
     "path-key": {
       "version": "1.0.0",
-      "from": "path-key@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
-      "from": "path-parse@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.4",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         }
       }
     },
     "pend": {
       "version": "1.2.0",
-      "from": "pend@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "performance-now": {
       "version": "0.2.0",
-      "from": "performance-now@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.3.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pipage": {
@@ -8437,25 +7077,21 @@
     },
     "pkg": {
       "version": "4.1.1",
-      "from": "pkg@4.1.1",
       "resolved": "https://registry.npmjs.org/pkg/-/pkg-4.1.1.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "5.0.3",
-          "from": "acorn@5.0.3",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
           "dev": true
         },
         "progress": {
           "version": "2.0.0",
-          "from": "progress@2.0.0",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
           "dev": true
         },
         "resolve": {
           "version": "1.3.3",
-          "from": "resolve@1.3.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
           "dev": true
         }
@@ -8463,30 +7099,25 @@
     },
     "pkg-conf": {
       "version": "1.1.3",
-      "from": "pkg-conf@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz"
     },
     "pkg-dir": {
       "version": "1.0.0",
-      "from": "pkg-dir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "dev": true
     },
     "pkg-fetch": {
       "version": "2.3.3",
-      "from": "pkg-fetch@2.3.3",
       "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-2.3.3.tgz",
       "dev": true,
       "dependencies": {
         "progress": {
           "version": "2.0.0",
-          "from": "progress@2.0.0",
           "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         }
@@ -8494,19 +7125,16 @@
     },
     "plist": {
       "version": "2.1.0",
-      "from": "plist@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
       "dev": true,
       "dependencies": {
         "base64-js": {
           "version": "1.2.0",
-          "from": "base64-js@1.2.0",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
           "dev": true
         },
         "xmlbuilder": {
           "version": "8.2.2",
-          "from": "xmlbuilder@8.2.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
           "dev": true
         }
@@ -8514,65 +7142,54 @@
     },
     "pluralize": {
       "version": "1.2.1",
-      "from": "pluralize@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "dev": true
     },
     "prebuild-install": {
       "version": "2.3.0",
-      "from": "prebuild-install@>=2.2.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "from": "prepend-http@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "dev": true
     },
     "pretty-bytes": {
       "version": "1.0.4",
-      "from": "pretty-bytes@1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz"
     },
     "private": {
       "version": "0.1.7",
-      "from": "private@>=0.1.5 <0.2.0",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "dev": true
     },
     "progress-bar-formatter": {
       "version": "2.0.1",
-      "from": "progress-bar-formatter@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/progress-bar-formatter/-/progress-bar-formatter-2.0.1.tgz"
     },
     "progress-stream": {
@@ -8591,47 +7208,39 @@
     },
     "project-name": {
       "version": "0.2.6",
-      "from": "project-name@>=0.2.6 <0.3.0",
       "resolved": "https://registry.npmjs.org/project-name/-/project-name-0.2.6.tgz",
       "dev": true
     },
     "promise": {
       "version": "7.1.1",
-      "from": "promise@>=7.1.1 <7.2.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "prop-types": {
       "version": "15.5.9",
-      "from": "prop-types@15.5.9",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.9.tgz",
       "dependencies": {
         "js-tokens": {
           "version": "3.0.1",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
         },
         "loose-envify": {
           "version": "1.3.1",
-          "from": "loose-envify@>=1.3.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
         }
       }
     },
     "propagate": {
       "version": "0.4.0",
-      "from": "propagate@0.4.0",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "dev": true
     },
     "proxy-agent": {
       "version": "1.1.1",
-      "from": "proxy-agent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.5.2",
-          "from": "lru-cache@>=2.5.0 <2.6.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz",
           "dev": true
         }
@@ -8639,33 +7248,27 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "pump": {
       "version": "1.0.2",
-      "from": "pump@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz"
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.3.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "q": {
       "version": "1.4.1",
-      "from": "q@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "dev": true
     },
     "qs": {
       "version": "6.4.0",
-      "from": "qs@>=6.4.0 <6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
     },
     "randomatic": {
       "version": "1.1.6",
-      "from": "randomatic@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "dev": true
     },
@@ -8676,7 +7279,6 @@
       "dependencies": {
         "uuid": {
           "version": "3.0.0",
-          "from": "uuid@3.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz"
         }
       }
@@ -8688,32 +7290,26 @@
     },
     "rc": {
       "version": "1.1.7",
-      "from": "rc@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz"
     },
     "react": {
       "version": "15.5.4",
-      "from": "react@15.5.4",
       "resolved": "https://registry.npmjs.org/react/-/react-15.5.4.tgz"
     },
     "react-dom": {
       "version": "15.5.4",
-      "from": "react-dom@15.5.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz"
     },
     "react2angular": {
       "version": "1.1.3",
-      "from": "react2angular@1.1.3",
       "resolved": "https://registry.npmjs.org/react2angular/-/react2angular-1.1.3.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
@@ -8728,7 +7324,6 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "safe-buffer": {
@@ -8745,24 +7340,20 @@
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "recast": {
       "version": "0.10.33",
-      "from": "recast@0.10.33",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
       "dev": true,
       "dependencies": {
         "ast-types": {
           "version": "0.8.12",
-          "from": "ast-types@0.8.12",
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
           "dev": true
         },
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
           "dev": true
         }
@@ -8770,41 +7361,34 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@>=0.6.2 <0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "dev": true
     },
     "redent": {
       "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "reduce-component": {
       "version": "1.0.1",
-      "from": "reduce-component@1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
       "dev": true
     },
     "reduce-object": {
       "version": "0.1.3",
-      "from": "reduce-object@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/reduce-object/-/reduce-object-0.1.3.tgz",
       "dev": true
     },
     "redux": {
       "version": "3.5.2",
-      "from": "redux@3.5.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz"
     },
     "regenerator": {
       "version": "0.8.46",
-      "from": "regenerator@>=0.8.13 <0.9.0",
       "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.46.tgz",
       "dev": true,
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
           "dev": true
         }
@@ -8812,43 +7396,36 @@
     },
     "regenerator-runtime": {
       "version": "0.9.6",
-      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
       "dev": true
     },
     "regex-cache": {
       "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "dev": true
     },
     "registry-auth-token": {
       "version": "3.3.1",
-      "from": "registry-auth-token@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "dev": true
     },
     "registry-url": {
       "version": "3.1.0",
-      "from": "registry-url@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "dev": true
     },
     "relative": {
       "version": "3.0.2",
-      "from": "relative@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "dev": true
         }
@@ -8856,19 +7433,16 @@
     },
     "remarkable": {
       "version": "1.7.1",
-      "from": "remarkable@>=1.6.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
       "dev": true,
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "from": "argparse@>=0.1.15 <0.2.0",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "dev": true
         },
         "underscore.string": {
           "version": "2.4.0",
-          "from": "underscore.string@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
           "dev": true
         }
@@ -8876,42 +7450,35 @@
     },
     "remote-origin-url": {
       "version": "0.5.2",
-      "from": "remote-origin-url@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.2.tgz",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@>=1.5.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "from": "repeating@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
     },
     "replace-ext": {
       "version": "0.0.1",
-      "from": "replace-ext@0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "dev": true
     },
     "repo-utils": {
       "version": "0.3.7",
-      "from": "repo-utils@>=0.3.4 <0.4.0",
       "resolved": "https://registry.npmjs.org/repo-utils/-/repo-utils-0.3.7.tgz",
       "dev": true,
       "dependencies": {
         "lazy-cache": {
           "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "dev": true
         }
@@ -8919,30 +7486,25 @@
     },
     "request": {
       "version": "2.81.0",
-      "from": "request@2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "dependencies": {
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         }
       }
     },
     "request-progress": {
       "version": "3.0.0",
-      "from": "request-progress@3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "dev": true,
       "dependencies": {
         "throttleit": {
           "version": "1.0.0",
-          "from": "throttleit@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
           "dev": true
         }
@@ -8950,51 +7512,42 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "require-uncached": {
       "version": "1.0.3",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "dev": true
     },
     "resin-cli-form": {
       "version": "1.4.1",
-      "from": "resin-cli-form@1.4.1",
       "resolved": "https://registry.npmjs.org/resin-cli-form/-/resin-cli-form-1.4.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.9.30 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.9.3 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
     },
     "resin-cli-visuals": {
       "version": "1.3.1",
-      "from": "resin-cli-visuals@1.3.1",
       "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.3.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "from": "bluebird@>=2.9.34 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         }
       }
@@ -9006,124 +7559,102 @@
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
-          "from": "cross-spawn@>=5.0.1 <6.0.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
         },
         "execa": {
           "version": "0.7.0",
-          "from": "execa@>=0.7.0 <0.8.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz"
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.17.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "from": "npm-run-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
         },
         "os-locale": {
           "version": "2.1.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
         },
         "path-key": {
           "version": "2.0.1",
-          "from": "path-key@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
         }
       }
     },
     "resolve": {
       "version": "1.4.0",
-      "from": "resolve@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "dev": true
     },
     "resolve-dir": {
       "version": "0.1.1",
-      "from": "resolve-dir@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.1",
-      "from": "rimraf@>=2.5.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "safe-buffer": {
       "version": "5.0.1",
-      "from": "safe-buffer@>=5.0.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
     },
     "samsam": {
       "version": "1.1.2",
-      "from": "samsam@1.1.2",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "dev": true
     },
     "sanitize-filename": {
       "version": "1.6.1",
-      "from": "sanitize-filename@>=1.6.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
       "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
-      "from": "sass-graph@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "dev": true,
       "dependencies": {
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "from": "string-width@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "dev": true
         },
         "yargs": {
           "version": "7.1.0",
-          "from": "yargs@>=7.0.0 <8.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "dev": true
         },
         "yargs-parser": {
           "version": "5.0.0",
-          "from": "yargs-parser@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "dev": true
         }
@@ -9131,55 +7662,46 @@
     },
     "sass-lint": {
       "version": "1.10.2",
-      "from": "sass-lint@1.10.2",
       "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.10.2.tgz",
       "dev": true,
       "dependencies": {
         "cli-width": {
           "version": "2.1.0",
-          "from": "cli-width@^2.0.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
           "dev": true
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@^2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dev": true
         },
         "doctrine": {
           "version": "1.5.0",
-          "from": "doctrine@>=1.2.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "dev": true
         },
         "eslint": {
           "version": "2.13.1",
-          "from": "eslint@>=2.7.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "dev": true
         },
         "file-entry-cache": {
           "version": "1.3.1",
-          "from": "file-entry-cache@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
           "dev": true
         },
         "fs-extra": {
           "version": "1.0.0",
-          "from": "fs-extra@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
           "dev": true
         },
         "globule": {
           "version": "1.1.0",
-          "from": "globule@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
           "dev": true,
           "dependencies": {
             "lodash": {
               "version": "4.16.6",
-              "from": "lodash@>=4.16.4 <4.17.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
               "dev": true
             }
@@ -9187,31 +7709,26 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "from": "inquirer@^0.12.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@^1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "dev": true
         },
         "shelljs": {
           "version": "0.6.1",
-          "from": "shelljs@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
           "dev": true
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "dev": true
         }
@@ -9219,18 +7736,15 @@
     },
     "sax": {
       "version": "1.2.2",
-      "from": "sax@>=0.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "from": "scss-tokenizer@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dev": true
         }
@@ -9238,160 +7752,132 @@
     },
     "seek-bzip": {
       "version": "1.0.5",
-      "from": "seek-bzip@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
     },
     "semver": {
       "version": "5.1.1",
-      "from": "semver@5.1.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz"
     },
     "semver-diff": {
       "version": "2.1.0",
-      "from": "semver-diff@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "dev": true
     },
     "set-blocking": {
       "version": "1.0.0",
-      "from": "set-blocking@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz"
     },
     "set-getter": {
       "version": "0.1.0",
-      "from": "set-getter@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "dev": true
     },
     "setimmediate": {
       "version": "1.0.5",
-      "from": "setimmediate@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
     },
     "shebang-command": {
       "version": "1.2.0",
-      "from": "shebang-command@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.7.8",
-      "from": "shelljs@>=0.7.5 <0.8.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
     },
     "simple-bufferstream": {
       "version": "1.0.0",
-      "from": "simple-bufferstream@1.0.0",
       "resolved": "https://registry.npmjs.org/simple-bufferstream/-/simple-bufferstream-1.0.0.tgz",
       "dev": true
     },
     "simple-fmt": {
       "version": "0.1.0",
-      "from": "simple-fmt@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
       "dev": true
     },
     "simple-get": {
       "version": "1.4.3",
-      "from": "simple-get@>=1.4.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
       "dependencies": {
         "unzip-response": {
           "version": "1.0.2",
-          "from": "unzip-response@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@^4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "simple-is": {
       "version": "0.2.0",
-      "from": "simple-is@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
       "dev": true
     },
     "single-line-log": {
       "version": "1.1.2",
-      "from": "single-line-log@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
       "dev": true
     },
     "sinon": {
       "version": "1.17.7",
-      "from": "sinon@>=1.15.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "dev": true
     },
     "sinon-chai": {
       "version": "2.8.0",
-      "from": "sinon-chai@>=2.8.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
       "dev": true
     },
     "ski": {
       "version": "1.0.0",
-      "from": "ski@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/ski/-/ski-1.0.0.tgz",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "from": "slice-ansi@0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "dev": true
     },
     "slide": {
       "version": "1.1.6",
-      "from": "slide@>=1.1.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "dev": true
     },
     "smart-buffer": {
       "version": "1.1.15",
-      "from": "smart-buffer@>=1.0.13 <2.0.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
       "dev": true
     },
     "sntp": {
       "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "socks": {
       "version": "1.1.10",
-      "from": "socks@>=1.1.5 <1.2.0",
       "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
       "dev": true
     },
     "socks-proxy-agent": {
       "version": "1.0.2",
-      "from": "socks-proxy-agent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-1.0.2.tgz",
       "dev": true,
       "dependencies": {
         "extend": {
           "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
           "dev": true
         }
@@ -9399,34 +7885,28 @@
     },
     "source-map": {
       "version": "0.5.6",
-      "from": "source-map@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "dev": true
     },
     "source-map-support": {
       "version": "0.4.15",
-      "from": "source-map-support@>=0.4.15 <0.5.0",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
-      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.2",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.1",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
     },
     "speedometer": {
@@ -9436,58 +7916,48 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.11.0",
-      "from": "sshpk@>=1.7.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
       "dependencies": {
         "asn1": {
           "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
         },
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "stable": {
       "version": "0.1.6",
-      "from": "stable@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
       "dev": true
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "stack-trace@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "stat-mode": {
       "version": "0.2.2",
-      "from": "stat-mode@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
       "dev": true
     },
     "stdout-stream": {
       "version": "1.4.0",
-      "from": "stdout-stream@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "dev": true
     },
     "stream-meter": {
       "version": "1.0.4",
-      "from": "stream-meter@1.0.4",
       "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
       "dev": true
     },
     "stream-to-array": {
       "version": "1.0.0",
-      "from": "stream-to-array@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-1.0.0.tgz",
       "dev": true
     },
@@ -9499,66 +7969,54 @@
     },
     "string-width": {
       "version": "1.0.1",
-      "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
     },
     "string.prototype.codepointat": {
       "version": "0.2.0",
-      "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "dev": true
     },
     "string.prototype.endswith": {
       "version": "0.2.0",
-      "from": "string.prototype.endswith@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
       "dev": true
     },
     "stringmap": {
       "version": "0.2.2",
-      "from": "stringmap@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
       "dev": true
     },
     "stringset": {
       "version": "0.2.1",
-      "from": "stringset@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
       "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-eof": {
       "version": "1.0.0",
-      "from": "strip-eof@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "from": "strip-json-comments@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
     },
     "striptags": {
       "version": "2.2.1",
-      "from": "striptags@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
       "dev": true
     },
@@ -9569,49 +8027,41 @@
     },
     "sumchecker": {
       "version": "1.3.1",
-      "from": "sumchecker@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
       "dev": true
     },
     "superagent": {
       "version": "0.21.0",
-      "from": "superagent@>=0.21.0 <0.22.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.21.0.tgz",
       "dev": true,
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "dev": true
         },
         "extend": {
           "version": "1.2.1",
-          "from": "extend@>=1.2.1 <1.3.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
           "dev": true
         },
         "form-data": {
           "version": "0.1.3",
-          "from": "form-data@0.1.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
           "dev": true
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@1.2.11",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "dev": true
         },
         "qs": {
           "version": "1.2.0",
-          "from": "qs@1.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.27-1",
-          "from": "readable-stream@1.0.27-1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
           "dev": true
         }
@@ -9619,19 +8069,16 @@
     },
     "superagent-proxy": {
       "version": "0.3.2",
-      "from": "superagent-proxy@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-0.3.2.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dev": true
         },
         "ms": {
           "version": "0.7.1",
-          "from": "ms@0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "dev": true
         }
@@ -9639,34 +8086,28 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "symbol": {
       "version": "0.2.3",
-      "from": "symbol@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz"
     },
     "symbol-observable": {
       "version": "0.2.4",
-      "from": "symbol-observable@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz"
     },
     "table": {
       "version": "3.8.3",
-      "from": "table@>=3.7.8 <4.0.0",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "dev": true,
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "dev": true
         }
@@ -9674,45 +8115,37 @@
     },
     "tar": {
       "version": "2.2.1",
-      "from": "tar@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
     },
     "tar-fs": {
       "version": "1.16.0",
-      "from": "tar-fs@>=1.13.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz"
     },
     "tar-pack": {
       "version": "3.4.0",
-      "from": "tar-pack@>=3.4.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
     },
     "tar-stream": {
       "version": "1.5.4",
-      "from": "tar-stream@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
       "dependencies": {
         "bl": {
           "version": "1.2.1",
-          "from": "bl@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@^4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "tempfile": {
       "version": "1.1.1",
-      "from": "tempfile@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
-          "from": "uuid@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "dev": true
         }
@@ -9720,36 +8153,30 @@
     },
     "temporary": {
       "version": "0.0.8",
-      "from": "temporary@>=0.0.8 <0.1.0",
       "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
       "dev": true
     },
     "term-size": {
       "version": "0.1.1",
-      "from": "term-size@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "dev": true
     },
     "throttleit": {
       "version": "0.0.2",
-      "from": "throttleit@0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "0.2.3",
-      "from": "through2@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "dev": true,
       "dependencies": {
@@ -9763,7 +8190,6 @@
     },
     "thunkify": {
       "version": "2.1.2",
-      "from": "thunkify@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "dev": true
     },
@@ -9780,25 +8206,21 @@
     },
     "to-file": {
       "version": "0.2.0",
-      "from": "to-file@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "dev": true
         },
         "lazy-cache": {
           "version": "2.0.2",
-          "from": "lazy-cache@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
           "dev": true
         }
@@ -9806,25 +8228,21 @@
     },
     "to-gfm-code-block": {
       "version": "0.1.1",
-      "from": "to-gfm-code-block@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/to-gfm-code-block/-/to-gfm-code-block-0.1.1.tgz",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "from": "to-object-path@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "dev": true
     },
     "touch": {
       "version": "0.0.3",
-      "from": "touch@0.0.3",
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "dev": true,
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dev": true
         }
@@ -9832,143 +8250,119 @@
     },
     "tough-cookie": {
       "version": "2.3.2",
-      "from": "tough-cookie@>=0.12.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
     },
     "tracery": {
       "version": "1.0.3",
-      "from": "tracery@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/tracery/-/tracery-1.0.3.tgz",
       "dev": true
     },
     "trackjs": {
       "version": "2.3.1",
-      "from": "trackjs@2.3.1",
       "resolved": "https://registry.npmjs.org/trackjs/-/trackjs-2.3.1.tgz"
     },
     "traverse": {
       "version": "0.3.9",
-      "from": "traverse@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
-      "from": "truncate-utf8-bytes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "dev": true
     },
     "tryit": {
       "version": "1.0.3",
-      "from": "tryit@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "dev": true
     },
     "tryor": {
       "version": "0.1.2",
-      "from": "tryor@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "from": "tunnel-agent@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "dev": true
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.12",
-      "from": "ua-parser-js@>=0.7.9 <0.8.0",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "udif": {
       "version": "0.10.0",
-      "from": "udif@0.10.0",
       "resolved": "https://registry.npmjs.org/udif/-/udif-0.10.0.tgz",
       "dependencies": {
         "base64-js": {
           "version": "1.1.2",
-          "from": "base64-js@1.1.2",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
         },
         "plist": {
           "version": "2.0.1",
-          "from": "plist@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz"
         },
         "xmlbuilder": {
           "version": "8.2.2",
-          "from": "xmlbuilder@8.2.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
         }
       }
     },
     "uglify-js": {
       "version": "2.8.13",
-      "from": "uglify-js@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.13.tgz",
       "dev": true,
       "optional": true,
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
-          "from": "cliui@^2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "dev": true,
           "optional": true
         },
         "window-size": {
           "version": "0.1.0",
-          "from": "window-size@0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "dev": true,
           "optional": true
@@ -9977,19 +8371,16 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "dev": true,
       "optional": true
     },
     "uid-number": {
       "version": "0.0.6",
-      "from": "uid-number@>=0.0.6 <0.0.7",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
     },
     "uid2": {
       "version": "0.0.3",
-      "from": "uid2@0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "dev": true
     },
@@ -10000,54 +8391,45 @@
     },
     "unc-path-regex": {
       "version": "0.1.2",
-      "from": "unc-path-regex@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "dev": true
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "underscore@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "dev": true
     },
     "underscore.string": {
       "version": "3.3.4",
-      "from": "underscore.string@>=3.2.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz"
     },
     "unique-string": {
       "version": "1.0.0",
-      "from": "unique-string@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "dev": true
     },
     "unique-temp-dir": {
       "version": "1.0.0",
-      "from": "unique-temp-dir@1.0.0",
       "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
       "dev": true
     },
     "universalify": {
       "version": "0.1.0",
-      "from": "universalify@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
       "dev": true
     },
     "unzip-response": {
       "version": "2.0.1",
-      "from": "unzip-response@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "dev": true
     },
     "update-json": {
       "version": "1.0.0",
-      "from": "update-json@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/update-json/-/update-json-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@^1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "dev": true
         }
@@ -10055,104 +8437,86 @@
     },
     "update-notifier": {
       "version": "2.2.0",
-      "from": "update-notifier@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
       "dev": true
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "from": "url-parse-lax@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "dev": true
     },
     "usb": {
       "version": "1.3.0",
-      "from": "tessel/node-usb#1.3.0",
       "resolved": "git://github.com/tessel/node-usb.git#38cc9cc75759e74f3d3ee8c79ca852395c3529b0",
       "dependencies": {
         "nan": {
           "version": "2.6.2",
-          "from": "nan@>=2.4.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
         }
       }
     },
     "user-home": {
       "version": "2.0.0",
-      "from": "user-home@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "dev": true
     },
     "utf8-byte-length": {
       "version": "1.0.4",
-      "from": "utf8-byte-length@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "dev": true
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.1 <0.11.0",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "util-extend": {
       "version": "1.0.3",
-      "from": "util-extend@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz"
     },
     "uuid": {
       "version": "3.0.1",
-      "from": "uuid@3.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
     },
     "uuid-1345": {
       "version": "0.99.6",
-      "from": "uuid-1345@>=0.99.6 <0.100.0",
       "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-0.99.6.tgz",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
-      "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "versionist": {
       "version": "2.8.1",
-      "from": "versionist@2.8.1",
       "resolved": "https://registry.npmjs.org/versionist/-/versionist-2.8.1.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "2.5.1",
-          "from": "debug@2.5.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
           "dev": true
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@^5.2.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         },
         "touch": {
           "version": "1.0.0",
-          "from": "touch@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
           "dev": true
         }
@@ -10160,19 +8524,16 @@
     },
     "vinyl": {
       "version": "1.2.0",
-      "from": "vinyl@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
       "dev": true
     },
     "w3cjs": {
       "version": "0.3.0",
-      "from": "w3cjs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/w3cjs/-/w3cjs-0.3.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.6.0",
-          "from": "commander@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
           "dev": true
         }
@@ -10180,72 +8541,59 @@
     },
     "wcwidth": {
       "version": "1.0.1",
-      "from": "wcwidth@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"
     },
     "whatwg-fetch": {
       "version": "2.0.3",
-      "from": "whatwg-fetch@>=0.10.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
     },
     "which": {
       "version": "1.2.10",
-      "from": "which@>=1.2.8 <2.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
     "which-module": {
       "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.0",
-      "from": "wide-align@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
     },
     "widest-line": {
       "version": "1.0.0",
-      "from": "widest-line@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "dev": true
     },
     "window-size": {
       "version": "0.2.0",
-      "from": "window-size@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.0.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "dev": true
     },
     "write-file-atomic": {
       "version": "2.1.0",
-      "from": "write-file-atomic@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
       "dev": true
     },
     "xdg-basedir": {
       "version": "3.0.0",
-      "from": "xdg-basedir@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "dev": true
     },
@@ -10256,22 +8604,18 @@
     },
     "xml2js": {
       "version": "0.4.17",
-      "from": "xml2js@0.4.17",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz"
     },
     "xmlbuilder": {
       "version": "4.2.1",
-      "from": "xmlbuilder@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
     },
     "xmldom": {
       "version": "0.1.27",
-      "from": "xmldom@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz"
     },
     "xregexp": {
       "version": "2.0.0",
-      "from": "xregexp@2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
       "dev": true
     },
@@ -10283,34 +8627,28 @@
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yallist": {
       "version": "2.0.0",
-      "from": "yallist@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
       "version": "4.7.1",
-      "from": "yargs@4.7.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz"
     },
     "yargs-parser": {
       "version": "2.4.0",
-      "from": "yargs-parser@>=2.4.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "from": "camelcase@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         }
       }
     },
     "yauzl": {
       "version": "2.6.0",
-      "from": "yauzl@2.6.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.6.0.tgz"
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8447,6 +8447,7 @@
     },
     "usb": {
       "version": "1.3.0",
+      "from": "tessel/node-usb#1.3.0",
       "resolved": "git://github.com/tessel/node-usb.git#38cc9cc75759e74f3d3ee8c79ca852395c3529b0",
       "dependencies": {
         "nan": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -297,7 +297,7 @@
     },
     "asn1": {
       "version": "0.1.11",
-      "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
       "dev": true
     },
     "assert-plus": {
@@ -677,7 +677,7 @@
     },
     "combined-stream": {
       "version": "0.0.7",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "dev": true
     },
     "command-join": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -406,17 +406,14 @@
     },
     "blockmap": {
       "version": "2.0.2",
-      "from": "blockmap@2.0.2",
       "resolved": "https://registry.npmjs.org/blockmap/-/blockmap-2.0.2.tgz",
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         }
       }
@@ -443,7 +440,6 @@
     },
     "bluebird-retry": {
       "version": "0.11.0",
-      "from": "bluebird-retry@0.11.0",
       "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.11.0.tgz"
     },
     "boom": {
@@ -794,7 +790,6 @@
     },
     "crc32-stream": {
       "version": "2.0.0",
-      "from": "crc32-stream@latest",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz"
     },
     "create-error-class": {
@@ -885,12 +880,10 @@
     },
     "debug": {
       "version": "2.6.8",
-      "from": "debug@2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "dependencies": {
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         }
       }
@@ -1057,29 +1050,24 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@^1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.4.1",
-      "from": "domhandler@^2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
     },
     "domutils": {
       "version": "1.6.2",
-      "from": "domutils@^1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz"
     },
     "dot-prop": {
@@ -1128,7 +1116,6 @@
     },
     "easy-stack": {
       "version": "1.0.0",
-      "from": "easy-stack@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz"
     },
     "ecc-jsbn": {
@@ -1480,7 +1467,6 @@
     },
     "entities": {
       "version": "1.1.1",
-      "from": "entities@^1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "env-paths": {
@@ -1827,7 +1813,6 @@
     },
     "event-pubsub": {
       "version": "4.3.0",
-      "from": "event-pubsub@4.3.0",
       "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz"
     },
     "execa": {
@@ -2062,12 +2047,10 @@
     },
     "flat": {
       "version": "4.0.0",
-      "from": "flat@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.0.0.tgz",
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "from": "is-buffer@>=1.1.5 <1.2.0",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
         }
       }
@@ -2522,7 +2505,6 @@
     },
     "htmlparser2": {
       "version": "3.9.2",
-      "from": "htmlparser2@>=3.9.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
     },
     "http-proxy-agent": {
@@ -2647,7 +2629,6 @@
     },
     "is-buffer": {
       "version": "1.1.4",
-      "from": "is-buffer@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
       "dev": true
     },
@@ -2857,7 +2838,6 @@
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "dev": true
     },
@@ -2899,7 +2879,6 @@
     },
     "js-queue": {
       "version": "2.0.0",
-      "from": "js-queue@2.0.0",
       "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz"
     },
     "js-tokens": {
@@ -3803,29 +3782,24 @@
     },
     "mixpanel": {
       "version": "0.7.0",
-      "from": "mixpanel@>=0.7.0 <0.8.0",
       "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.7.0.tgz",
       "dependencies": {
         "agent-base": {
           "version": "2.1.1",
-          "from": "agent-base@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz"
         },
         "https-proxy-agent": {
           "version": "1.0.0",
-          "from": "https-proxy-agent@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
         },
         "semver": {
           "version": "5.0.3",
-          "from": "semver@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
         }
       }
     },
     "mixpanel-browser": {
       "version": "2.14.0",
-      "from": "mixpanel-browser@>=2.11.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.14.0.tgz"
     },
     "mkdirp": {
@@ -4002,7 +3976,6 @@
     },
     "ms": {
       "version": "0.7.2",
-      "from": "ms@0.7.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
       "dev": true
     },
@@ -4088,7 +4061,6 @@
     },
     "node-ipc": {
       "version": "9.1.1",
-      "from": "node-ipc@9.1.1",
       "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz"
     },
     "node-pre-gyp": {
@@ -6859,7 +6831,6 @@
     },
     "object-keys": {
       "version": "0.4.0",
-      "from": "object-keys@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "dev": true
     },
@@ -7060,17 +7031,14 @@
     },
     "pipage": {
       "version": "1.0.2",
-      "from": "pipage@latest",
       "resolved": "https://registry.npmjs.org/pipage/-/pipage-1.0.2.tgz",
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <3.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         }
       }
@@ -7194,13 +7162,11 @@
     },
     "progress-stream": {
       "version": "1.2.0",
-      "from": "progress-stream@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
       "dev": true,
       "dependencies": {
         "speedometer": {
           "version": "0.1.4",
-          "from": "speedometer@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
           "dev": true
         }
@@ -7274,7 +7240,6 @@
     },
     "raven": {
       "version": "2.2.1",
-      "from": "raven@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/raven/-/raven-2.2.1.tgz",
       "dependencies": {
         "uuid": {
@@ -7285,7 +7250,6 @@
     },
     "raven-js": {
       "version": "3.20.1",
-      "from": "raven-js@>=3.19.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.20.1.tgz"
     },
     "rc": {
@@ -7314,12 +7278,10 @@
     },
     "readable-stream": {
       "version": "2.3.3",
-      "from": "readable-stream@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@>=2.0.3 <2.1.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         },
         "isarray": {
@@ -7328,12 +7290,10 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "from": "safe-buffer@>=5.1.1 <5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
         },
         "string_decoder": {
           "version": "1.0.3",
-          "from": "string_decoder@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
         }
       }
@@ -7554,7 +7514,6 @@
     },
     "resin-corvus": {
       "version": "1.0.0-beta.31",
-      "from": "resin-corvus@1.0.0-beta.31",
       "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.31.tgz",
       "dependencies": {
         "cross-spawn": {
@@ -7911,7 +7870,6 @@
     },
     "speedometer": {
       "version": "1.0.0",
-      "from": "speedometer@1.0.0",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz"
     },
     "sprintf-js": {
@@ -7963,7 +7921,6 @@
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "dev": true
     },
@@ -8022,7 +7979,6 @@
     },
     "sudo-prompt": {
       "version": "8.0.0",
-      "from": "sudo-prompt@8.0.0",
       "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.0.0.tgz"
     },
     "sumchecker": {
@@ -8182,7 +8138,6 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "dev": true
         }
@@ -8195,12 +8150,10 @@
     },
     "timed-out": {
       "version": "4.0.1",
-      "from": "timed-out@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz"
     },
     "tmp": {
       "version": "0.0.31",
-      "from": "tmp@0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "dev": true
     },
@@ -8600,7 +8553,6 @@
     },
     "xml": {
       "version": "1.0.1",
-      "from": "xml@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz"
     },
     "xml2js": {
@@ -8622,7 +8574,6 @@
     },
     "xtend": {
       "version": "2.1.2",
-      "from": "xtend@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -28,15 +28,9 @@
   "author": "Resin Inc. <hello@etcher.io>",
   "license": "Apache-2.0",
   "platformSpecificDependencies": [
-    [
-      "7zip-bin-mac"
-    ],
-    [
-      "7zip-bin-win"
-    ],
-    [
-      "7zip-bin-linux"
-    ]
+    "7zip-bin-mac",
+    "7zip-bin-win",
+    "7zip-bin-linux"
   ],
   "dependencies": {
     "angular": "1.6.3",

--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -78,6 +78,13 @@ traverseDeps(shrinkwrap, (parent, parentName, name, info) => {
     return
   }
 
+  // Ensure the `resolved` field contains a HTTPS registry URL,
+  // as some versions of npm apparently fall back to HTTP on some platforms
+  // under some circumstances
+  if (/^http:\/\//.test(info.resolved)) {
+    info.resolved = info.resolved.replace(/^http/, 'https')
+  }
+
   // Delete `from` fields to avoid different diffs
   // on different platforms
   info.from = undefined
@@ -85,7 +92,7 @@ traverseDeps(shrinkwrap, (parent, parentName, name, info) => {
 })
 
 // Generate the new shrinkwrap JSON
-const shrinkwrapJson = JSON.stringify(shrinkwrap, null, JSON_INDENT)
+const shrinkwrapJson = `${JSON.stringify(shrinkwrap, null, JSON_INDENT)}\n`
 
 // Write back the modified npm-shrinkwrap.json
 fs.writeFile(SHRINKWRAP_FILENAME, shrinkwrapJson, (error) => {

--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -91,7 +91,7 @@ traverseDeps(shrinkwrap, (parent, parentName, name, info) => {
   // to resolve properly during shrinkwrapping
   const isScoped = /^@/.test(name)
   const fromNpm = !/^[a-z0-9-]+\//i.test(info.from)
-  if ( isScoped || fromNpm ) {
+  if (isScoped || fromNpm) {
     info.from = undefined
     Reflect.deleteProperty(info, 'from')
   }

--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -85,10 +85,16 @@ traverseDeps(shrinkwrap, (parent, parentName, name, info) => {
     info.resolved = info.resolved.replace(/^http/, 'https')
   }
 
-  // Delete `from` fields to avoid different diffs
-  // on different platforms
-  info.from = undefined
-  Reflect.deleteProperty(info, 'from')
+  // Delete `from` fields to avoid different diffs on different platforms
+  // NOTE: Only do this if it's a npm package version range,
+  // as direct installs from github or git need this field
+  // to resolve properly during shrinkwrapping
+  const isScoped = /^@/.test(name)
+  const fromNpm = !/^[a-z0-9-]+\//i.test(info.from)
+  if ( isScoped || fromNpm ) {
+    info.from = undefined
+    Reflect.deleteProperty(info, 'from')
+  }
 })
 
 // Generate the new shrinkwrap JSON

--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -33,7 +33,7 @@ const shrinkwrap = require('../npm-shrinkwrap.json')
  * a given function on each dependency
  * @param {Object} tree - shrinkwrap
  * @param {Function} onNode - callback({Object} parent, {String} parentName, {String} name, {Object} info)
- * @param {String} [parentName] - name of dependant (used internally)
+ * @param {String} [parentName] - name of dependent (used internally)
  * @example
  * traverseDeps(shrinkwrap, (parent, parentName, name, info) => {
  *   // ...

--- a/scripts/clean-shrinkwrap.js
+++ b/scripts/clean-shrinkwrap.js
@@ -51,7 +51,7 @@ const traverseDeps = (tree, onNode, parentName) => {
   for (let index = 0; index < keys.length; index += 1) {
     name = keys[index]
 
-    // Check for this depedency to still exist,
+    // Check for this dependency to still exist,
     // as a node might have been removed just before this iteration
     if (tree.dependencies[name]) {
       onNode(tree, parentName || tree.name, name, tree.dependencies[name])


### PR DESCRIPTION
This updates the `postshrinkwrap` script to traverse the dependency tree
and remove all `from` fields to avoid inconsistent diffs across platforms,
environments and installs when shrinkwrapping anew.

Change-Type: patch