### PR TITLE
feat(writer): Display actual write speed

### DIFF
--- a/lib/writer/block-write-stream.js
+++ b/lib/writer/block-write-stream.js
@@ -18,9 +18,11 @@
 
 const stream = require('readable-stream')
 const fs = require('fs')
+const speedometer = require('speedometer')
 const debug = require('debug')('block-write-stream')
 
 const CHUNK_SIZE = 64 * 1024
+const UPDATE_INTERVAL_MS = 500
 
 /**
  * @summary BlockWriteStream
@@ -60,6 +62,23 @@ class BlockWriteStream extends stream.Writable {
     this.blocksRead = 0
     this.bytesWritten = 0
     this.blocksWritten = 0
+    this.meter = speedometer()
+    this.delta = 0
+    this.speed = 0
+
+    this.clear = () => {
+      clearInterval(this.timer)
+    }
+
+    this.update = () => {
+      this.speed = this.meter(this.delta)
+      this.delta = 0
+    }
+
+    this.once('end', this.clear)
+    this.once('error', this.clear)
+
+    this.timer = setInterval(this.update, UPDATE_INTERVAL_MS)
 
     this.closed = false
     this.destroyed = false
@@ -116,6 +135,7 @@ class BlockWriteStream extends stream.Writable {
 
     fs.write(this.fd, chunk, 0, chunk.length, chunk.position, (error, bytesWritten) => {
       this.bytesWritten += bytesWritten
+      this.delta += bytesWritten
       this.blocksWritten += 1
       this.position += bytesWritten
       next(error)

--- a/lib/writer/index.js
+++ b/lib/writer/index.js
@@ -226,6 +226,7 @@ class ImageWriter extends EventEmitter {
     progressStream.on('progress', (state) => {
       state.device = options.path
       state.type = 'write'
+      state.speed = target.speed
       this.emit('progress', state)
     })
 


### PR DESCRIPTION
As we've actually been displaying the read-speed in various
forms during the flashing process, this is a venture into
displaying the actual write-speed from the end of the pipeline.

Change-Type: minor
Changelog-Entry: Display actual write speed