### PR TITLE
fix(shared): trailing space in Windows elevation env vars

### DIFF
--- a/lib/shared/permissions.js
+++ b/lib/shared/permissions.js
@@ -99,7 +99,12 @@ exports.getEnvironmentCommandPrefix = (environment) => {
     }
 
     if (isWindows) {
-      return [ 'set', `${key}=${value}`, '&&' ]
+      // Doing something like `set foo=bar &&` (notice
+      // the space before the first ampersand) would
+      // cause the environment variable's value to
+      // contain a trailing space.
+      // See https://superuser.com/a/57726
+      return [ 'set', `${key}=${value}&&` ]
     }
 
     return [ `${key}=${value}` ]

--- a/tests/shared/permissions.spec.js
+++ b/tests/shared/permissions.spec.js
@@ -45,8 +45,7 @@ describe('Shared: permissions', function () {
           FOO: 'bar'
         })).to.deep.equal([
           'set',
-          'FOO=bar',
-          '&&',
+          'FOO=bar&&',
           'call'
         ])
       })
@@ -58,14 +57,11 @@ describe('Shared: permissions', function () {
           BAZ: 'qux'
         })).to.deep.equal([
           'set',
-          'FOO=bar',
-          '&&',
+          'FOO=bar&&',
           'set',
-          'BAR=baz',
-          '&&',
+          'BAR=baz&&',
           'set',
-          'BAZ=qux',
-          '&&',
+          'BAZ=qux&&',
           'call'
         ])
       })
@@ -77,8 +73,7 @@ describe('Shared: permissions', function () {
           BAZ: undefined
         })).to.deep.equal([
           'set',
-          'BAR=qux',
-          '&&',
+          'BAR=qux&&',
           'call'
         ])
       })
@@ -90,14 +85,11 @@ describe('Shared: permissions', function () {
           BAZ: -1
         })).to.deep.equal([
           'set',
-          'FOO=1',
-          '&&',
+          'FOO=1&&',
           'set',
-          'BAR=0',
-          '&&',
+          'BAR=0&&',
           'set',
-          'BAZ=-1',
-          '&&',
+          'BAZ=-1&&',
           'call'
         ])
       })


### PR DESCRIPTION
This is a strange one. On Windows, putting a space before the
double-ampersand command concatenator makes the environment variable
value contain a trailing space. So for something like `set foo=bar &&
...` the variable `foo` will be `'bar '` instead of `'bar'`.

Change-Type: patch
Changelog-Entry: Fix trailing space in environment variables during Windows elevation.
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>