### PR TITLE
chore: revise Concourse CI related npm scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,7 @@ TARGETS = \
 	test-spectron \
 	test-gui \
 	test-sdk \
+	test-cli \
 	test \
 	sanity-checks \
 	clean \
@@ -546,6 +547,11 @@ test-gui:
 
 test-sdk:
 	electron-mocha $(MOCHA_OPTIONS) \
+		tests/shared \
+		tests/image-stream
+
+test-cli:
+	mocha $(MOCHA_OPTIONS) \
 		tests/shared \
 		tests/image-stream
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "configure": "node-gyp configure",
     "build": "node-gyp build",
     "install": "node-gyp rebuild",
-    "concourse-dependencies": "make info && make electron-develop",
     "concourse-test": "npm test",
-    "concourse-build-installers": "make installers-all"
+    "concourse-test-electron": "npm test",
+    "concourse-test-node-cli": "make lint test-cli sanity-checks"
   },
   "author": "Resin Inc. <hello@etcher.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
- The `concourse-dependencies` and `concourse-build-installers` scripts
are not necessary anymore, given that the Electron pipeline already
knows how to perform these tasks

- The `concourse-test` script will be renamed to
`concourse-test-electron` to include the pipeline name (electron), so a
single project can be served by more than one pipeline. I'll keep the
old `concourse-test` for a bit for backwards compatibility until all
Etcher PRs are rebased

- There is a new `concourse-test-node-cli` script that will be used by
the Node.js CLI pipeline

- There is a new `test-cli` target that is supposed to host CLI tests.
For now, it just runs the SDK tests in a Node.js environment (instead of
in Electron)

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>