### PR TITLE
doc(github): Update instructions in ISSUE_TEMPLATE

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.md]
+trim_trailing_whitespace = false
+
 [Makefile]
 indent_style = tab

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-- **Etcher version:**
-- **Operating system and architecture:**
-- **Image flashed:**
-- **Do you see any meaningful error information in the DevTools?**
+- **Etcher version:** 
+- **Operating system and architecture:** 
+- **Image flashed:** 
+- **Do you see any meaningful error information in the DevTools?** 
 
-<!-- You can open DevTools by pressing `Ctrl+Alt+I`, or `Cmd+Alt+I` if you're running OS X. -->
+<!-- You can open DevTools by pressing `Ctrl+Shift+I` (`Ctrl+Alt+I` for Etcher before v1.3.x), or `Cmd+Alt+I` if you're on Mac OS. -->


### PR DESCRIPTION
This updates the instructions to open the Developer Tools in the issue template,
as the keyboard shortcuts have changed to their defaults on Linux & Windows
from <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>I</kbd> to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>.

Further, the editor config is updated to allow trailing spaces in Markdown
files to add trailing spaces to the list items in the issue template, in
order to avoid people not putting whitespace in between, causing the formatting
to not be parsed properly.

Change-Type: patch
Connects To: https://github.com/resin-io/etcher/issues/2001
See also: https://github.com/resin-io/etcher/pull/1997