### PR TITLE
fix(store): Fix "Missing state eta" error on Infinity/NaN

### DIFF
--- a/lib/writer/progress-stream.js
+++ b/lib/writer/progress-stream.js
@@ -70,7 +70,10 @@ class ProgressStream extends Stream.Transform {
       this.state.remaining = this.state.length - this.state.transferred
       this.state.runtime = Date.now() - this.start
       this.state.speed = this.meter(this.state.delta)
-      this.state.eta = this.state.remaining / this.state.speed
+
+      // NOTE: We need to guard against this becoming Infinity,
+      // because that value isn't transmitted properly over IPC and becomes `null`
+      this.state.eta = this.state.speed ? this.state.remaining / this.state.speed : 0
       this.delta = 0
       this.emit('progress', this.state)
     }


### PR DESCRIPTION
If the speed is zero, the eta becomes Infinity, which isn't transmitted
properly over IPC for at this time unknown reasons.
To prevent the "Missing state eta" error from popping up when the speed is
zero, we set the eta to zero as well in those cases.

Change-Type: patch
Changelog-Entry: Fix "Missing state eta" error when speed is zero