### PR TITLE
chore: declare Concourse dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,15 @@
     "7zip-bin-win",
     "7zip-bin-linux"
   ],
+  "concourse": {
+    "dependencies": {
+      "linux": [
+        "libudev-dev",
+        "libusb-1.0-0-dev",
+        "libyaml-dev"
+      ]
+    }
+  },
   "dependencies": {
     "angular": "1.6.3",
     "angular-if-state": "1.0.0",


### PR DESCRIPTION
Resin Concourse will make sure to provide these during build time.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>