### PR TITLE
fix(writer): Emit checksum event when verifying bmaps

### DIFF
--- a/lib/writer/index.js
+++ b/lib/writer/index.js
@@ -271,7 +271,15 @@ class ImageWriter extends EventEmitter {
     if (options.image.bmap) {
       debug('verify:bmap')
       const blockMap = BlockMap.parse(options.image.bmap)
-      pipeline.append(new BlockMap.FilterStream(blockMap))
+      const blockMapStream = new BlockMap.FilterStream(blockMap)
+      pipeline.append(blockMapStream)
+
+      // NOTE: Because the blockMapStream checksums each range,
+      // and doesn't emit a final "checksum" event, we artificially
+      // raise one once the stream finishes
+      blockMapStream.once('finish', () => {
+        pipeline.emit('checksum', {})
+      })
     } else {
       const checksumStream = new ChecksumStream({
         algorithms: options.checksumAlgorithms


### PR DESCRIPTION
Due to the Blockmap.FilterStream not emitting a "checksum"
event (as it individually verifies specified ranges), the
flashing process would get stuck on finish.

This emits a "checksum" event on "finish" when blockmapping,
averting this issue.

Change-Type: patch