### PR TITLE
fix(writer): Don't calcluate checksum before block-stream

### DIFF
--- a/lib/writer/checksum-stream.js
+++ b/lib/writer/checksum-stream.js
@@ -121,7 +121,7 @@ class ChecksumStream extends stream.Transform {
       })
     }
 
-    return this.pipe(hash)
+    return hash
   }
 
   /**
@@ -134,8 +134,24 @@ class ChecksumStream extends stream.Transform {
    * checksumStream.write(buffer)
    */
   _transform (chunk, encoding, next) {
-    this.push(chunk)
-    next()
+    for (let index = 0; index < this.hashes.length; index += 1) {
+      this.hashes[index].write(chunk)
+    }
+    next(null, chunk)
+  }
+
+  /**
+   * @summary End the hash streams once this stream ends
+   * @private
+   * @param {Function} done - callback
+   * @example
+   * checksumStream.end()
+   */
+  _flush (done) {
+    for (let index = 0; index < this.hashes.length; index += 1) {
+      this.hashes[index].end()
+    }
+    done()
   }
 }
 

--- a/lib/writer/index.js
+++ b/lib/writer/index.js
@@ -206,11 +206,12 @@ class ImageWriter extends EventEmitter {
     } else {
       debug('write:blockstream')
       const checksumStream = new ChecksumStream({
+        objectMode: true,
         algorithms: options.checksumAlgorithms
       })
+      pipeline.append(new BlockStream())
       pipeline.append(checksumStream)
       pipeline.bind(checksumStream, 'checksum')
-      pipeline.append(new BlockStream())
     }
 
     const target = new BlockWriteStream({


### PR DESCRIPTION
The checksum-stream being situated in front of the block-stream, which
ensures block size alignment to multiples of 512, and pads the last block,
caused the checksum to be incorrectly calculated for images where the last
block needed to be padded.

Change-Type: patch