### PR TITLE
chore: make `test` npm script run everything we run on the CI services

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "url": "git@github.com:resin-io/etcher.git"
   },
   "scripts": {
-    "test": "make test",
+    "test": "make lint test sanity-checks",
     "start": "electron lib/start.js",
     "postshrinkwrap": "node ./scripts/clean-shrinkwrap.js",
     "configure": "node-gyp configure",
     "build": "node-gyp build",
     "install": "node-gyp rebuild",
     "concourse-dependencies": "make info && make electron-develop",
-    "concourse-test": "make lint test sanity-checks",
+    "concourse-test": "npm test",
     "concourse-build-installers": "make installers-all"
   },
   "author": "Resin Inc. <hello@etcher.io>",


### PR DESCRIPTION
The idea is that the `test` command will replace the recently introduced
`concourse-test` script.

`concourse-test` will become simply a call to `test` for now to ensure
backwards compatibility while we update Resin Concourse.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>