### PR TITLE
upgrade(package): Bump drivelist 5.2.4 -> 5.2.12

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1296,8 +1296,8 @@
       "dev": true
     },
     "drivelist": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.2.4.tgz",
+      "version": "5.2.12",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.2.12.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.3.0",
@@ -1315,17 +1315,21 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
         },
         "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+        },
+        "prebuild-install": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.4.1.tgz"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "command-join": "2.0.0",
     "crc32-stream": "2.0.0",
     "debug": "2.6.8",
-    "drivelist": "5.2.4",
+    "drivelist": "5.2.12",
     "electron-is-running-in-asar": "1.0.0",
     "file-type": "4.1.0",
     "flexboxgrid": "6.3.0",


### PR DESCRIPTION
This version of drivelist also includes the perl-fix, which was causing high CPU load occasionally.

Change-Type: patch
Connects To: #1288