### PR TITLE
upgrade(package): Bump mountutils 1.3.8 -> 1.3.10

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4324,8 +4324,8 @@
       "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
     },
     "mountutils": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.3.8.tgz",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.3.10.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lzma-native": "1.5.2",
     "mbr": "1.1.2",
     "mime-types": "2.1.15",
-    "mountutils": "1.3.8",
+    "mountutils": "1.3.10",
     "nan": "2.3.5",
     "node-ipc": "9.1.1",
     "node-stream-zip": "1.3.7",


### PR DESCRIPTION
This updates `mountutils` from 1.3.8 -> 1.3.10;

- fix(linux): Fix partial unmounts on Linux
- fix(windows): Link to appropriate libraries

Change-Type: patch
Changelog-Entry: Fix incomplete unmounts after flashing on Linux
Connects To: https://github.com/resin-io/etcher/issues/1911