### PR TITLE
fix(writer): Set flags manually to avoid verifying cache

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -75,7 +75,15 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
   }).then(() => {
     return diskpart.clean(drive.device)
   }).then(() => {
-    return fs.openAsync(drive.raw, 'rs+')
+    /* eslint-disable no-bitwise */
+    const flags = fs.constants.O_RDWR |
+      fs.constants.O_EXCL |
+      fs.constants.O_NONBLOCK |
+      fs.constants.O_SYNC |
+      fs.constants.O_DIRECT
+    /* eslint-enable no-bitwise */
+
+    return fs.openAsync(drive.raw, flags)
   }).then((driveFileDescriptor) => {
     return imageStream.getFromFilePath(imagePath).then((image) => {
       if (!constraints.isDriveLargeEnough(drive, image)) {


### PR DESCRIPTION
We change from using `rs+` to a composition of read/write,
exlusive, sync & direct i/o flags, in order to avoid reading
stale data from the cache during verification.

Tested on:

- [x] Linux
- [x] Windows
- [x] Mac OS

Connects To: https://github.com/resin-io/etcher/issues/1523
Change-Type: patch
Changelog-Entry: Fix verification step reading from the cache