### PR TITLE
fix(child-writer): Kill child process chain on exit

### DIFF
--- a/lib/child-writer/index.js
+++ b/lib/child-writer/index.js
@@ -75,6 +75,7 @@ class ChildWriter extends EventEmitter {
     this.child = null
 
     this.on('close', () => {
+      debug('close')
       this.aborting = false
       ChildWriter.currentInstance = null
     })
@@ -90,6 +91,7 @@ class ChildWriter extends EventEmitter {
    * child.on('error', this.onError)
    */
   onError (error) {
+    debug('onError', error)
     this.abort()
     this.emit('error', error)
   }
@@ -105,9 +107,10 @@ class ChildWriter extends EventEmitter {
    * child.on('exit', this.onExit)
    */
   onExit (code, signal) {
-    this.terminateServer()
+    debug('onExit', code, signal)
 
     if (code === EXIT_CODES.CANCELLED) {
+      this.terminateServer()
       this.emit('done', {
         cancelled: true
       })
@@ -117,6 +120,7 @@ class ChildWriter extends EventEmitter {
     // We shouldn't emit the `done` event manually here
     // since the writer process will take care of it.
     if (code === EXIT_CODES.SUCCESS || code === EXIT_CODES.VALIDATION_ERROR) {
+      this.terminateServer()
       return
     }
 

--- a/lib/child-writer/index.js
+++ b/lib/child-writer/index.js
@@ -16,7 +16,7 @@
 
 'use strict'
 
-const EventEmitter = require('events').EventEmitter
+const EventEmitter = require('events')
 const _ = require('lodash')
 const childProcess = require('child_process')
 const ipc = require('node-ipc')
@@ -25,6 +25,7 @@ const cli = require('./cli')
 const CONSTANTS = require('./constants')
 const EXIT_CODES = require('../shared/exit-codes')
 const robot = require('../shared/robot')
+const debug = require('debug')('child-writer')
 
 // There might be multiple Etcher instances running at
 // the same time, therefore we must ensure each IPC
@@ -37,96 +38,107 @@ ipc.config.socketRoot = CONSTANTS.TMP_DIRECTORY
 ipc.config.silent = true
 
 /**
- * @summary Perform a write
- * @function
- * @public
- *
- * @param {String} image - image
- * @param {Object} drive - drive
- * @param {Object} options - options
- * @returns {EventEmitter} event emitter
- *
- * @example
- * const child = childWriter.write('path/to/rpi.img', {
- *   device: '/dev/disk2'
- * }, {
- *   validateWriteOnSuccess: true,
- *   unmountOnSuccess: true
- * });
- *
- * child.on('progress', (state) => {
- *   console.log(state);
- * });
- *
- * child.on('error', (error) => {
- *   throw error;
- * });
- *
- * child.on('done', () => {
- *   console.log('Validation was successful!');
- * });
+ * @summary ChildWriter class
+ * @class
+ * @extends {EventEmitter}
  */
-exports.write = (image, drive, options) => {
-  const emitter = new EventEmitter()
-
-  const argv = cli.getArguments({
-    entryPoint: rendererUtils.getApplicationEntryPoint(),
-    image,
-    device: drive.device,
-    validateWriteOnSuccess: options.validateWriteOnSuccess,
-    unmountOnSuccess: options.unmountOnSuccess
-  })
-
-  ipc.serve()
-
+class ChildWriter extends EventEmitter {
   /**
-   * @summary Safely terminate the IPC server
-   * @function
-   * @private
+   * @summary ChildWriter constructor
+   * @class
    *
    * @example
-   * terminateServer();
+   * var childWriter = new ChildWriter()
+   *
+   * childWriterwrite('path/to/rpi.img', {
+   *   device: '/dev/disk2'
+   * }, {
+   *   validateWriteOnSuccess: true,
+   *   unmountOnSuccess: true
+   * })
+   *
+   * child.on('done', () => {
+   *   console.log('Validation was successful!')
+   * })
    */
-  const terminateServer = () => {
-    // Turns out we need to destroy all sockets for
-    // the server to actually close. Otherwise, it
-    // just stops receiving any further connections,
-    // but remains open if there are active ones.
-    _.each(ipc.server.sockets, (socket) => {
-      socket.destroy()
-    })
+  constructor () {
+    super()
 
-    ipc.server.stop()
+    // NOTE: These need binding to this context,
+    // so we can pass them through as event handlers,
+    // and remove them at a later stage again
+    this.onError = this.onError.bind(this)
+    this.onExit = this.onExit.bind(this)
+    this.bridgeRobotMessage = this.bridgeRobotMessage.bind(this)
+
+    this.aborting = false
+    this.child = null
+
+    this.on('close', () => {
+      this.aborting = false
+      ChildWriter.currentInstance = null
+    })
   }
 
   /**
-   * @summary Emit an error to the client
-   * @function
+   * @summary Error handler
    * @private
    *
    * @param {Error} error - error
    *
    * @example
-   * emitError(new Error('foo bar'));
+   * child.on('error', this.onError)
    */
-  const emitError = (error) => {
-    terminateServer()
-    emitter.emit('error', error)
+  onError (error) {
+    this.abort()
+    this.emit('error', error)
+  }
+
+  /**
+   * @summary Child process exit handler
+   * @private
+   *
+   * @param {Number} code - exit code
+   * @param {String} signal - signal
+   *
+   * @example
+   * child.on('exit', this.onExit)
+   */
+  onExit (code, signal) {
+    this.terminateServer()
+
+    if (code === EXIT_CODES.CANCELLED) {
+      this.emit('done', {
+        cancelled: true
+      })
+      return
+    }
+
+    // We shouldn't emit the `done` event manually here
+    // since the writer process will take care of it.
+    if (code === EXIT_CODES.SUCCESS || code === EXIT_CODES.VALIDATION_ERROR) {
+      return
+    }
+
+    const error = new Error(`Child process exited with code ${code}, signal ${signal}`)
+    error.code = code
+    error.signal = signal
+
+    this.onError(error)
   }
 
   /**
    * @summary Bridge robot message to the child writer caller
-   * @function
    * @private
    *
    * @param {String} message - robot message
    *
    * @example
-   * bridgeRobotMessage(robot.buildMessage('foo', {
+   * this.bridgeRobotMessage(robot.buildMessage('foo', {
    *   bar: 'baz'
-   * }));
+   * }))
    */
-  const bridgeRobotMessage = (message) => {
+  bridgeRobotMessage (message) {
     const parsedMessage = _.attempt(() => {
       if (robot.isMessage(message)) {
         return robot.parseMessage(message)
@@ -141,7 +153,7 @@ exports.write = (image, drive, options) => {
     })
 
     if (_.isError(parsedMessage)) {
-      emitError(parsedMessage)
+      this.onError(parsedMessage)
       return
     }
 
@@ -155,7 +167,7 @@ exports.write = (image, drive, options) => {
       // purposes. We compose it back to an `Error` here in order
       // to provide better encapsulation.
       if (messageCommand === robot.COMMAND.ERROR) {
-        emitError(robot.recomposeErrorMessage(parsedMessage))
+        this.onError(robot.recomposeErrorMessage(parsedMessage))
       } else if (messageCommand === robot.COMMAND.LOG) {
         // If the message data is an object and it contains a
         // message string then log the message string only.
@@ -165,59 +177,222 @@ exports.write = (image, drive, options) => {
           console.log(messageData)
         }
       } else {
-        emitter.emit(messageCommand, messageData)
+        this.emit(messageCommand, messageData)
       }
     } catch (error) {
-      emitError(error)
+      this.onError(error)
     }
   }
 
-  ipc.server.on('error', emitError)
-  ipc.server.on('message', bridgeRobotMessage)
+  /**
+   * @summary Safely terminate the IPC server
+   * @private
+   *
+   * @param {Function} [callback] - callback
+   *
+   * @example
+   * this.terminateServer()
+   */
+  terminateServer (callback) {
+    debug('terminate-server')
 
-  ipc.server.on('start', () => {
-    const child = childProcess.fork(CONSTANTS.WRITER_PROXY_SCRIPT, argv, {
-      silent: true,
-      env: process.env
+    // NOTE: node-ipc's server never actually emits a "close" event
+    // on it's own server, because it's not hooked up, so we try and
+    // get a hold of the underlying server;
+    // otherwise there isn't much we can do about it
+    if (ipc.server.server) {
+      ipc.server.server.once('close', () => {
+        debug('terminate-server:close')
+        this.emit('close')
+        callback && callback()
+      })
+    } else {
+      process.nextTick(() => {
+        debug('terminate-server:fake-close')
+        this.emit('close')
+        callback && callback()
+      })
+    }
+
+    // Turns out we need to destroy all sockets for
+    // the server to actually close. Otherwise, it
+    // just stops receiving any further connections,
+    // but remains open if there are active ones.
+    _.each(ipc.server.sockets, (socket) => {
+      socket.destroy()
     })
 
-    child.stdout.on('data', (data) => {
-      console.info(`WRITER: ${data.toString()}`)
+    ipc.server.stop()
+  }
+
+  /**
+   * @summary Perform a write
+   * @public
+   *
+   * @param {String} image - image
+   * @param {Object} drive - drive
+   * @param {Object} options - options
+   * @returns {ChildWriter} childWriter
+   *
+   * @example
+   * See `ChildWriter.write()`
+   */
+  write (image, drive, options) {
+    const argv = cli.getArguments({
+      entryPoint: rendererUtils.getApplicationEntryPoint(),
+      image,
+      device: drive.device,
+      validateWriteOnSuccess: options.validateWriteOnSuccess,
+      unmountOnSuccess: options.unmountOnSuccess
     })
 
-    child.stderr.on('data', (data) => {
-      bridgeRobotMessage(data.toString())
+    ipc.serve()
 
-      // This function causes the `close` event to be emitted
-      child.kill()
+    ipc.server.on('error', this.onError)
+    ipc.server.on('message', this.bridgeRobotMessage)
+
+    ipc.server.once('start', () => {
+      this.child = childProcess.fork(CONSTANTS.WRITER_PROXY_SCRIPT, argv, {
+        silent: true,
+        env: process.env
+      })
+
+      this.child.stdout.on('data', (data) => {
+        console.info(`WRITER: ${data.toString()}`)
+      })
+
+      this.child.stderr.on('data', (data) => {
+        this.bridgeRobotMessage(data.toString())
+        this.abort()
+      })
+
+      this.child.on('error', this.onError)
+      this.child.on('exit', this.onExit)
     })
 
-    child.on('error', emitError)
+    ipc.server.start()
 
-    child.on('exit', (code, signal) => {
-      terminateServer()
+    return this
+  }
 
-      if (code === EXIT_CODES.CANCELLED) {
-        return emitter.emit('done', {
-          cancelled: true
-        })
+  /**
+   * @summary Detach event handlers from the IPC
+   * and child to avoid emitting further events
+   * @private
+   *
+   * @example
+   * this.detachHandlers()
+   */
+  detachHandlers () {
+    // NOTE: The `ipc.server` is not an instance of EventEmitter,
+    // but a PubSub; see https://github.com/RIAEvangelist/event-pubsub
+    // Thus the method to remove event handlers is not `.removeListener()`
+    ipc.server.off('error', this.onError)
+    ipc.server.off('message', this.bridgeRobotMessage)
+    this.child.removeListener('exit', this.onExit)
+  }
+
+  /**
+   * @summary Abort the current writing process
+   * @public
+   *
+   * @param {Function} callback - callback
+   *
+   * @example
+   * childWriter.abort(() => {
+   *   console.log('Writing aborted')
+   * })
+   */
+  abort (callback) {
+    debug('abort')
+
+    if (this.aborting) {
+      debug('abort:in-progress')
+      if (_.isFunction(callback)) {
+        this.once('close', callback)
       }
+      return
+    }
 
-      // We shouldn't emit the `done` event manually here
-      // since the writer process will take care of it.
-      if (code === EXIT_CODES.SUCCESS || code === EXIT_CODES.VALIDATION_ERROR) {
-        return null
-      }
-
-      const error = new Error(`Child process exited with code ${code}, signal ${signal}`)
-      error.code = code
-      error.signal = signal
-
-      return emitError(error)
+    this.aborting = true
+    this.detachHandlers()
+    this.child.once('exit', (code, signal) => {
+      debug('abort:child:exit', code, signal)
+      this.emit('done', {
+        cancelled: true
+      })
+      this.terminateServer(callback)
     })
-  })
 
-  ipc.server.start()
-
-  return emitter
+    ipc.server.broadcast('abort', {
+      signal: 'SIGINT'
+    })
+  }
 }
+
+/**
+ * @summary The currently running instance of the writer
+ * @type {ChildWriter}
+ */
+ChildWriter.currentInstance = null
+
+/**
+ * @summary Perform a write
+ * @function
+ * @public
+ *
+ * @param {String} image - image
+ * @param {Object} drive - drive
+ * @param {Object} options - options
+ * @returns {ChildWriter} childWriter
+ *
+ * @example
+ * const child = childWriter.write('path/to/rpi.img', {
+ *   device: '/dev/disk2'
+ * }, {
+ *   validateWriteOnSuccess: true,
+ *   unmountOnSuccess: true
+ * })
+ *
+ * child.on('progress', (state) => {
+ *   console.log(state)
+ * })
+ *
+ * child.on('error', (error) => {
+ *   throw error
+ * })
+ *
+ * child.on('done', () => {
+ *   console.log('Validation was successful!')
+ * })
+ */
+ChildWriter.write = (image, drive, options) => {
+  if (ChildWriter.currentInstance) {
+    throw new Error('Write already in progress')
+  }
+  const writer = new ChildWriter().write(image, drive, options)
+  ChildWriter.currentInstance = writer
+  return writer
+}
+
+/**
+ * @summary Abort the writing process
+ * and kill the child process chain
+ * @param {Function} callback - callback
+ * @example
+ * ChildWriter.abort(() => {
+ *   console.log('Writing aborted')
+ * })
+ */
+ChildWriter.abort = (callback) => {
+  if (!ChildWriter.currentInstance) {
+    process.nextTick(callback)
+    return
+  }
+  ChildWriter.currentInstance.abort(() => {
+    ChildWriter.currentInstance = null
+    callback()
+  })
+}
+
+module.exports = ChildWriter

--- a/lib/child-writer/index.js
+++ b/lib/child-writer/index.js
@@ -92,8 +92,9 @@ class ChildWriter extends EventEmitter {
    */
   onError (error) {
     debug('onError', error)
-    this.abort()
+    error.code = 'EUNEXPECTEDEXIT'
     this.emit('error', error)
+    this.abort()
   }
 
   /**
@@ -110,6 +111,7 @@ class ChildWriter extends EventEmitter {
     debug('onExit', code, signal)
 
     if (code === EXIT_CODES.CANCELLED) {
+      debug('onExit:cancelled')
       this.terminateServer()
       this.emit('done', {
         cancelled: true
@@ -120,15 +122,17 @@ class ChildWriter extends EventEmitter {
     // We shouldn't emit the `done` event manually here
     // since the writer process will take care of it.
     if (code === EXIT_CODES.SUCCESS || code === EXIT_CODES.VALIDATION_ERROR) {
+      debug('onExit:success')
       this.terminateServer()
       return
     }
 
     const error = new Error(`Child process exited with code ${code}, signal ${signal}`)
-    error.code = code
+    error.code = 'EUNEXPECTEDEXIT'
     error.signal = signal
 
-    this.onError(error)
+    this.emit('error', error)
+    this.terminateServer()
   }
 
   /**
@@ -266,8 +270,7 @@ class ChildWriter extends EventEmitter {
       })
 
       this.child.stderr.on('data', (data) => {
-        this.bridgeRobotMessage(data.toString())
-        this.abort()
+        this.bridgeRobotMessage(data)
       })
 
       this.child.on('error', this.onError)

--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -163,14 +163,43 @@ permissions.isElevated().then((elevated) => {
         error: error.message,
         data: error.stack
       })
-      child && child.kill()
+      child && child.kill('SIGINT')
       reject(error)
     }
+
+    /**
+     * @summary Create a signal handler that will
+     * either kill the child with the received signal,
+     * or exit, if the child is already killed
+     * @private
+     *
+     * @param {String} signal - signal
+     * @returns {Function}
+     *
+     * @example
+     * process.on('SIGINT', signalHandler('SIGINT'))
+     */
+    const signalHandler = (signal) => {
+      return () => {
+        if (child) {
+          child.kill(signal)
+        } else {
+          process.exit(EXIT_CODES.GENERAL_ERROR)
+        }
+      }
+    }
+
+    process.on('SIGINT', signalHandler('SIGINT'))
+    process.on('SIGTERM', signalHandler('SIGTERM'))
 
     ipc.connectTo(process.env.IPC_SERVER_ID, () => {
       ipc.of[process.env.IPC_SERVER_ID].on('error', onError)
       ipc.of[process.env.IPC_SERVER_ID].on('disconnect', () => {
         onError(new Error('Writer process disconnected'))
+      })
+
+      ipc.of[process.env.IPC_SERVER_ID].on('abort', (data) => {
+        child && child.kill(data.signal)
       })
 
       ipc.of[process.env.IPC_SERVER_ID].on('connect', () => {

--- a/lib/child-writer/writer-proxy.js
+++ b/lib/child-writer/writer-proxy.js
@@ -227,7 +227,7 @@ permissions.isElevated().then((elevated) => {
           if (code != null && signal == null) {
             resolve(code)
           } else {
-            const error = new Error(`Exited with code ${code}, signal ${signal}`)
+            const error = new Error(`Writer process exited unexpectedly with code ${code}, signal ${signal}`)
             error.code = code
             error.signal = signal
             reject(error)

--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -29,7 +29,6 @@ var angular = require('angular')
 const electron = require('electron')
 const Bluebird = require('bluebird')
 const semver = require('semver')
-const EXIT_CODES = require('../shared/exit-codes')
 const messages = require('../shared/messages')
 const s3Packages = require('../shared/s3-packages')
 const release = require('../shared/release')
@@ -46,6 +45,9 @@ const selectionState = require('../shared/models/selection-state')
 const driveScanner = require('./modules/drive-scanner')
 const osDialog = require('./os/dialog')
 const exceptionReporter = require('./modules/exception-reporter')
+const childWriter = require('../child-writer')
+const debug = require('debug')('gui:app')
+const ipcRenderer = require('electron').ipcRenderer
 
 // Enable debug information from all modules that use `debug`
 // See https://github.com/visionmedia/debug#browser-support
@@ -179,6 +181,11 @@ app.run(() => {
 
 app.run(() => {
   store.subscribe(() => {
+    // Send the flash state to the main process,
+    // so that it can handle situations where we don't want to exit
+    // right away while we're flashing and show a confirmation dialogue
+    ipcRenderer.send('flash-state', flashState.isFlashing())
+
     if (!flashState.isFlashing()) {
       return
     }
@@ -223,19 +230,17 @@ app.run(($timeout) => {
   driveScanner.start()
 })
 
-app.run(($window) => {
+app.run(() => {
   let popupExists = false
 
-  $window.addEventListener('beforeunload', (event) => {
+  ipcRenderer.on('confirm-before-quit', () => {
+    debug('beforeunload')
     if (!flashState.isFlashing() || popupExists) {
       analytics.logEvent('Close application', {
         isFlashing: flashState.isFlashing()
       })
       return
     }
-
-    // Don't close window while flashing
-    event.returnValue = false
 
     // Don't open any more popups
     popupExists = true
@@ -249,16 +254,23 @@ app.run(($window) => {
       description: messages.warning.exitWhileFlashing()
     }).then((confirmed) => {
       if (confirmed) {
+        debug('aborting')
         analytics.logEvent('Close confirmed while flashing', {
           uuid: flashState.getFlashUuid()
         })
 
-        // This circumvents the 'beforeunload' event unlike
-        // electron.remote.app.quit() which does not.
-        electron.remote.process.exit(EXIT_CODES.SUCCESS)
-      }
+        childWriter.abort(() => {
+          // This circumvents the 'beforeunload' event unlike
+          // electron.remote.app.quit() which does not.
+          debug('aborted')
 
-      analytics.logEvent('Close rejected while flashing')
+          // Force-ignore the flash-state here, as we've decided to quit
+          ipcRenderer.send('flash-state', false)
+          process.nextTick(electron.remote.app.quit)
+        })
+      } else {
+        analytics.logEvent('Close rejected while flashing')
+      }
       popupExists = false
     }).catch(exceptionReporter.report)
   })

--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -19,20 +19,47 @@
 const electron = require('electron')
 const _ = require('lodash')
 const path = require('path')
-const EXIT_CODES = require('../shared/exit-codes')
+const debug = require('debug')('gui:etcher')
+
 let mainWindow = null
+let isFlashing = false
 
-electron.app.on('window-all-closed', electron.app.quit)
-
-// Sending a `SIGINT` (e.g: Ctrl-C) to an Electron app that registers
-// a `beforeunload` window event handler results in a disconnected white
-// browser window in GNU/Linux and macOS.
-// The `before-quit` Electron event is triggered in `SIGINT`, so we can
-// make use of it to ensure the browser window is completely destroyed.
-// See https://github.com/electron/electron/issues/5273
-electron.app.on('before-quit', () => {
-  process.exit(EXIT_CODES.SUCCESS)
+// Listen for flash-state event & set it accordingly,
+// to prevent premature exit during a flash, leaving time
+// for cleanup (i.e. termination of the child-writer)
+electron.ipcMain.on('flash-state', (event, flashState) => {
+  isFlashing = flashState
+  debug('flash-state', isFlashing)
 })
+
+/**
+ * @summary Handle termination situations (window close, quit, crash)
+ * @private
+ * @param {Event} event - before-quit event
+ * @example
+ * electron.app.on('before-quit', onBeforeQuit)
+ */
+const onBeforeQuit = (event) => {
+  // If the window's webContents have crashed, exit immediately
+  // NOTE: This happens when killing Etcher via Ctrl+C in the terminal
+  if (mainWindow && mainWindow.webContents.isCrashed()) {
+    debug('window:crashed')
+    electron.app.exit()
+  }
+
+  // If we're flashing an image while quitting, signal the renderer
+  // process, and prevent quitting for now to ensure the renderer process
+  // can initiate & complete cleanup actions.
+  // The renderer process will then call `electron.app.quit()` once
+  // cleanup is done, and cause the exit to conclude.
+  debug('isFlashing', isFlashing)
+  if (isFlashing && mainWindow) {
+    event.preventDefault()
+    mainWindow.webContents.send('confirm-before-quit')
+  }
+}
+
+electron.app.on('before-quit', onBeforeQuit)
 
 electron.app.on('ready', () => {
   // No menu bar
@@ -52,7 +79,17 @@ electron.app.on('ready', () => {
   // Prevent flash of white when starting the application
   mainWindow.on('ready-to-show', mainWindow.show)
 
+  // NOTE: Because Ctrl+C (SIGINT) handling is pretty fickle in Electron,
+  // if a `beforeunload` window event handler is registered,
+  // and can cause a crashed webContents (displaying blank contents) to remain,
+  // we attempt to force-close & quit if it's crashed.
+  // See https://github.com/electron/electron/issues/5273
+  mainWindow.webContents.on('crashed', onBeforeQuit)
+
+  mainWindow.on('close', onBeforeQuit)
+
   mainWindow.on('closed', () => {
+    debug('window:closed')
     mainWindow = null
   })
 

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -57,13 +57,30 @@ imageWriter.service('ImageWriterService', function ($q, $rootScope) {
    */
   this.performWrite = (image, drive, onProgress) => {
     return $q((resolve, reject) => {
+      let isDone = false
+
       const child = childWriter.write(image, drive, {
         validateWriteOnSuccess: settings.get('validateWriteOnSuccess'),
         unmountOnSuccess: settings.get('unmountOnSuccess')
       })
-      child.on('error', reject)
-      child.on('done', resolve)
+
+      child.on('close', () => {
+        // NOTE: This is a safeguard against child process exits on Windows,
+        // as the child processes don't get the proper exit code or signal
+        // set when being killed off by external forces
+        if (!isDone) {
+          const error = new Error('Writer process exited unexpectedly')
+          error.code = 'EUNEXPECTEDEXIT'
+          reject(error)
+        }
+      })
+
       child.on('progress', onProgress)
+      child.on('error', reject)
+      child.on('done', (state) => {
+        isDone = true
+        resolve(state)
+      })
     })
   }
 

--- a/lib/gui/pages/main/controllers/flash.js
+++ b/lib/gui/pages/main/controllers/flash.js
@@ -98,6 +98,11 @@ module.exports = function (
         FlashErrorModalService.show(messages.error.inputOutput())
       } else if (error.code === 'ENOSPC') {
         FlashErrorModalService.show(messages.error.notEnoughSpaceInDrive())
+      } else if (error.code === 'EUNEXPECTEDEXIT') {
+        FlashErrorModalService.show(messages.error.unexpectedChildExit({
+          imageBasename: path.basename(image.path),
+          drive
+        }))
       } else {
         FlashErrorModalService.show(messages.error.genericFlashError())
         exceptionReporter.report(error)

--- a/lib/shared/messages.js
+++ b/lib/shared/messages.js
@@ -115,6 +115,11 @@ module.exports = {
       'Looks like Etcher is not able to write to this location of the drive.',
       'This error is usually caused by a faulty drive, reader, or port.',
       '\n\nPlease try again with another drive, reader, or port.'
+    ].join(' ')),
+
+    unexpectedChildExit: _.template([
+      'The writer process exited unexpectedly while writing <%= imageBasename %>',
+      'to <%= drive.description %> (<%= drive.displayName %>)'
     ].join(' '))
 
   }


### PR DESCRIPTION
This aims to ensure that the child processes exit properly,
and exit at all, if Etcher is quit while the flashing is still
in progress.

Change-Type: patch
Changelog-Entry: Ensure the writer process exits when Etcher is quit