### PR TITLE
fix: specify utf-8 encoding with meta tag

### DIFF
--- a/lib/gui/index.html
+++ b/lib/gui/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8" />
     <title>Etcher</title>
     <link rel="stylesheet" type="text/css" href="../../node_modules/flexboxgrid/dist/flexboxgrid.css">
     <link rel="stylesheet" type="text/css" href="css/main.css">


### PR DESCRIPTION
We specify the encoding to be UTF-8 with a meta tag such that Electron
won't get confused and try any other encodings.

Change-Type: patch
Changelog-Entry: Specify UTF-8 encoding with meta tag.