### PR TITLE
fix(usb): Ignore errors if winusb doesn't load

### DIFF
--- a/lib/shared/sdk/usbboot/usb.js
+++ b/lib/shared/sdk/usbboot/usb.js
@@ -74,15 +74,22 @@ exports.listDevices = () => {
 
   // Include driverless devices into the list of USB devices.
   if (process.platform === 'win32') {
-    const winusbDriverGenerator = require('winusb-driver-generator')
-    for (const device of winusbDriverGenerator.listDriverlessDevices()) {
-      devices.push({
-        accessible: false,
-        deviceDescriptor: {
-          idVendor: device.vid,
-          idProduct: device.pid
-        }
-      })
+    // NOTE: Temporarily ignore errors when loading winusb-driver-generator,
+    // due to C Runtime issues on Windows;
+    // see https://github.com/resin-io/etcher/issues/1956
+    try {
+      const winusbDriverGenerator = require('winusb-driver-generator')
+      for (const device of winusbDriverGenerator.listDriverlessDevices()) {
+        devices.push({
+          accessible: false,
+          deviceDescriptor: {
+            idVendor: device.vid,
+            idProduct: device.pid
+          }
+        })
+      }
+    } catch (error) {
+      // Ignore error
     }
   }
 


### PR DESCRIPTION
Due to some Windows systems missing certain C runtime libraries
(Visual C/C++ 2012 / 2015 Redistributables), we ignore errors when loading
this module until we can ensure distribution of those along with it.

Change-Type: patch
Changelog-Entry: Fix "The specified module could not be found" on Windows
Connects To: #1956 