### PR TITLE
feat(lib): Use win-drive-clean instead of diskpart

### DIFF
--- a/lib/cli/diskpart.js
+++ b/lib/cli/diskpart.js
@@ -16,70 +16,13 @@
 
 'use strict'
 
-const os = require('os')
-const fs = require('fs')
-const path = require('path')
-const crypto = require('crypto')
-const childProcess = require('child_process')
 const debug = require('debug')('etcher:cli:diskpart')
 const Promise = require('bluebird')
 const retry = require('bluebird-retry')
+const driveClean = require('win-drive-clean')
 
-const TMP_RANDOM_BYTES = 6
 const DISKPART_DELAY = 2000
 const DISKPART_RETRIES = 5
-
-/**
- * @summary Generate a tmp filename with full path of OS' tmp dir
- * @function
- * @private
- *
- * @param {String} extension - temporary file extension
- * @returns {String} filename
- *
- * @example
- * const filename = tmpFilename('.sh');
- */
-const tmpFilename = (extension) => {
-  const random = crypto.randomBytes(TMP_RANDOM_BYTES).toString('hex')
-  const filename = `etcher-diskpart-${random}${extension}`
-  return path.join(os.tmpdir(), filename)
-}
-
-/**
- * @summary Run a diskpart script
- * @param {Array<String>} commands - list of commands to run
- * @param {Function} callback - callback(error)
- * @example
- * runDiskpart(['rescan'], (error) => {
- *   ...
- * })
- */
-const runDiskpart = (commands, callback) => {
-  if (os.platform() !== 'win32') {
-    callback()
-    return
-  }
-
-  const filename = tmpFilename('')
-  const script = commands.join('\r\n')
-
-  fs.writeFile(filename, script, {
-    mode: 0o755
-  }, (writeError) => {
-    debug('write %s:', filename, writeError || 'OK')
-
-    childProcess.exec(`diskpart /s ${filename}`, (execError, stdout, stderr) => {
-      debug('stdout:', stdout)
-      debug('stderr:', stderr)
-
-      fs.unlink(filename, (unlinkError) => {
-        debug('unlink %s:', filename, unlinkError || 'OK')
-        callback(execError)
-      })
-    })
-  })
-}
 
 module.exports = {
 
@@ -93,32 +36,21 @@ module.exports = {
    * @returns {Promise}
    */
   clean (device) {
-    if (os.platform() !== 'win32') {
-      return Promise.resolve()
-    }
-
     debug('clean', device)
 
-    const pattern = /PHYSICALDRIVE(\d+)/i
-
-    if (pattern.test(device)) {
-      const deviceId = device.match(pattern).pop()
-      return retry(() => {
-        return new Promise((resolve, reject) => {
-          runDiskpart([ `select disk ${deviceId}`, 'clean', 'rescan' ], (error) => {
-            return error ? reject(error) : resolve()
-          })
-        }).delay(DISKPART_DELAY)
-      }, {
-        /* eslint-disable camelcase */
-        max_tries: DISKPART_RETRIES
-        /* eslint-enable camelcase */
-      }).catch((error) => {
-        throw new Error(`Couldn't clean the drive, ${error.failure.message} (code ${error.failure.code})`)
-      })
-    }
-
-    return Promise.reject(new Error(`Invalid device: "${device}"`))
+    // NOTE: This is a noop on Linux & Mac OS at this time and
+    // will always succeed without doing anything
+    return retry(() => {
+      return new Promise((resolve, reject) => {
+        driveClean(device, (error) => {
+          return error ? reject(error) : resolve()
+        })
+      }).delay(DISKPART_DELAY)
+    }, {
+      /* eslint-disable camelcase */
+      max_tries: DISKPART_RETRIES
+      /* eslint-enable camelcase */
+    })
   }
 
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1891,6 +1891,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz"
+    },
     "decompress-zip": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
@@ -2043,6 +2047,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "dev": true
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
     },
     "detect-node": {
       "version": "2.0.3",
@@ -5457,6 +5465,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
     },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz"
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -7163,6 +7175,10 @@
       "resolved": "https://registry.npmjs.org/simple-bufferstream/-/simple-bufferstream-1.0.0.tgz",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz"
+    },
     "simple-fmt": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
@@ -8472,6 +8488,10 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz"
+    },
     "wide-align": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
@@ -8500,6 +8520,40 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
+        }
+      }
+    },
+    "win-drive-clean": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/win-drive-clean/-/win-drive-clean-1.0.1.tgz",
+      "dependencies": {
+        "bindings": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+        },
+        "nan": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+        },
+        "node-abi": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.2.0.tgz"
+        },
+        "prebuild-install": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz"
+        },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz"
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
+        },
+        "simple-get": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "unbzip2-stream": "github:resin-io-modules/unbzip2-stream#core-streams",
     "usb": "github:tessel/node-usb#1.3.0",
     "uuid": "3.0.1",
+    "win-drive-clean": "1.0.1",
     "winusb-driver-generator": "1.1.1",
     "xml2js": "0.4.17",
     "yargs": "11.0.0",


### PR DESCRIPTION
This replaces shelling out to `diskpart` on Windows to clear
the partition table with `win-drive-clean`, which does so via DeviceIoControl.

**TODO:**
- [x] Changelog entry
- [x] Publish `win-drive-clean` to npm & update package.json & shrinkwrap
- [x] Evaluate whether this actually resolves the issues with diskpart on Windows

Change-Type: minor
Changelog-Entry: Use native code to clean drives on Windows
Connects To: #1793 #1991 