### PR TITLE
fix(child-writer): Reduce env vars passed during elevation

### DIFF
--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -101,7 +101,10 @@ permissions.isElevated().then((elevated) => {
     // For debugging purposes
     console.log(`Running: ${commandArguments.join(' ')}`)
 
-    const commandEnv = _.assign({}, process.env, {
+    const commandEnv = {
+      PATH: process.env.PATH,
+      DEBUG: process.env.DEBUG,
+      XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR,
       ELECTRON_RUN_AS_NODE: 1,
       IPC_SERVER_ID: process.env.IPC_SERVER_ID,
       IPC_CLIENT_ID: process.env.IPC_CLIENT_ID,
@@ -110,8 +113,7 @@ permissions.isElevated().then((elevated) => {
       // desktop integration script from presenting the
       // "installation" dialog.
       SKIP: 1
-
-    })
+    }
 
     return permissions.elevateCommand(commandArguments, {
       applicationName: packageJSON.displayName,
@@ -176,11 +178,6 @@ permissions.isElevated().then((elevated) => {
       ipc.of[process.env.IPC_SERVER_ID].on('connect', () => {
         // Inherit the parent evnironment
         const childEnv = _.assign({}, process.env, {
-
-          // The CLI might call operating system utilities (like `diskutil`),
-          // so we must ensure the `PATH` is inherited.
-          PATH: process.env.PATH,
-
           ELECTRON_RUN_AS_NODE: 1,
           ETCHER_CLI_ROBOT: 1,
 


### PR DESCRIPTION
As we're not escaping env vars properly in `permissions.getEnvironmentCommandPrefix()`,
passing the entire environment along can cause another instance of the "stuck at starting"
problem, thus we limit the vars explicitly passed along again, keeping PATH and DEBUG.

Tested on:

- [x] Windows
- [x] Mac OS
- [ ] Linux

Change-Type: patch
Connects To: #1851 