### PR TITLE
fix(drive-scanner): Dynamically get unsafe mode setting

### DIFF
--- a/lib/gui/modules/drive-scanner.js
+++ b/lib/gui/modules/drive-scanner.js
@@ -32,7 +32,9 @@ const BLOBS_DIRECTORY = path.join(__dirname, '..', '..', 'blobs')
 
 const scanner = SDK.createScanner({
   standard: {
-    includeSystemDrives: settings.get('unsafeMode')
+    get includeSystemDrives () {
+      return settings.get('unsafeMode')
+    }
   },
   usbboot: {
     readFile: (name) => {


### PR DESCRIPTION
Due to the SDK keeping it's options once initialized,
the unsafe mode setting change was not reflected on subsequent scans.

Change-Type: patch