### PR TITLE
fix(writer): Silence IPC output on stdout

### DIFF
--- a/lib/gui/modules/child-writer.js
+++ b/lib/gui/modules/child-writer.js
@@ -23,7 +23,10 @@ const writer = require('../../cli/writer')
 
 ipc.config.id = process.env.IPC_CLIENT_ID
 ipc.config.socketRoot = process.env.IPC_SOCKET_ROOT
-ipc.config.silent = false
+
+// NOTE: Ensure this isn't disabled, as it will cause
+// the stdout maxBuffer size to be exceeded when flashing
+ipc.config.silent = true
 
 // > If set to 0, the client will NOT try to reconnect.
 // See https://github.com/RIAEvangelist/node-ipc/

--- a/lib/gui/modules/image-writer.js
+++ b/lib/gui/modules/image-writer.js
@@ -84,6 +84,9 @@ exports.performWrite = (image, drive, onProgress) => {
 
   ipc.config.id = IPC_SERVER_ID
   ipc.config.socketRoot = path.join(process.env.XDG_RUNTIME_DIR || os.tmpdir(), path.sep)
+
+  // NOTE: Ensure this isn't disabled, as it will cause
+  // the stdout maxBuffer size to be exceeded when flashing
   ipc.config.silent = true
   ipc.serve()
 


### PR DESCRIPTION
This was causing the stdout maxBuffer size to be exceeded
when flashing larger images (or having flashes that took a while).

Change-Type: patch
Changlog Entry: Fix "stdout maxBuffer exceeded" error on Linux
Connects To: #1955 