### PR TITLE
minifix: hide drive selector hyphen when no size info

### DIFF
--- a/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -19,9 +19,9 @@
           tabindex="{{ 15 + $index }}"
           ng-keypress="modal.keyboardToggleDrive(drive, $event)">
 
-          <h4 class="list-group-item-heading">{{ drive.description }} -
+          <h4 class="list-group-item-heading">{{ drive.description }}
             <span class="word-keep"
-              ng-show="drive.size">{{ drive.size | closestUnit }}</span>
+              ng-show="drive.size"> - {{ drive.size | closestUnit }}</span>
           </h4>
           <p class="list-group-item-text">{{ drive.displayName }}</p>
 


### PR DESCRIPTION
We hide the separator hyphen between the name and size when there is no
size information available, in the drive selector modal.

Change-Type: patch
Changelog-Entry: Hide the drive-selector separator hyphen when no drive
size is available.