### PR TITLE
fix(scripts): Fix pip install in docker

### DIFF
--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -20,8 +20,10 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
-    libx11-xcb1 \
+    libudev-dev \
+    libusb-1.0-0-dev \
     libnss3 \
+    libx11-xcb1 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
@@ -49,4 +51,11 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install --quiet -r requirements.txt
+
+# FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
+RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+  && tar xvfz pip-9.0.1.tar.gz \
+  && cd pip-9.0.1 \
+  && python setup.py install
+
+RUN pip --version && pip install --quiet -r requirements.txt

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -57,4 +57,11 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install --quiet -r requirements.txt
+
+# FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
+RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+  && tar xvfz pip-9.0.1.tar.gz \
+  && cd pip-9.0.1 \
+  && python setup.py install
+
+RUN pip --version && pip install --quiet -r requirements.txt

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -56,4 +56,11 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install --quiet -r requirements.txt
+
+# FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
+RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+  && tar xvfz pip-9.0.1.tar.gz \
+  && cd pip-9.0.1 \
+  && python setup.py install
+
+RUN pip --version && pip install --quiet -r requirements.txt

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -61,4 +61,11 @@ RUN npm config set spin=false
 
 # Python
 COPY requirements.txt requirements.txt
-RUN pip install --quiet -r requirements.txt
+
+# FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
+RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+  && tar xvfz pip-9.0.1.tar.gz \
+  && cd pip-9.0.1 \
+  && python setup.py install
+
+RUN pip --version && pip install --quiet -r requirements.txt


### PR DESCRIPTION
This works around the "Cannot fetch index base URL http://pypi.python.org/simple/"
error by installing pip==9.0.1 directly from the pypi.python.org/packages/

Change-Type: patch