### PR TITLE
feat(gui): Add ref params to homepage links in menu

### DIFF
--- a/lib/gui/menu.js
+++ b/lib/gui/menu.js
@@ -84,13 +84,13 @@ const buildWindowMenu = (window) => {
         {
           label: 'Etcher Pro',
           click () {
-            electron.shell.openExternal('https://etcher.io/pro')
+            electron.shell.openExternal('https://etcher.io/pro?utm_source=etcher_menu&ref=etcher_menu')
           }
         },
         {
           label: 'Etcher Website',
           click () {
-            electron.shell.openExternal('https://etcher.io')
+            electron.shell.openExternal('https://etcher.io?ref=etcher_menu')
           }
         },
         {


### PR DESCRIPTION
This adds a `ref` param to the URLs in the menu,
in order to see where page views are coming from.

Change-Type: patch