### PR TITLE
fix(writer): Use a core streams variant of unbzip2-stream

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -452,11 +452,6 @@
       "from": "balanced-match@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
-    "base64-js": {
-      "version": "0.0.8",
-      "from": "base64-js@0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
@@ -609,18 +604,6 @@
       "from": "browser-stdout@1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "dev": true
-    },
-    "buffer": {
-      "version": "3.6.0",
-      "from": "buffer@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        }
-      }
     },
     "buffer-crc32": {
       "version": "0.2.5",
@@ -3042,11 +3025,6 @@
       "version": "0.4.15",
       "from": "iconv-lite@>=0.4.5 <0.5.0",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-    },
-    "ieee754": {
-      "version": "1.1.6",
-      "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
     },
     "ignore": {
       "version": "3.2.6",
@@ -9992,9 +9970,9 @@
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "1.0.11",
-      "from": "unbzip2-stream@1.0.11",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.0.11.tgz"
+      "version": "1.2.5",
+      "from": "resin-io-modules/unbzip2-stream#core-streams",
+      "resolved": "git://github.com/resin-io-modules/unbzip2-stream.git#f33fe81c5379675f2a9898e7b86886a68c32ccc8"
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "sudo-prompt": "6.1.0",
     "trackjs": "2.3.1",
     "udif": "0.10.0",
-    "unbzip2-stream": "1.0.11",
+    "unbzip2-stream": "github:resin-io-modules/unbzip2-stream#core-streams",
     "usb": "github:tessel/node-usb#1.3.0",
     "uuid": "3.0.1",
     "xml2js": "0.4.17",


### PR DESCRIPTION
This fixes pipage blowing up on unbzip2-stream because it's
based on through streams (which don't implement `.unpipe()`),
by utilizing a custom version based on core streams.

Change-Type: patch
Changelog-Entry: Fix bzip2 streaming with the new pipelines