### PR TITLE
fix(gui): Allow selection of images in folders with extension

### DIFF
--- a/lib/gui/os/dialog.js
+++ b/lib/gui/os/dialog.js
@@ -57,9 +57,9 @@ exports.selectImage = () => {
       //
       // See: https://github.com/probonopd/AppImageKit/commit/1569d6f8540aa6c2c618dbdb5d6fcbf0003952b7
       defaultPath: process.env.OWD,
-
       properties: [
-        'openFile'
+        'openFile',
+        'treatPackageAsDirectory'
       ],
       filters: [
         {


### PR DESCRIPTION
This fixes selection of images contained in directories with a file extension
(i.e. "openSUSE-Leap-42.3-DVD-x86_64.iso") in the open file dialog.

![screen shot 2018-01-18 at 20 00 25](https://user-images.githubusercontent.com/244907/35116163-b108b7d2-fc8a-11e7-9f01-10185ca3cd5a.png)

Change-Type: patch
Changelog-Entry: Fix selection of images in folders with file extension
Connects To: https://github.com/resin-io/etcher/issues/1926