### PR TITLE
fix(gui): Re-enable application menu

### DIFF
--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -346,6 +346,13 @@ app.controller('StateController', function ($rootScope, $scope) {
   this.currentName = null
 })
 
+// Handle [Cmd] + [,] shortcut to open the settings
+app.run(($state) => {
+  electron.ipcRenderer.on('menu:preferences', () => {
+    $state.go('settings')
+  })
+})
+
 // Ensure user settings are loaded before
 // we bootstrap the Angular.js application
 angular.element(document).ready(() => {

--- a/lib/gui/app.js
+++ b/lib/gui/app.js
@@ -346,7 +346,7 @@ app.controller('StateController', function ($rootScope, $scope) {
   this.currentName = null
 })
 
-// Handle [Cmd] + [,] shortcut to open the settings
+// Handle keyboard shortcut to open the settings
 app.run(($state) => {
   electron.ipcRenderer.on('menu:preferences', () => {
     $state.go('settings')

--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -17,7 +17,6 @@
 'use strict'
 
 const electron = require('electron')
-const _ = require('lodash')
 const path = require('path')
 const EXIT_CODES = require('../shared/exit-codes')
 let mainWindow = null
@@ -35,8 +34,7 @@ electron.app.on('before-quit', () => {
 })
 
 electron.app.on('ready', () => {
-  // No menu bar
-  electron.Menu.setApplicationMenu(null)
+  electron.Menu.setApplicationMenu(require('./menu'))
 
   mainWindow = new electron.BrowserWindow({
     width: 800,
@@ -44,7 +42,10 @@ electron.app.on('ready', () => {
     useContentSize: true,
     show: false,
     resizable: false,
+    maximizable: false,
     fullscreen: false,
+    fullscreenable: false,
+    autoHideMenuBar: true,
     titleBarStyle: 'hidden-inset',
     icon: path.join(__dirname, '..', '..', 'assets', 'icon.png')
   })
@@ -54,34 +55,6 @@ electron.app.on('ready', () => {
 
   mainWindow.on('closed', () => {
     mainWindow = null
-  })
-
-  // For some reason, Electron shortcuts are registered
-  // globally, which means that the app listers for shorcuts
-  // even if its not currently focused, potentially interferring
-  // with shorcuts registered by other applications.
-  // As a workaround, we register all shortcuts when the windows
-  // gains focus, and unregister them when the windows loses focus.
-  // See http://electron.atom.io/docs/api/global-shortcut/
-
-  mainWindow.on('focus', () => {
-    electron.globalShortcut.register('CmdOrCtrl+Alt+I', () => {
-      mainWindow.webContents.openDevTools({
-        mode: 'detach'
-      })
-    })
-
-    // Disable refreshing the browser window
-    // This is supposed to be handled by the `will-navigate`
-    // event, however there seems to be an issue where such
-    // event is not fired in macOS
-    // See: https://github.com/electron/electron/issues/8841
-    electron.globalShortcut.register('CmdOrCtrl+R', _.noop)
-    electron.globalShortcut.register('F5', _.noop)
-  })
-
-  mainWindow.on('blur', () => {
-    electron.globalShortcut.unregisterAll()
   })
 
   // Prevent the user from being allowed to zoom-in the application.

--- a/lib/gui/menu.js
+++ b/lib/gui/menu.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 resin.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+const electron = require('electron')
+
+const menuTemplate = [
+  {
+    role: 'editMenu'
+  },
+  {
+    label: 'View',
+    submenu: [
+      {
+        role: 'toggledevtools',
+        click () {
+          const window = electron.BrowserWindow.getFocusedWindow()
+          if (window) {
+            window.webContents.openDevTools({
+              mode: 'detach'
+            })
+          }
+        }
+      }
+    ]
+  },
+  {
+    role: 'windowMenu'
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Etcher Pro',
+        click () {
+          electron.shell.openExternal('https://etcher.io/pro')
+        }
+      },
+      {
+        label: 'Etcher Website',
+        click () {
+          electron.shell.openExternal('https://etcher.io')
+        }
+      },
+      {
+        label: 'Report an issue',
+        click () {
+          electron.shell.openExternal('https://github.com/resin-io/etcher/issues')
+        }
+      }
+    ]
+  }
+]
+
+if (process.platform === 'darwin') {
+  menuTemplate.unshift({
+    label: electron.app.getName(),
+    submenu: [ {
+      role: 'about'
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Preferences',
+      accelerator: 'Command+,',
+      click () {
+        const window = electron.BrowserWindow.getFocusedWindow()
+        if (window) {
+          window.webContents.send('menu:preferences')
+        }
+      }
+    }, {
+      type: 'separator'
+    }, {
+      role: 'hide'
+    }, {
+      role: 'hideothers'
+    }, {
+      role: 'unhide'
+    }, {
+      type: 'separator'
+    }, {
+      role: 'quit'
+    } ]
+  })
+} else {
+  menuTemplate.unshift({
+    label: electron.app.getName(),
+    submenu: [ {
+      label: 'Settings',
+      click () {
+        const window = electron.BrowserWindow.getFocusedWindow()
+        if (window) {
+          window.webContents.send('menu:preferences')
+        }
+      }
+    }, {
+      role: 'quit'
+    } ]
+  })
+}
+
+module.exports = electron.Menu.buildFromTemplate(menuTemplate)


### PR DESCRIPTION
This re-enables the application menu to allow for OS native shortcuts
to work again (i.e. hide/minimize window), which also allows us to
get rid of the global-shortcuts hack to prevent window reloads.
Also adds links to the website, Etcher Pro and GitHub issues in the help menu.

Menu:

- App (Mac OS): Quit, hide / show window, preferences
- App (Windows, Linux): Quit, preferences
- View: Enable showing DevTools without that global shortcut hack, disable content zoom and reloads
- Edit: Don't disable native copy/paste & shortcuts (needed in DevTools and when we'll add an "Open URL" etc)
- Window: Native window management shortcuts, like minimize / maximise and friends (dep. on OS)

## Mac OS

![screen shot 2017-12-11 at 20 37 29](https://user-images.githubusercontent.com/244907/33850185-518f842e-deb3-11e7-8de7-9889b58d5398.png)

![etcher-mac-os-preferences](https://user-images.githubusercontent.com/244907/33945805-52f23532-e020-11e7-947b-38114bb92dba.gif)

## Windows

Default state:

![etcher-menu-default](https://user-images.githubusercontent.com/244907/33717949-16c1d4c8-db5c-11e7-8833-5c7ab092bcf4.png)

When hitting <kbd>Alt</kbd>:

![etcher-menu-open](https://user-images.githubusercontent.com/244907/33717948-169b3dcc-db5c-11e7-8f31-842f94107ede.png)

## Linux

Default state:

![screenshot from 2018-01-03 16-36-44](https://user-images.githubusercontent.com/244907/34527085-b6a41854-f0a4-11e7-8c4e-acc85afdc2e0.png)

When hovering over the menu bar:

![screenshot from 2018-01-03 16-39-20](https://user-images.githubusercontent.com/244907/34527090-bca3a2ce-f0a4-11e7-88b6-79d53249b0b2.png)


Connects To: #1883 #1909
Change-Type: patch
Changelog-Entry: Fix disabled native OS window shortcuts
  