### PR TITLE
fix(ci): Install python on Mac OS Travis workers

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -68,7 +68,7 @@ else
 
   npm config set spin=false
   npm config set progress=false
-  pip install --quiet -r requirements.txt
+  pip2 install --quiet -r requirements.txt
 
   make info
   make electron-develop


### PR DESCRIPTION
As python/pip have recently become unavailable on Travis' Mac OS workers,
we actively install python on them to work around this issue.

Change-Type: patch