### PR TITLE
fix(writer): Fix verify size for unaligned images

### DIFF
--- a/lib/writer/index.js
+++ b/lib/writer/index.js
@@ -260,7 +260,11 @@ class ImageWriter extends EventEmitter {
   _createVerifyPipeline (options) {
     const pipeline = new Pipage()
 
-    const size = options.image.size.final.estimation ? this.bytesWritten : options.image.size.final.value
+    let size = this.bytesWritten
+
+    if (!options.image.size.final.estimation) {
+      size = Math.max(this.bytesWritten, options.image.size.final.value)
+    }
 
     const progressStream = new ProgressStream({
       length: size,


### PR DESCRIPTION
This fixes read-lengths during verification for images that don't align to a 512 multiple.

Change-Type: patch