### PR TITLE
minifix: remove duplicate debug enable in usbboot

### DIFF
--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -31,8 +31,6 @@ const utils = require('../../utils')
 
 debug.enabled = true
 
-debug.enabled = true
-
 /**
  * @summary The radix used by USB ID numbers
  * @type {Number}


### PR DESCRIPTION
Changelog-Entry: Remove duplicate debug enabling in usbboot module.
Change-Type: patch