### PR TITLE
chore(package): Remove unnecessary deps

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6339,10 +6339,6 @@
       "resolved": "https://registry.npmjs.org/tracery/-/tracery-1.0.3.tgz",
       "dev": true
     },
-    "trackjs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/trackjs/-/trackjs-2.3.1.tgz"
-    },
     "traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2512,11 +2512,6 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dev": true
     },
-    "file-exists": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-1.0.0.tgz",
-      "dev": true
-    },
     "file-name": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "eslint-plugin-node": "6.0.0",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-standard": "3.0.1",
-    "file-exists": "1.0.0",
     "html-angular-validate": "0.1.9",
     "mocha": "3.2.0",
     "mochainon": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "semver": "5.1.1",
     "speedometer": "1.0.0",
     "sudo-prompt": "8.0.0",
-    "trackjs": "2.3.1",
     "udif": "0.13.0",
     "unbzip2-stream": "github:resin-io-modules/unbzip2-stream#core-streams",
     "usb": "github:tessel/node-usb#1.3.0",

--- a/tests/image-stream/tester.js
+++ b/tests/image-stream/tester.js
@@ -34,17 +34,17 @@ const doFilesContainTheSameData = (file1, file2) => {
 }
 
 const deleteIfExists = (file) => {
-  return Bluebird.try(() => {
+  return new Bluebird((resolve, reject) => {
     try {
       fs.accessSync(file)
       fs.unlinkSync(file)
     } catch (error) {
       if (error.code !== 'ENOENT') {
-        return Bluebird.reject(error)
+        return reject(error)
       }
     }
 
-    return Bluebird.resolve()
+    resolve()
   })
 }
 

--- a/tests/image-stream/tester.js
+++ b/tests/image-stream/tester.js
@@ -19,8 +19,7 @@
 const m = require('mochainon')
 const _ = require('lodash')
 const Bluebird = require('bluebird')
-const fileExists = require('file-exists')
-const fs = Bluebird.promisifyAll(require('fs'))
+const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const imageStream = require('../../lib/image-stream/index')
@@ -35,9 +34,14 @@ const doFilesContainTheSameData = (file1, file2) => {
 }
 
 const deleteIfExists = (file) => {
-  return Bluebird.try(function () {
-    if (fileExists(file)) {
-      return fs.unlinkAsync(file)
+  return Bluebird.try(() => {
+    try {
+      fs.accessSync(file)
+      fs.unlinkSync(file)
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        return Bluebird.reject(error)
+      }
     }
 
     return Bluebird.resolve()

--- a/tests/image-stream/tester.js
+++ b/tests/image-stream/tester.js
@@ -19,7 +19,7 @@
 const m = require('mochainon')
 const _ = require('lodash')
 const Bluebird = require('bluebird')
-const fs = require('fs')
+const fs = Bluebird.promisifyAll(require('fs'))
 const os = require('os')
 const path = require('path')
 const imageStream = require('../../lib/image-stream/index')
@@ -30,21 +30,6 @@ const doFilesContainTheSameData = (file1, file2) => {
     file2: fs.readFileAsync(file2)
   }).then(function (data) {
     return _.isEqual(data.file1, data.file2)
-  })
-}
-
-const deleteIfExists = (file) => {
-  return new Bluebird((resolve, reject) => {
-    try {
-      fs.accessSync(file)
-      fs.unlinkSync(file)
-    } catch (error) {
-      if (error.code !== 'ENOENT') {
-        return reject(error)
-      }
-    }
-
-    resolve()
   })
 }
 
@@ -93,7 +78,8 @@ exports.extractFromFilePath = function (file, image) {
     }).then(function (areEqual) {
       m.chai.expect(areEqual).to.be.true
     }).finally(function () {
-      return deleteIfExists(output)
+      return fs.unlinkAsync(output)
+        .catch({ code: 'ENOENT' }, _.noop)
     })
   })
 }


### PR DESCRIPTION
This removes unnecessary or unused dependencies; `trackjs` hasn't been in use for a very long time, and `file-exists` was a single use dependency, which can be replaced with a single line of code.