### PR TITLE
upgrade(package): Update udif 0.10 -> 0.13

### DIFF
--- a/lib/image-stream/handlers.js
+++ b/lib/image-stream/handlers.js
@@ -179,8 +179,6 @@ module.exports = {
         extension: fileExtensions.getLastFileExtension(imagePath),
         stream: udif.createReadStream(imagePath),
         size: {
-          // FIXME(jhermsmeier): Originally `options.size`,
-          // See discussion in https://github.com/resin-io/etcher/pull/1587
           original: options.size,
           final: {
             estimation: false,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -204,8 +204,8 @@
       }
     },
     "apple-data-compression": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.1.0.tgz"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/apple-data-compression/-/apple-data-compression-0.2.0.tgz"
     },
     "aproba": {
       "version": "1.1.1",
@@ -413,8 +413,7 @@
     },
     "base64-js": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -4913,12 +4912,10 @@
     "plist": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "xmlbuilder": {
           "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
         }
       }
     },
@@ -6230,22 +6227,8 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "udif": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/udif/-/udif-0.10.0.tgz",
-      "dependencies": {
-        "base64-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
-        },
-        "plist": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz"
-        },
-        "xmlbuilder": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
-        }
-      }
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/udif/-/udif-0.13.0.tgz"
     },
     "uglify-js": {
       "version": "2.8.13",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "speedometer": "1.0.0",
     "sudo-prompt": "8.0.0",
     "trackjs": "2.3.1",
-    "udif": "0.10.0",
+    "udif": "0.13.0",
     "unbzip2-stream": "github:resin-io-modules/unbzip2-stream#core-streams",
     "usb": "github:tessel/node-usb#1.3.0",
     "uuid": "3.0.1",


### PR DESCRIPTION
This updates `udif` to v0.13.0:

**v0.13.0:**

- fix(readstream): Use strict mode for compat with Node 4
- refactor(lib): Improve & fix zerofill streaming
- test: Add passthrough to check for read/push after EOD
- test: Add compression method tests
- feat(udif): Add LZFSE compression type constant
- fix(readstream): Fix passing on readable stream options

**v0.12.0:**

- feat(image): Support use of custom `fs` instances
- feat(readstream): Stream ZEROFILL & FREE blocks

Fixes a buffer allocation failure on large zerofill ranges.

Change-Type: patch
Changelog-Entry: Fix "Array buffer allocation failed" when flashing some .dmg images