### PR TITLE
chore(appveyor): build x86 on real x86 machines

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,31 +19,32 @@ environment:
   global:
     ELECTRON_NO_ATTACH_CONSOLE: true
     nodejs_version: "6.10.3"
-  matrix:
-    - TARGET_ARCH: x64
-    - TARGET_ARCH: x86
+
+platform:
+  - x86
+  - x64
 
 matrix:
   fast_finish: true
 
 install:
-  - ps: Update-NodeJsInstallation $env:nodejs_version $env:TARGET_ARCH
+  - ps: Update-NodeJsInstallation $env:nodejs_version $env:Platform
   - set PATH=C:\Program Files (x86)\Windows Kits\8.1\bin\x86;%PATH%
   - set PATH=C:\Program Files (x86)\NSIS;%PATH%
   - set PATH=C:\MinGW\bin;%PATH%
   - set PATH=C:\MinGW\msys\1.0\bin;%PATH%
-  - bash .\scripts\ci\install.sh -o win32 -r %TARGET_ARCH%
+  - bash .\scripts\ci\install.sh -o win32 -r %Platform%
 
 build: off
 
 test_script:
   - node --version
   - npm --version
-  - bash .\scripts\ci\test.sh -o win32 -r %TARGET_ARCH%
-  - bash .\scripts\ci\build-installers.sh -o win32 -r %TARGET_ARCH%
+  - bash .\scripts\ci\test.sh -o win32 -r %Platform%
+  - bash .\scripts\ci\build-installers.sh -o win32 -r %Platform%
 
 deploy_script:
-  - if %APPVEYOR_REPO_BRANCH%==master (bash .\scripts\ci\deploy.sh -o win32 -r %TARGET_ARCH%)
+  - if %APPVEYOR_REPO_BRANCH%==master (bash .\scripts\ci\deploy.sh -o win32 -r %Platform%)
 
 notifications:
 

--- a/scripts/ci/build-installers.sh
+++ b/scripts/ci/build-installers.sh
@@ -46,10 +46,11 @@ fi
 
 if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
   ./scripts/build/docker/run-command.sh \
-    -r "$TARGET_ARCH" \
+    -r "$ARGV_ARCHITECTURE" \
     -s "$(pwd)" \
     -c 'make installers-all'
 else
   ./scripts/build/check-dependency.sh make
+  export TARGET_ARCH="$ARGV_ARCHITECTURE"
   make installers-all
 fi

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -51,5 +51,6 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
     -c "make publish-all"
 else
   ./scripts/build/check-dependency.sh make
+  export TARGET_ARCH="$ARGV_ARCHITECTURE"
   make publish-all
 fi

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -72,6 +72,7 @@ else
   npm config set progress=false
   "$PIP_COMMAND" install --quiet -r requirements.txt
 
+  export TARGET_ARCH="$ARGV_ARCHITECTURE"
   make info
   make electron-develop
 fi

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -51,5 +51,6 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
     -c 'xvfb-run --server-args=$XVFB_ARGS make lint test sanity-checks'
 else
   ./scripts/build/check-dependency.sh make
+  export TARGET_ARCH="$ARGV_ARCHITECTURE"
   make lint test sanity-checks
 fi


### PR DESCRIPTION
We do this by using Appveyor's `platform` configuration variable instead
of always running on x64 and cross-compiling to x86.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>