### PR TITLE
chore: add node-cli.node Resin CI option

### DIFF
--- a/.resinci.json
+++ b/.resinci.json
@@ -1,4 +1,13 @@
 {
+  "node-cli": {
+    "node": "6.1.0",
+    "dependencies": {
+      "linux": [
+        "libudev-dev",
+        "libusb-1.0-0-dev"
+      ]
+    }
+  },
   "electron": {
     "dependencies": {
       "linux": [


### PR DESCRIPTION
This represents the Node.js version that will be used to compile the
Etcher CLI.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>