### PR TITLE
chore(scripts): Update Dockerfiles' base to Ubuntu 16.04

### DIFF
--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -20,23 +20,24 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libnss3 \
     libudev-dev \
     libusb-1.0-0-dev \
-    libnss3 \
     libx11-xcb1 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
     python \
-    python-pip \
     python-dev \
+    python-pip \
     python-software-properties \
+    rpm \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \
     xz-utils \
-    zip \
-    rpm
+    zip
 
 
 

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,4 +1,4 @@
-FROM erwinchang/ubuntu-12.04-32bit-build
+FROM erwinchang/ubuntu-16.04-32bit-build
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -21,23 +21,24 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libnss3 \
     libudev-dev \
     libusb-1.0-0-dev \
-    libnss3 \
     libx11-xcb1 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
     python \
-    python-pip \
     python-dev \
+    python-pip \
     python-software-properties \
+    rpm \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \
     xz-utils \
-    zip \
-    rpm
+    zip
 
 
 # Install a C++11 compiler

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -1,4 +1,4 @@
-FROM erwinchang/ubuntu-16.04-32bit-build
+FROM ioft/i386-ubuntu:16.04
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -20,23 +20,24 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libnss3 \
     libudev-dev \
     libusb-1.0-0-dev \
-    libnss3 \
     libx11-xcb1 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
     python \
-    python-pip \
     python-dev \
+    python-pip \
     python-software-properties \
+    rpm \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \
     xz-utils \
-    zip \
-    rpm
+    zip
 
 
 # Install a C++11 compiler

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 # Setup APT sources
 
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list
 
 
 

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:16.04
 
 # Setup APT sources
 

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -6,7 +6,7 @@ RUN sed s,ubuntu\.stu\.edu\.tw,archive.ubuntu.com, /etc/apt/sources.list > /tmp/
   && mv /tmp/sources.list /etc/apt/sources.list
 <% } %>
 <% if (architecture == 'x86_64') { %>
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-backports main restricted universe multiverse" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list
 <% } %>
 <% if (architecture == 'armv7hf') { %>
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -25,23 +25,24 @@ RUN apt-get update \
     libasound2 \
     libgconf-2-4 \
     libgtk2.0-0 \
+    libnss3 \
     libudev-dev \
     libusb-1.0-0-dev \
-    libnss3 \
     libx11-xcb1 \
     libxss1 \
     libxtst6 \
     libyaml-dev \
     python \
-    python-pip \
     python-dev \
+    python-pip \
     python-software-properties \
+    rpm \
+    software-properties-common \
     unzip \
     xorriso \
     xvfb \
     xz-utils \
-    zip \
-    rpm
+    zip
 
 <% if (architecture != 'armv7hf') { %>
 # Install a C++11 compiler

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,11 +31,11 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'erwinchang/ubuntu-12.04-32bit-build'
+    image: 'erwinchang/ubuntu-16.04-32bit-build'
   },
   {
     architecture: 'x86_64',
-    image: 'ubuntu:12.04'
+    image: 'ubuntu:16.04'
   },
   {
     architecture: 'armv7hf',

--- a/scripts/build/docker/compile-template.js
+++ b/scripts/build/docker/compile-template.js
@@ -31,7 +31,7 @@ const template = fs.readFileSync(path.join(currentDirectory, 'Dockerfile.templat
 _.each([
   {
     architecture: 'i686',
-    image: 'erwinchang/ubuntu-16.04-32bit-build'
+    image: 'ioft/i386-ubuntu:16.04'
   },
   {
     architecture: 'x86_64',


### PR DESCRIPTION
This updates the docker base images from Ubuntu 12.04 to the current LTS, Ubuntu 16.04.

Change-Type: patch