### PR TITLE
upgrade: `resin-corvus` to v1.0.0-beta.31

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2458,9 +2458,16 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
     },
     "flat": {
-      "version": "2.0.1",
-      "from": "flat@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz"
+      "version": "4.0.0",
+      "from": "flat@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.0.0.tgz",
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "from": "is-buffer@>=1.1.5 <1.2.0",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
+        }
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
@@ -3153,7 +3160,8 @@
     "is-buffer": {
       "version": "1.1.4",
       "from": "is-buffer@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4559,14 +4567,31 @@
       }
     },
     "mixpanel": {
-      "version": "0.6.0",
-      "from": "mixpanel@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.6.0.tgz"
+      "version": "0.7.0",
+      "from": "mixpanel@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.7.0.tgz",
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "from": "agent-base@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz"
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "from": "https-proxy-agent@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
+        },
+        "semver": {
+          "version": "5.0.3",
+          "from": "semver@>=5.0.1 <5.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+        }
+      }
     },
     "mixpanel-browser": {
-      "version": "2.13.0",
+      "version": "2.14.0",
       "from": "mixpanel-browser@>=2.11.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.13.0.tgz"
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.14.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -8645,9 +8670,9 @@
       "dev": true
     },
     "raven": {
-      "version": "1.2.1",
-      "from": "raven@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
+      "version": "2.2.1",
+      "from": "raven@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.2.1.tgz",
       "dependencies": {
         "uuid": {
           "version": "3.0.0",
@@ -8657,9 +8682,9 @@
       }
     },
     "raven-js": {
-      "version": "3.19.1",
-      "from": "raven-js@>=3.12.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.19.1.tgz"
+      "version": "3.20.1",
+      "from": "raven-js@>=3.19.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.20.1.tgz"
     },
     "rc": {
       "version": "1.1.7",
@@ -8975,9 +9000,9 @@
       }
     },
     "resin-corvus": {
-      "version": "1.0.0-beta.30",
-      "from": "resin-corvus@1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.30.tgz",
+      "version": "1.0.0-beta.31",
+      "from": "resin-corvus@1.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/resin-corvus/-/resin-corvus-1.0.0-beta.31.tgz",
       "dependencies": {
         "cross-spawn": {
           "version": "5.1.0",
@@ -9745,8 +9770,7 @@
     "timed-out": {
       "version": "4.0.1",
       "from": "timed-out@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz"
     },
     "tmp": {
       "version": "0.0.31",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "request": "2.81.0",
     "resin-cli-form": "1.4.1",
     "resin-cli-visuals": "1.3.1",
-    "resin-corvus": "1.0.0-beta.30",
+    "resin-corvus": "1.0.0-beta.31",
     "semver": "5.1.1",
     "speedometer": "1.0.0",
     "sudo-prompt": "8.0.0",


### PR DESCRIPTION
This version contains a couple of patches to ensure that the Mixpanel
library doesn't send any HTTP request to api.mixpanel.com unless the
user enabled analytics.

- https://github.com/resin-io-modules/resin-corvus/pull/35
- https://github.com/resin-io-modules/resin-corvus/pull/36

See: https://github.com/resin-io/etcher/issues/1772
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>