### PR TITLE
upgrade(package): Bump electron 1.7.9 -> 1.7.10

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,8 +31,8 @@
       "resolved": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz"
     },
     "@types/node": {
-      "version": "7.0.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.46.tgz",
+      "version": "7.0.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.51.tgz",
       "dev": true
     },
     "@types/react": {
@@ -1349,8 +1349,8 @@
       "dev": true
     },
     "electron": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.9.tgz",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.10.tgz",
       "dev": true,
       "dependencies": {
         "electron-download": {
@@ -1726,8 +1726,8 @@
       }
     },
     "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
       "dev": true
     },
     "es6-set": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "devDependencies": {
     "angular-mocks": "1.6.3",
     "asar": "0.10.0",
-    "electron": "1.7.9",
+    "electron": "1.7.10",
     "electron-builder": "19.40.0",
     "electron-mocha": "3.3.0",
     "eslint": "3.19.0",


### PR DESCRIPTION
Electron changelog:

- Fixed crash in custom protocols
- Fixed webrtc crash
- Linux: Fixed subpixel font rendering with freetype
- Mac OS: Fixed rendering issues with Nvidia GPU on High Sierra
- Mac OS: Fixed incorrectly cropped TouchBar items

Change-Type: patch