### PR TITLE
upgrade(package): Update yargs 4.7.1 -> 11.0.0

### DIFF
--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -88,7 +88,7 @@ module.exports = yargs
   .help()
 
   // Version option
-  .version(_.constant(packageJSON.version))
+  .version(packageJSON.version)
 
   // Error reporting
   .fail((message, error) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -667,7 +667,8 @@
     },
     "camelcase": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -779,7 +780,8 @@
     },
     "cliui": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "dev": true
     },
     "clone": {
       "version": "1.0.2",
@@ -962,8 +964,7 @@
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -2110,8 +2111,7 @@
     },
     "execa": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -2528,8 +2528,7 @@
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
     "get-object": {
       "version": "0.2.0",
@@ -3346,12 +3345,10 @@
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
         }
       }
     },
@@ -3400,8 +3397,9 @@
       "dev": true
     },
     "lodash.assign": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.0.9.tgz"
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "dev": true
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -3467,10 +3465,6 @@
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
       "dev": true
     },
-    "lodash.keys": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.0.7.tgz"
-    },
     "lodash.mapvalues": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz"
@@ -3484,10 +3478,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
       "dev": true
-    },
-    "lodash.rest": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.3.tgz"
     },
     "lodash.some": {
       "version": "4.6.0",
@@ -4499,8 +4489,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
     },
     "npmlog": {
       "version": "4.0.2",
@@ -4580,7 +4569,8 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -4596,13 +4586,11 @@
     },
     "p-limit": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
     },
     "pac-proxy-agent": {
       "version": "0.2.0",
@@ -4698,8 +4686,7 @@
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
     },
     "path-parse": {
       "version": "1.0.5",
@@ -4771,10 +4758,6 @@
           "dev": true
         }
       }
-    },
-    "pkg-conf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz"
     },
     "pkg-dir": {
       "version": "1.0.0",
@@ -5223,8 +5206,7 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -5525,8 +5507,8 @@
       "dev": true
     },
     "set-blocking": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-1.0.0.tgz"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-getter": {
       "version": "0.1.0",
@@ -5862,10 +5844,6 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-    },
-    "symbol": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz"
     },
     "symbol-observable": {
       "version": "0.2.4",
@@ -6324,6 +6302,16 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
           "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "dev": true
         }
       }
     },
@@ -6645,7 +6633,8 @@
     },
     "window-size": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "dev": true
     },
     "winusb-driver-generator": {
       "version": "1.1.1",
@@ -6724,16 +6713,50 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
     },
     "yargs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz"
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz"
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
+        }
+      }
     },
     "yargs-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.0.tgz",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "uuid": "3.0.1",
     "winusb-driver-generator": "1.1.1",
     "xml2js": "0.4.17",
-    "yargs": "4.7.1",
+    "yargs": "11.0.0",
     "yauzl": "2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates `yargs` to 11.0.0, while also fixing #1452:

Before:
```
$ ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron lib/cli/etcher.js
Usage: node_modules/electron/dist/Electron.app/Contents/MacOS/Electron lib/cli/etcher.js [options] <image>

Options:
  --help, -h     show help  [boolean]
  --version, -v  show version number  [boolean]
  --drive, -d    drive  [string]
  --check, -c    validate write  [boolean] [default: true]
  --yes, -y      confirm non-interactively  [boolean]
  --unmount, -u  unmount on success  [boolean] [default: true]

Examples:
  node_modules/electron/dist/Electron.app/Contents/MacOS/Electron lib/cli/etcher.js raspberry-pi.img
  node_modules/electron/dist/Electron.app/Contents/MacOS/Electron lib/cli/etcher.js --no-check raspberry-pi.img
  node_modules/electron/dist/Electron.app/Contents/MacOS/Electron lib/cli/etcher.js -d /dev/disk2 ubuntu.iso
  node_modules/electron/dist/Electron.app/Contents/MacOS/Electron lib/cli/etcher.js -d /dev/disk2 -y rpi.img

```

After:
```
$ env ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron lib/cli/etcher.js
Usage: etcher.js [options] <image>

Options:
  --help, -h     show help  [boolean]
  --version, -v  show version number  [boolean]
  --drive, -d    drive  [string]
  --check, -c    validate write  [boolean] [default: true]
  --yes, -y      confirm non-interactively  [boolean]
  --unmount, -u  unmount on success  [boolean] [default: true]

Examples:
  etcher.js raspberry-pi.img
  etcher.js --no-check raspberry-pi.img
  etcher.js -d /dev/disk2 ubuntu.iso
  etcher.js -d /dev/disk2 -y rpi.img

```

Change-Type: patch
Connects To: #1452