### PR TITLE
fix(SDK): disable usbboot adapter on GNU/Linux

### DIFF
--- a/lib/shared/sdk/index.js
+++ b/lib/shared/sdk/index.js
@@ -20,6 +20,7 @@ const EventEmitter = require('events')
 const _ = require('lodash')
 const SDK = module.exports
 const debug = require('debug')('sdk')
+const os = require('os')
 
 debug.enabled = true
 
@@ -29,9 +30,15 @@ debug.enabled = true
  * @constant
  */
 const ADAPTERS = [
-  require('./standard'),
-  require('./usbboot')
+  require('./standard')
 ]
+
+// We don't support usbboot on GNU/Linux yet, given
+// that some distributions require root permissions
+// to open USB devices.
+if (os.platform() !== 'linux') {
+  ADAPTERS.push(require('./usbboot'))
+}
 
 /**
  * @summary Initialised adapters
@@ -90,7 +97,8 @@ SDK.Scanner = class Scanner extends EventEmitter {
         _.get(this.options, [ 'adapters', adapterId ])
 
       if (_.isNil(adapter)) {
-        throw new Error(`Unknown adapter "${adapterId}"`)
+        console.warn(`Unknown adapter "${adapterId}"`)
+        return
       }
 
       this.subscribe(adapter)


### PR DESCRIPTION
Various GNU/Linux distributions require root access to be able to open
USB devices. This means that Etcher would need to be ran as root, which
is now not possible on Wayland based systems.

We declare usbboot as unsupported on GNU/Linux from the time being, but
we are currently working on a solution.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>