### PR TITLE
fix: Correct image.size usage in tests and code-comments

### DIFF
--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -41,7 +41,13 @@ module.exports = function (
    * @example
    * FlashController.flashImageToDrive({
    *   path: 'rpi.img',
-   *   size: 1000000000
+   *   size: {
+   *     original: 1000000000,
+   *     final: {
+   *       estimation: false,
+   *       value: 1000000000
+   *     }
+   *   }
    * }, {
    *   device: '/dev/disk2',
    *   description: 'Foo',

--- a/lib/shared/drive-constraints.js
+++ b/lib/shared/drive-constraints.js
@@ -102,7 +102,13 @@ exports.isSystemDrive = (drive) => {
  *   ]
  * }, {
  *   path: '/Volumes/Untitled/image.img',
- *   size: 1000000000
+ *   size: {
+ *     original: 1000000000,
+ *     final: {
+ *       estimation: false,
+ *       value: 1000000000
+ *     }
+ *   }
  * })) {
  *   console.log('This drive is a source drive!');
  * }
@@ -136,7 +142,13 @@ exports.isSourceDrive = (drive, image) => {
  *   size: 1000000000
  * }, {
  *   path: 'rpi.img',
- *   size: 1000000000
+ *   size: {
+ *     original: 1000000000,
+ *     final: {
+ *       estimation: false,
+ *       value: 1000000000
+ *     }
+ *   },
  * })) {
  *   console.log('We can flash the image to this drive!');
  * }
@@ -206,7 +218,13 @@ exports.isDriveDisabled = (drive) => {
  *   protected: false
  * }, {
  *   path: 'rpi.img',
- *   size: 1000000000,
+ *   size: {
+ *     original: 1000000000,
+ *     final: {
+ *       estimation: false,
+ *       value: 1000000000
+ *     }
+ *   },
  *   recommendedDriveSize: 2000000000
  * })) {
  *   console.log('This drive is valid!');
@@ -242,7 +260,13 @@ exports.isDriveValid = (drive, image) => {
  *
  * const image = {
  *   path: 'rpi.img',
- *   size: 2000000000
+ *   size: {
+ *     original: 2000000000,
+ *     final: {
+ *       estimation: false,
+ *       value: 2000000000
+ *     }
+ *   },
  *   recommendedDriveSize: 4000000000
  * });
  *
@@ -347,7 +371,13 @@ exports.COMPATIBILITY_STATUS_TYPES = {
  *
  * const image = {
  *   path: '/path/to/rpi.img',
- *   size: 2000000000
+ *   size: {
+ *     original: 2000000000,
+ *     final: {
+ *       estimation: false,
+ *       value: 2000000000
+ *     }
+ *   },
  *   recommendedDriveSize: 4000000000
  * });
  *

--- a/lib/shared/models/selection-state.js
+++ b/lib/shared/models/selection-state.js
@@ -64,7 +64,14 @@ exports.toggleSetDrive = (drive) => {
  *
  * @example
  * selectionState.setImage({
- *   path: 'foo.img'
+ *   path: 'foo.img',
+ *   size: {
+ *     original: 1000000000,
+ *     final: {
+ *       estimation: false,
+ *       value: 1000000000
+ *     }
+ *   }
  * });
  */
 exports.setImage = (image) => {

--- a/tests/shared/drive-constraints.spec.js
+++ b/tests/shared/drive-constraints.spec.js
@@ -325,14 +325,14 @@ describe('Shared: DriveConstraints', function () {
             size: {
               original: this.drive.size - 1,
               final: {
-                estimation: false
+                estimation: false,
+                value: this.drive.size - 1
               }
             }
           }
         })
 
         it('should return true if the final size is less than the drive size', function () {
-          this.image.size.final.value = this.drive.size - 1
           m.chai.expect(constraints.isDriveLargeEnough(this.drive, this.image)).to.be.true
         })
 
@@ -354,7 +354,8 @@ describe('Shared: DriveConstraints', function () {
             size: {
               original: this.drive.size,
               final: {
-                estimation: false
+                estimation: false,
+                value: this.drive.size
               }
             }
           }
@@ -366,7 +367,6 @@ describe('Shared: DriveConstraints', function () {
         })
 
         it('should return true if the final size is equal to the drive size', function () {
-          this.image.size.final.value = this.drive.size
           m.chai.expect(constraints.isDriveLargeEnough(this.drive, this.image)).to.be.true
         })
 
@@ -383,7 +383,8 @@ describe('Shared: DriveConstraints', function () {
             size: {
               original: this.drive.size + 1,
               final: {
-                estimation: false
+                estimation: false,
+                value: this.drive.size + 1
               }
             }
           }
@@ -400,7 +401,6 @@ describe('Shared: DriveConstraints', function () {
         })
 
         it('should return false if the final size is greater than the drive size', function () {
-          this.image.size.final.value = this.drive.size + 1
           m.chai.expect(constraints.isDriveLargeEnough(this.drive, this.image)).to.be.false
         })
       })
@@ -414,14 +414,14 @@ describe('Shared: DriveConstraints', function () {
             size: {
               original: this.drive.size - 1,
               final: {
-                estimation: true
+                estimation: true,
+                value: this.drive.size - 1
               }
             }
           }
         })
 
         it('should return true if the final size is less than the drive size', function () {
-          this.image.size.final.value = this.drive.size - 1
           m.chai.expect(constraints.isDriveLargeEnough(this.drive, this.image)).to.be.true
         })
 
@@ -443,7 +443,8 @@ describe('Shared: DriveConstraints', function () {
             size: {
               original: this.drive.size,
               final: {
-                estimation: true
+                estimation: true,
+                value: this.drive.size
               }
             }
           }
@@ -455,7 +456,6 @@ describe('Shared: DriveConstraints', function () {
         })
 
         it('should return true if the final size is equal to the drive size', function () {
-          this.image.size.final.value = this.drive.size
           m.chai.expect(constraints.isDriveLargeEnough(this.drive, this.image)).to.be.true
         })
 
@@ -472,7 +472,8 @@ describe('Shared: DriveConstraints', function () {
             size: {
               original: this.drive.size + 1,
               final: {
-                estimation: true
+                estimation: true,
+                value: this.drive.size + 1
               }
             }
           }
@@ -489,7 +490,6 @@ describe('Shared: DriveConstraints', function () {
         })
 
         it('should return false if the final size is greater than the drive size', function () {
-          this.image.size.final.value = this.drive.size + 1
           m.chai.expect(constraints.isDriveLargeEnough(this.drive, this.image)).to.be.false
         })
       })
@@ -573,7 +573,13 @@ describe('Shared: DriveConstraints', function () {
         protected: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
-        size: 1000000000,
+        size: {
+          original: 1000000000,
+          final: {
+            estimation: false,
+            value: 1000000000
+          }
+        },
         recommendedDriveSize: 2000000000
       })
 
@@ -588,7 +594,13 @@ describe('Shared: DriveConstraints', function () {
         protected: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
-        size: 1000000000,
+        size: {
+          original: 1000000000,
+          final: {
+            estimation: false,
+            value: 1000000000
+          }
+        },
         recommendedDriveSize: 2000000000
       })
 
@@ -603,7 +615,13 @@ describe('Shared: DriveConstraints', function () {
         protected: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
-        size: 1000000000,
+        size: {
+          original: 1000000000,
+          final: {
+            estimation: false,
+            value: 1000000000
+          }
+        },
         recommendedDriveSize: 2000000001
       })
 
@@ -618,7 +636,13 @@ describe('Shared: DriveConstraints', function () {
         protected: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
-        size: 1000000000
+        size: {
+          original: 1000000000,
+          final: {
+            estimation: false,
+            value: 1000000000
+          }
+        }
       })
 
       m.chai.expect(result).to.be.true
@@ -627,7 +651,13 @@ describe('Shared: DriveConstraints', function () {
     it('should return false if the drive is undefined', function () {
       const result = constraints.isDriveSizeRecommended(undefined, {
         path: path.join(__dirname, 'rpi.img'),
-        size: 1000000000,
+        size: {
+          original: 1000000000,
+          final: {
+            estimation: false,
+            value: 1000000000
+          }
+        },
         recommendedDriveSize: 1000000000
       })
 
@@ -945,7 +975,8 @@ describe('Shared: DriveConstraints', function () {
         size: {
           original: this.drive.size - 1,
           final: {
-            estimation: false
+            estimation: false,
+            value: this.drive.size - 1
           }
         }
       }
@@ -966,10 +997,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given there are no errors or warnings', () => {
       it('should return an empty list', function () {
-        const result = constraints.getDriveImageCompatibilityStatuses(this.drive, {
-          path: '/mnt/disk2/rpi.img',
-          size: 1000000000
-        })
+        const result = constraints.getDriveImageCompatibilityStatuses(this.drive, this.image)
 
         m.chai.expect(result).to.deep.equal([])
       })
@@ -978,10 +1006,7 @@ describe('Shared: DriveConstraints', function () {
     describe('given the drive is disabled', () => {
       it('should return an empty list', function () {
         this.drive.disabled = true
-        const result = constraints.getDriveImageCompatibilityStatuses(this.drive, {
-          path: '/mnt/disk2/rpi.img',
-          size: 1000000000
-        })
+        const result = constraints.getDriveImageCompatibilityStatuses(this.drive, this.image)
 
         const expectedTuples = []
         expectStatusTypesAndMessagesToBe(result, expectedTuples)


### PR DESCRIPTION
image.size is always an object, never a plain number

Change-type: patch