### PR TITLE
chore: encode complete paths to patched file in patches/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ $(BUILD_DIRECTORY)/$(APPLICATION_NAME)-cli-$(APPLICATION_VERSION)-$(PLATFORM)-$(
 		-x $@ \
 		-t node \
 		-s "$(PLATFORM)"
-	git apply --directory $@/node_modules/lzma-native patches/cli/lzma-native-index-static-addon-require.patch
+	patch --directory=$@ --force --strip=1 --ignore-whitespace < patches/lzma-native-index-static-addon-require.patch
 	cp -r lib $@
 	cp package.json $@
 

--- a/patches/lzma-native-index-static-addon-require.patch
+++ b/patches/lzma-native-index-static-addon-require.patch
@@ -1,7 +1,5 @@
-diff --git a/index.js b/index.js
-index 1e7c766..e42c513 100644
---- a/index.js
-+++ b/index.js
+--- b/node_modules/lzma-native/index.js	2018-01-23 14:37:50.000000000 -0400
++++ a/node_modules/lzma-native/index.js	2018-01-23 14:37:00.000000000 -0400
 @@ -7,11 +7,8 @@ var extend = require('util-extend');
  var assert = require('assert');
  var fs = require('fs');


### PR DESCRIPTION
So that the build system doesn't need to know in advance at which
directory the paths needs to be applied.

This will make it easier to add patches support to the Concourse
pipelines.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>