### PR TITLE
chore: add Concourse related NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "postshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
     "configure": "node-gyp configure",
     "build": "node-gyp build",
-    "install": "node-gyp rebuild"
+    "install": "node-gyp rebuild",
+    "concourse-dependencies": "make info && make electron-develop",
+    "concourse-test": "make lint test sanity-checks",
+    "concourse-build-installers": "make installers-all"
   },
   "author": "Resin Inc. <hello@etcher.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Our Electron Concourse pipeline is completely independent from the
application its testing (ie we can apply it to any other Electron app we
build with ease).

In order to keep such genericity, the application under test should
provide certain npm scripts that tell Concourse how to do specific tasks
on the repo, like install dependencies, in a build-system independent
fashion.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>