### PR TITLE
chore: remove npx's node_modules/.bin after dependencies installation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "postshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
     "configure": "node-gyp configure",
     "build": "node-gyp build",
-    "install": "node-gyp rebuild"
+    "install": "node-gyp rebuild",
+    "postinstall": "rm -rf node_modules/npx/node_modules/.bin"
   },
   "author": "Resin Inc. <hello@etcher.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is a subtle issue I just discovered. `npx` is a tool to
automatically run a program inside `./node_modules/.bin`. The issue is
that when it runs, it prepends its own local `.bin` to the `PATH`, and
if any of `npx`'s dependencies have binaries (which they do), `npx` will
incorrectly use those instead of the ones we configure in our top level
`package.json`.

In my particular case, `npx`'s `npm` was being executed instead of the
system's one. I wonder if this explains the weird shrinkwrap
discrepancies in certain operating systems.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>