### PR TITLE
fix(GUI): only emit toggle drive event if drive is selectable

### DIFF
--- a/lib/gui/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/components/drive-selector/controllers/drive-selector.js
@@ -107,13 +107,13 @@ module.exports = function (
    * });
    */
   this.toggleDrive = (drive) => {
-    analytics.logEvent('Toggle drive', {
-      drive,
-      previouslySelected: selectionState.isCurrentDrive(drive.device)
-    })
-
     return shouldChangeDriveSelectionState(drive).then((canChangeDriveSelectionState) => {
       if (canChangeDriveSelectionState) {
+        analytics.logEvent('Toggle drive', {
+          drive,
+          previouslySelected: selectionState.isCurrentDrive(drive.device)
+        })
+
         selectionState.toggleSetDrive(drive.device)
       }
     })


### PR DESCRIPTION
Right now we emit "Toggle drive" analytics events even when clicking on
disable/unselectable drives.

The fix is to move the `analytics.logEvent` inside the code path that
applies if a drive selection is considered valid.

Change-Type: patch
Changelog-Entry: Don't send analytics events when attempting to toggle a disabled drive.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>