### PR TITLE
fix(child-writer): Ensure tmpdir path has trailing slash

### DIFF
--- a/lib/child-writer/constants.js
+++ b/lib/child-writer/constants.js
@@ -31,7 +31,7 @@ module.exports = {
    * @memberof CONSTANTS
    * @constant
    */
-  TMP_DIRECTORY: process.env.XDG_RUNTIME_DIR || os.tmpdir(),
+  TMP_DIRECTORY: path.join(process.env.XDG_RUNTIME_DIR || os.tmpdir(), path.sep),
 
   /**
    * @property {String} PROJECT_ROOT


### PR DESCRIPTION
There's a bug in node-ipc which doesn't allow it to handle
tmpdirs without trailing slashes; this works around this bug.

Change-Type: patch
Connects To: #1340 #1690 
Changelog-Entry: Fix "hangs on starting" bug