### PR TITLE
fix: move tabindex attrs to button from within

### DIFF
--- a/lib/gui/app/index.html
+++ b/lib/gui/app/index.html
@@ -13,22 +13,22 @@
     <header class="section-header" ng-controller="HeaderController as header">
       <button class="button button-link"
         ng-click="header.openHelpPage()"
-        tabindex="-1">
-        <span tabindex="4" class="glyphicon glyphicon-question-sign"></span>
+        tabindex="4">
+        <span class="glyphicon glyphicon-question-sign"></span>
       </button>
 
       <button class="button button-link"
         ui-sref="settings"
         hide-if-state="settings"
-        tabindex="-1">
-        <span tabindex="5" class="glyphicon glyphicon-cog"></span>
+        tabindex="5">
+        <span class="glyphicon glyphicon-cog"></span>
       </button>
 
       <button class="button button-link"
-        tabindex="-1"
+        tabindex="5"
         ui-sref="main"
         show-if-state="settings">
-        <span tabindex="5" class="glyphicon glyphicon-chevron-left"></span> Back
+        <span class="glyphicon glyphicon-chevron-left"></span> Back
       </button>
     </header>
 


### PR DESCRIPTION
We move the `tabindex` attributes to the button element directly from
elements contained within the button element – this is to satisfy the
HTML linter.

Changelog-Entry: Move tabindex attributes to button elements from
contained elements.
Change-Type: patch