### PR TITLE
fix(gui): Fix menu's application name

### DIFF
--- a/lib/gui/menu.js
+++ b/lib/gui/menu.js
@@ -17,6 +17,7 @@
 'use strict'
 
 const electron = require('electron')
+const packageJson = require('../../package.json')
 
 const menuTemplate = [
   {
@@ -68,7 +69,7 @@ const menuTemplate = [
 
 if (process.platform === 'darwin') {
   menuTemplate.unshift({
-    label: electron.app.getName(),
+    label: packageJson.displayName,
     submenu: [ {
       role: 'about'
     }, {
@@ -98,7 +99,7 @@ if (process.platform === 'darwin') {
   })
 } else {
   menuTemplate.unshift({
-    label: electron.app.getName(),
+    label: packageJson.displayName,
     submenu: [ {
       label: 'Settings',
       click () {


### PR DESCRIPTION
This replaces use of `electron.app.getName()` with the package.json's `.displayName`
property to ensure the correct application name is displayed when packaged.

Change-Type: patch