### PR TITLE
fix(versionist): Ignore case of Change-Type value

### DIFF
--- a/versionist.conf.js
+++ b/versionist.conf.js
@@ -38,7 +38,11 @@ module.exports = {
   },
 
   getIncrementLevelFromCommit: (commit) => {
-    return commit.footer['Change-Type']
+    if (/none/i.test(commit.footer['Change-Type'])) {
+      return null
+    }
+    return commit.footer['Change-Type'] &&
+      _.toLower(commit.footer['Change-Type'])
   },
 
   transformTemplateData: (data) => {


### PR DESCRIPTION
There's a commit that slipped in (sorry) with a capitalised
Change-Type value of "Patch". This avoids versionist erroring,
by always lowercasing that value.

Change-Type: PATCH