### PR TITLE
fix(lib): Fix readonly property typo

### DIFF
--- a/lib/shared/drive-constraints.js
+++ b/lib/shared/drive-constraints.js
@@ -43,13 +43,13 @@ const UNKNOWN_SIZE = 0
  *   device: '/dev/disk2',
  *   name: 'My Drive',
  *   size: 123456789,
- *   isReadonly: true
+ *   isReadOnly: true
  * })) {
  *   console.log('This drive is locked (e.g: write-protected)');
  * }
  */
 exports.isDriveLocked = (drive) => {
-  return Boolean(_.get(drive, [ 'isReadonly' ], false))
+  return Boolean(_.get(drive, [ 'isReadOnly' ], false))
 }
 
 /**
@@ -64,7 +64,7 @@ exports.isDriveLocked = (drive) => {
  *   device: '/dev/disk2',
  *   name: 'My Drive',
  *   size: 123456789,
- *   isReadonly: true,
+ *   isReadOnly: true,
  *   system: true
  * })) {
  *   console.log('This drive is a system drive!');
@@ -93,7 +93,7 @@ exports.isSystemDrive = (drive) => {
  *   device: '/dev/disk2',
  *   name: 'My Drive',
  *   size: 123456789,
- *   isReadonly: true,
+ *   isReadOnly: true,
  *   system: true,
  *   mountpoints: [
  *     {
@@ -215,7 +215,7 @@ exports.isDriveDisabled = (drive) => {
  *   device: '/dev/disk2',
  *   name: 'My Drive',
  *   size: 1000000000,
- *   isReadonly: false
+ *   isReadOnly: false
  * }, {
  *   path: 'rpi.img',
  *   size: {
@@ -231,12 +231,10 @@ exports.isDriveDisabled = (drive) => {
  * }
  */
 exports.isDriveValid = (drive, image) => {
-  return _.every([
-    !this.isDriveLocked(drive),
-    this.isDriveLargeEnough(drive, image),
-    !this.isSourceDrive(drive, image),
+  return !this.isDriveLocked(drive) &&
+    this.isDriveLargeEnough(drive, image) &&
+    !this.isSourceDrive(drive, image) &&
     !this.isDriveDisabled(drive)
-  ])
 }
 
 /**

--- a/lib/shared/sdk/usbboot/index.js
+++ b/lib/shared/sdk/usbboot/index.js
@@ -269,7 +269,7 @@ class USBBootAdapter extends EventEmitter {
           displayName: 'Missing drivers',
           description,
           mountpoints: [],
-          isReadonly: false,
+          isReadOnly: false,
           isSystem: false,
           disabled: true,
           icon: 'warning',
@@ -292,7 +292,7 @@ class USBBootAdapter extends EventEmitter {
 
         size: null,
         mountpoints: [],
-        isReadonly: false,
+        isReadOnly: false,
         isSystem: false,
         disabled: true,
         icon: 'loading',

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -298,7 +298,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
         })
       }
 
-      if (selectedDrive.get('isReadonly')) {
+      if (selectedDrive.get('isReadOnly')) {
         throw errors.createError({
           title: 'The drive is write-protected'
         })

--- a/tests/shared/drive-constraints.spec.js
+++ b/tests/shared/drive-constraints.spec.js
@@ -28,7 +28,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: true
+        isReadOnly: true
       })
 
       m.chai.expect(result).to.be.true
@@ -39,7 +39,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: false
+        isReadOnly: false
       })
 
       m.chai.expect(result).to.be.false
@@ -68,7 +68,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: true,
+        isReadOnly: true,
         isSystem: true
       })
 
@@ -80,7 +80,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: true
+        isReadOnly: true
       })
 
       m.chai.expect(result).to.be.false
@@ -91,7 +91,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: true,
+        isReadOnly: true,
         isSystem: false
       })
 
@@ -111,7 +111,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: true,
+        isReadOnly: true,
         isSystem: false
       }, undefined)
 
@@ -131,7 +131,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk2',
         name: 'USB Drive',
         size: 999999999,
-        isReadonly: true,
+        isReadOnly: true,
         isSystem: false
       }, {
         path: '/Volumes/Untitled/image.img'
@@ -313,7 +313,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 1000000000,
-        isReadonly: false
+        isReadOnly: false
       }
     })
 
@@ -515,7 +515,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 1000000000,
-        isReadonly: false
+        isReadOnly: false
       }, undefined)
 
       m.chai.expect(result).to.be.true
@@ -533,7 +533,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 1000000000,
-        isReadonly: false,
+        isReadOnly: false,
         disabled: true
       })
 
@@ -545,7 +545,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 1000000000,
-        isReadonly: false,
+        isReadOnly: false,
         disabled: false
       })
 
@@ -557,7 +557,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 1000000000,
-        isReadonly: false
+        isReadOnly: false
       })
 
       m.chai.expect(result).to.be.false
@@ -570,7 +570,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 2000000001,
-        isReadonly: false
+        isReadOnly: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
         size: {
@@ -591,7 +591,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 2000000000,
-        isReadonly: false
+        isReadOnly: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
         size: {
@@ -612,7 +612,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 2000000000,
-        isReadonly: false
+        isReadOnly: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
         size: {
@@ -633,7 +633,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 2000000000,
-        isReadonly: false
+        isReadOnly: false
       }, {
         path: path.join(__dirname, 'rpi.img'),
         size: {
@@ -669,7 +669,7 @@ describe('Shared: DriveConstraints', function () {
         device: '/dev/disk1',
         name: 'USB Drive',
         size: 2000000000,
-        isReadonly: false
+        isReadOnly: false
       }, undefined)
 
       m.chai.expect(result).to.be.true
@@ -703,7 +703,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given the drive is locked', function () {
       beforeEach(function () {
-        this.drive.isReadonly = true
+        this.drive.isReadOnly = true
       })
 
       describe('given the drive is disabled', function () {
@@ -825,7 +825,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given the drive is not locked', function () {
       beforeEach(function () {
-        this.drive.isReadonly = false
+        this.drive.isReadOnly = false
       })
 
       describe('given the drive is disabled', function () {
@@ -959,7 +959,7 @@ describe('Shared: DriveConstraints', function () {
       this.drive = {
         device: '/dev/disk2',
         name: 'My Drive',
-        isReadonly: false,
+        isReadOnly: false,
         isSystem: false,
         disabled: false,
         mountpoints: [
@@ -1060,7 +1060,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given the drive is locked', () => {
       it('should return the locked drive error', function () {
-        this.drive.isReadonly = true
+        this.drive.isReadOnly = true
 
         const result = constraints.getDriveImageCompatibilityStatuses(this.drive, this.image)
         const expectedTuples = [ [ 'ERROR', 'LOCKED' ] ]
@@ -1098,7 +1098,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given a locked drive and image is null', () => {
       it('should return locked drive error', function () {
-        this.drive.isReadonly = true
+        this.drive.isReadOnly = true
 
         const result = constraints.getDriveImageCompatibilityStatuses(this.drive, null)
         const expectedTuples = [ [ 'ERROR', 'LOCKED' ] ]
@@ -1120,7 +1120,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given the drive contains the image and the drive is locked', () => {
       it('should return the contains-image drive error by precedence', function () {
-        this.drive.isReadonly = true
+        this.drive.isReadOnly = true
         this.image.path = path.join(this.mountpoint, 'rpi.img')
 
         const result = constraints.getDriveImageCompatibilityStatuses(this.drive, this.image)
@@ -1132,7 +1132,7 @@ describe('Shared: DriveConstraints', function () {
 
     describe('given a locked and too small drive', () => {
       it('should return the locked error by precedence', function () {
-        this.drive.isReadonly = true
+        this.drive.isReadOnly = true
 
         const result = constraints.getDriveImageCompatibilityStatuses(this.drive, this.image)
         const expectedTuples = [ [ 'ERROR', 'LOCKED' ] ]

--- a/tests/shared/models/available-drives.spec.js
+++ b/tests/shared/models/available-drives.spec.js
@@ -158,7 +158,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -206,7 +206,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               },
               {
                 device: '/dev/sdc',
@@ -216,7 +216,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/bar'
                 } ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -235,7 +235,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -247,7 +247,7 @@ describe('Model: availableDrives', function () {
                 path: '/mnt/foo'
               } ],
               isSystem: false,
-              isReadonly: false
+              isReadOnly: false
             })
           })
 
@@ -263,7 +263,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -282,7 +282,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -301,7 +301,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: false,
-                isReadonly: true
+                isReadOnly: true
               }
             ])
 
@@ -322,7 +322,7 @@ describe('Model: availableDrives', function () {
                   }
                 ],
                 isSystem: false,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -341,7 +341,7 @@ describe('Model: availableDrives', function () {
                   path: '/mnt/foo'
                 } ],
                 isSystem: true,
-                isReadonly: false
+                isReadOnly: false
               }
             ])
 
@@ -362,7 +362,7 @@ describe('Model: availableDrives', function () {
               path: '/mnt/foo'
             } ],
             isSystem: false,
-            isReadonly: false
+            isReadOnly: false
           },
           {
             device: '/dev/sdc',
@@ -372,7 +372,7 @@ describe('Model: availableDrives', function () {
               path: '/mnt/bar'
             } ],
             isSystem: false,
-            isReadonly: false
+            isReadOnly: false
           }
         ]
 
@@ -390,7 +390,7 @@ describe('Model: availableDrives', function () {
                 path: '/mnt/bar'
               } ],
               isSystem: false,
-              isReadonly: false
+              isReadOnly: false
             }
           ])
 
@@ -416,7 +416,7 @@ describe('Model: availableDrives', function () {
                 path: '/mnt/bar'
               } ],
               isSystem: false,
-              isReadonly: false
+              isReadOnly: false
             },
             {
               device: '/dev/sdb',
@@ -426,7 +426,7 @@ describe('Model: availableDrives', function () {
                 path: '/mnt/foo'
               } ],
               isSystem: false,
-              isReadonly: false
+              isReadOnly: false
             }
           ])
 

--- a/tests/shared/models/selection-state.spec.js
+++ b/tests/shared/models/selection-state.spec.js
@@ -83,13 +83,13 @@ describe('Model: selectionState', function () {
           device: '/dev/disk2',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         },
         {
           device: '/dev/disk5',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         }
       ])
 
@@ -103,7 +103,7 @@ describe('Model: selectionState', function () {
           device: '/dev/disk2',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         })
       })
     })
@@ -123,7 +123,7 @@ describe('Model: selectionState', function () {
           device: '/dev/disk5',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         })
       })
     })
@@ -145,7 +145,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk5',
             name: 'USB Drive',
             size: 999999999,
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -155,7 +155,7 @@ describe('Model: selectionState', function () {
           device: '/dev/disk5',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         })
       })
 
@@ -165,7 +165,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk1',
             name: 'USB Drive',
             size: 999999999,
-            isReadonly: true
+            isReadOnly: true
           }
         ])
 
@@ -180,7 +180,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk1',
             name: 'USB Drive',
             size: 999999999,
-            isReadonly: true
+            isReadOnly: true
           }
         ])
 
@@ -226,7 +226,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk2',
             name: 'USB Drive',
             size: 999999998,
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -756,7 +756,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk1',
             name: 'USB Drive',
             size: 999999999,
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -785,7 +785,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk1',
             name: 'USB Drive',
             size: 1200000000,
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -828,7 +828,7 @@ describe('Model: selectionState', function () {
                 path: path.dirname(imagePath)
               }
             ],
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -860,7 +860,7 @@ describe('Model: selectionState', function () {
           device: '/dev/disk1',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         }
       ])
 
@@ -938,7 +938,7 @@ describe('Model: selectionState', function () {
             } ],
             name: '/dev/sdb',
             isSystem: false,
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -985,7 +985,7 @@ describe('Model: selectionState', function () {
           } ],
           name: '/dev/sdb',
           isSystem: false,
-          isReadonly: false
+          isReadOnly: false
         }
 
         availableDrives.setDrives([
@@ -994,7 +994,7 @@ describe('Model: selectionState', function () {
             device: '/dev/disk2',
             name: 'USB Drive',
             size: 999999999,
-            isReadonly: false
+            isReadOnly: false
           }
         ])
 
@@ -1012,7 +1012,7 @@ describe('Model: selectionState', function () {
           device: '/dev/disk2',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         }
 
         m.chai.expect(selectionState.getDrive()).to.deep.equal(this.drive)
@@ -1032,7 +1032,7 @@ describe('Model: selectionState', function () {
           device: '/dev/disk2',
           name: 'USB Drive',
           size: 999999999,
-          isReadonly: false
+          isReadOnly: false
         }
 
         m.chai.expect(selectionState.hasDrive()).to.be.false


### PR DESCRIPTION
This fixes the camelcasing of the `.isReadOnly` property
of detected storage devices.

Change-Type: patch