### PR TITLE
upgrade(package): Bump drivelist 6.0.0 -> 6.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1296,8 +1296,8 @@
       "dev": true
     },
     "drivelist": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-6.0.0.tgz",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-6.0.4.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "command-join": "2.0.0",
     "crc32-stream": "2.0.0",
     "debug": "2.6.8",
-    "drivelist": "6.0.0",
+    "drivelist": "6.0.4",
     "electron-is-running-in-asar": "1.0.0",
     "file-type": "4.1.0",
     "flexboxgrid": "6.3.0",


### PR DESCRIPTION
This updates `drivelist` to v6.0.4, fixing a crash on Windows 7,
among other things:

- Fix(windows): Impl IsSystemDevice()
- Fix crash on Windows 7
- Fix(darwin): Use proper flag to enable extended regexes in `sed`
- Fix(darwin): Allow mountpoints containing space characters

Change-Type: patch
Changelog-Entry: Fix Etcher not working / crashing on older Windows systems
Connects To: https://github.com/resin-io/etcher/issues/1971, https://github.com/resin-io/etcher/issues/1288