### PR TITLE
upgrade(package): Update electron 1.7.10 -> 1.7.11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,8 +31,8 @@
       "resolved": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz"
     },
     "@types/node": {
-      "version": "7.0.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.51.tgz",
+      "version": "7.0.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
       "dev": true
     },
     "@types/react": {
@@ -1353,8 +1353,8 @@
       "dev": true
     },
     "electron": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.10.tgz",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
       "dev": true,
       "dependencies": {
         "electron-download": {
@@ -1368,8 +1368,8 @@
           "dev": true
         },
         "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "devDependencies": {
     "angular-mocks": "1.6.3",
     "asar": "0.10.0",
-    "electron": "1.7.10",
+    "electron": "1.7.11",
     "electron-builder": "19.40.0",
     "electron-mocha": "5.0.0",
     "eslint": "3.19.0",


### PR DESCRIPTION
This updates Electron to v1.7.11, mitigating CVE-2018-1000006.

Note: As we don't use custom protocol handlers, Etcher is not vulnerable at this time.

See: https://electronjs.org/blog/protocol-handler-fix
Change-Type: patch
Changelog-Entry: Update Electron to v1.7.11