### PR TITLE
feat(writer): Add read/write retry delays

### DIFF
--- a/lib/writer/block-read-stream.js
+++ b/lib/writer/block-read-stream.js
@@ -25,6 +25,13 @@ const CHUNK_SIZE = 64 * 1024
 const MIN_CHUNK_SIZE = 512
 
 /**
+ * @summary I/O retry base timeout, in milliseconds
+ * @constant
+ * @type {Number}
+ */
+const RETRY_BASE_TIMEOUT = 100
+
+/**
  * @summary BlockReadStream
  * @class
  */
@@ -91,7 +98,9 @@ class BlockReadStream extends stream.Readable {
 
         if (isTransient && (this.retries < this.maxRetries)) {
           this.retries += 1
-          this._read()
+          setTimeout(() => {
+            this._read()
+          }, RETRY_BASE_TIMEOUT * this.retries)
           return
         } else if (isTransient) {
           error.code = 'EUNPLUGGED'

--- a/lib/writer/block-write-stream.js
+++ b/lib/writer/block-write-stream.js
@@ -26,6 +26,13 @@ const CHUNK_SIZE = 64 * 1024
 const UPDATE_INTERVAL_MS = 500
 
 /**
+ * @summary I/O retry base timeout, in milliseconds
+ * @constant
+ * @type {Number}
+ */
+const RETRY_BASE_TIMEOUT = 100
+
+/**
  * @summary BlockWriteStream
  * @class
  */
@@ -154,7 +161,9 @@ class BlockWriteStream extends stream.Writable {
 
       if (isTransient && (this.retries < this.maxRetries)) {
         this.retries += 1
-        this._write(chunk, encoding, next)
+        setTimeout(() => {
+          this._write(chunk, encoding, next)
+        }, RETRY_BASE_TIMEOUT * this.retries)
         return
       } else if (isTransient) {
         error.code = 'EUNPLUGGED'


### PR DESCRIPTION
This adds minor backoff times to failed reads/writes that fall into the "transient" category, replicating the behavior of etcher-image-write.

Change-Type: minor