### PR TITLE
upgrade(package): Bump sudo-prompt 6.1.0 -> 8.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9560,9 +9560,9 @@
       "dev": true
     },
     "sudo-prompt": {
-      "version": "6.1.0",
-      "from": "sudo-prompt@6.1.0",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-6.1.0.tgz"
+      "version": "8.0.0",
+      "from": "sudo-prompt@8.0.0",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.0.0.tgz"
     },
     "sumchecker": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "resin-corvus": "1.0.0-beta.30",
     "semver": "5.1.1",
     "speedometer": "1.0.0",
-    "sudo-prompt": "6.1.0",
+    "sudo-prompt": "8.0.0",
     "trackjs": "2.3.1",
     "udif": "0.10.0",
     "unbzip2-stream": "1.0.11",


### PR DESCRIPTION
This updates `sudo-prompt` from v6.1.0 to v8.0.0

Changes:

- v8.0.0:
  - Breaking: Windows: Set code page of command batch script to UTF-8
- v7.1.1:
  - readme: explicitly mention that no child process is returned
- v7.1.0:
  - Detect when PowerShell fails to launch command
  - Escape ampersand and other characters special to PowerShell
- v7.0.0:
  - Add status code to error on Windows and macOS
- v6.2.0:
  - Rename OS X to macOS

Tested on:

- [x] Mac OS
- [x] Windows
- [x] Linux

Change-Type: patch