### PR TITLE
chore: add concourse.builder package.json configuration object

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,44 @@
         "libusb-1.0-0-dev",
         "libyaml-dev"
       ]
+    },
+    "builder": {
+      "appId": "io.resin.etcher",
+      "copyright": "Copyright 2016 Resinio Ltd",
+      "productName": "Etcher",
+      "mac": {
+        "category": "public.app-category.developer-tools"
+      },
+      "dmg": {
+        "iconSize": 110,
+        "contents": [
+          {
+            "x": 140,
+            "y": 225
+          },
+          {
+            "x": 415,
+            "y": 225,
+            "type": "link",
+            "path": "/Applications"
+          }
+        ],
+        "window": {
+          "width": 540,
+          "height": 405
+        }
+      },
+      "linux": {
+        "category": "Utility",
+        "packageCategory": "utils",
+        "synopsis": "Etcher is a powerful OS image flasher built with web technologies to ensure flashing an SDCard or USB drive is a pleasant and safe experience. It protects you from accidentally writing to your hard-drives, ensures every byte of data was written correctly and much more."
+      },
+      "deb": {
+        "priority": "optional",
+        "depends": [
+          "polkit-1-auth-agent | policykit-1-gnome | polkit-kde-1"
+        ]
+      }
     }
   },
   "dependencies": {


### PR DESCRIPTION
This object will eventually replace the `electron-builder.yml` file
that's currently present in the root of the project.

For now, it contains the `electron-builder` options that are project
specific (all the generic bits live in the Electron Concourse pipeline),
but in the future we might want to decouple how users configure packages
from the `electron-builder` project, instead making the user provide
Resin Concourse specific options that are then translated to
`electron-builder` (or any other packaging technology we might decide to
use) under the hood.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>