### PR TITLE
refactor: rename selection state and store functions

### DIFF
--- a/lib/gui/app/components/drive-selector/controllers/drive-selector.js
+++ b/lib/gui/app/components/drive-selector/controllers/drive-selector.js
@@ -111,7 +111,7 @@ module.exports = function (
           previouslySelected: selectionState.isCurrentDrive(drive.device)
         })
 
-        selectionState.toggleSetDrive(drive.device)
+        selectionState.toggleDrive(drive.device)
       }
     })
   }
@@ -155,7 +155,7 @@ module.exports = function (
   this.selectDriveAndClose = (drive) => {
     return shouldChangeDriveSelectionState(drive).then((canChangeDriveSelectionState) => {
       if (canChangeDriveSelectionState) {
-        selectionState.setDrive(drive.device)
+        selectionState.selectDrive(drive.device)
 
         analytics.logEvent('Drive selected (double click)')
 

--- a/lib/gui/app/pages/main/controllers/drive-selection.js
+++ b/lib/gui/app/pages/main/controllers/drive-selection.js
@@ -36,7 +36,7 @@ module.exports = function (DriveSelectorService) {
         return
       }
 
-      selectionState.setDrive(drive.device)
+      selectionState.selectDrive(drive.device)
 
       analytics.logEvent('Select drive', {
         device: drive.device,

--- a/lib/gui/app/pages/main/controllers/image-selection.js
+++ b/lib/gui/app/pages/main/controllers/image-selection.js
@@ -105,7 +105,7 @@ module.exports = function (
         return this.reselectImage()
       }
 
-      selectionState.setImage(image)
+      selectionState.selectImage(image)
 
       // An easy way so we can quickly identify if we're making use of
       // certain features without printing pages of text to DevTools.

--- a/lib/shared/models/selection-state.js
+++ b/lib/shared/models/selection-state.js
@@ -49,7 +49,7 @@ exports.selectDrive = (driveDevice) => {
  */
 exports.toggleDrive = (driveDevice) => {
   if (exports.isCurrentDrive(driveDevice)) {
-    exports.unselectDrive()
+    exports.deselectDrive()
   } else {
     exports.selectDrive(driveDevice)
   }
@@ -277,25 +277,25 @@ exports.hasImage = () => {
  * @public
  *
  * @example
- * selectionState.unselectDrive();
+ * selectionState.deselectDrive();
  */
-exports.unselectDrive = () => {
+exports.deselectDrive = () => {
   store.dispatch({
-    type: store.Actions.UNSELECT_DRIVE
+    type: store.Actions.DESELECT_DRIVE
   })
 }
 
 /**
- * @summary Unselect image
+ * @summary Deselect image
  * @function
  * @public
  *
  * @example
- * selectionState.unselectImage();
+ * selectionState.deselectImage();
  */
-exports.unselectImage = () => {
+exports.deselectImage = () => {
   store.dispatch({
-    type: store.Actions.UNSELECT_IMAGE
+    type: store.Actions.DESELECT_IMAGE
   })
 }
 
@@ -316,12 +316,12 @@ exports.unselectImage = () => {
 exports.clear = (options = {}) => {
   if (!options.preserveImage) {
     store.dispatch({
-      type: store.Actions.UNSELECT_IMAGE
+      type: store.Actions.DESELECT_IMAGE
     })
   }
 
   store.dispatch({
-    type: store.Actions.UNSELECT_DRIVE
+    type: store.Actions.DESELECT_DRIVE
   })
 }
 

--- a/lib/shared/models/selection-state.js
+++ b/lib/shared/models/selection-state.js
@@ -21,49 +21,49 @@ const store = require('../store')
 const availableDrives = require('./available-drives')
 
 /**
- * @summary Set a drive
+ * @summary Select a drive by its device path
  * @function
  * @public
  *
- * @param {String} drive - drive device
+ * @param {String} driveDevice - drive device
  *
  * @example
- * selectionState.setDrive('/dev/disk2');
+ * selectionState.selectDrive('/dev/disk2');
  */
-exports.setDrive = (drive) => {
+exports.selectDrive = (driveDevice) => {
   store.dispatch({
     type: store.Actions.SELECT_DRIVE,
-    data: drive
+    data: driveDevice
   })
 }
 
 /**
- * @summary Toggle set drive
+ * @summary Toggle drive selection
  * @function
  * @public
  *
- * @param {String} drive - drive device
+ * @param {String} driveDevice - drive device
  *
  * @example
- * selectionState.toggleSetDrive('/dev/disk2');
+ * selectionState.toggleDrive('/dev/disk2');
  */
-exports.toggleSetDrive = (drive) => {
-  if (exports.isCurrentDrive(drive)) {
-    exports.removeDrive()
+exports.toggleDrive = (driveDevice) => {
+  if (exports.isCurrentDrive(driveDevice)) {
+    exports.unselectDrive()
   } else {
-    exports.setDrive(drive)
+    exports.selectDrive(driveDevice)
   }
 }
 
 /**
- * @summary Set a image
+ * @summary Select an image
  * @function
  * @public
  *
  * @param {Object} image - image
  *
  * @example
- * selectionState.setImage({
+ * selectionState.selectImage({
  *   path: 'foo.img',
  *   size: {
  *     original: 1000000000,
@@ -74,7 +74,7 @@ exports.toggleSetDrive = (drive) => {
  *   }
  * });
  */
-exports.setImage = (image) => {
+exports.selectImage = (image) => {
   store.dispatch({
     type: store.Actions.SELECT_IMAGE,
     data: image
@@ -277,25 +277,25 @@ exports.hasImage = () => {
  * @public
  *
  * @example
- * selectionState.removeDrive();
+ * selectionState.unselectDrive();
  */
-exports.removeDrive = () => {
+exports.unselectDrive = () => {
   store.dispatch({
-    type: store.Actions.REMOVE_DRIVE
+    type: store.Actions.UNSELECT_DRIVE
   })
 }
 
 /**
- * @summary Remove image
+ * @summary Unselect image
  * @function
  * @public
  *
  * @example
- * selectionState.removeImage();
+ * selectionState.unselectImage();
  */
-exports.removeImage = () => {
+exports.unselectImage = () => {
   store.dispatch({
-    type: store.Actions.REMOVE_IMAGE
+    type: store.Actions.UNSELECT_IMAGE
   })
 }
 
@@ -316,12 +316,12 @@ exports.removeImage = () => {
 exports.clear = (options = {}) => {
   if (!options.preserveImage) {
     store.dispatch({
-      type: store.Actions.REMOVE_IMAGE
+      type: store.Actions.UNSELECT_IMAGE
     })
   }
 
   store.dispatch({
-    type: store.Actions.REMOVE_DRIVE
+    type: store.Actions.UNSELECT_DRIVE
   })
 }
 
@@ -330,7 +330,7 @@ exports.clear = (options = {}) => {
  * @function
  * @public
  *
- * @param {String} drive - drive device
+ * @param {String} driveDevice - drive device
  * @returns {Boolean} whether the drive is the current drive
  *
  * @example
@@ -338,10 +338,10 @@ exports.clear = (options = {}) => {
  *   console.log('This is the current drive!');
  * }
  */
-exports.isCurrentDrive = (drive) => {
-  if (!drive) {
+exports.isCurrentDrive = (driveDevice) => {
+  if (!driveDevice) {
     return false
   }
 
-  return drive === _.get(exports.getDrive(), [ 'device' ])
+  return driveDevice === _.get(exports.getDrive(), [ 'device' ])
 }

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -68,8 +68,8 @@ const ACTIONS = _.fromPairs(_.map([
   'UNSET_FLASHING_FLAG',
   'SELECT_DRIVE',
   'SELECT_IMAGE',
-  'UNSELECT_DRIVE',
-  'UNSELECT_IMAGE',
+  'DESELECT_DRIVE',
+  'DESELECT_IMAGE',
   'SET_SETTINGS'
 ], (message) => {
   return [ message, message ]
@@ -108,7 +108,7 @@ const findDrive = (state, device) => {
  *
  * @example
  * const newState = storeReducer(DEFAULT_STATE, {
- *   type: ACTIONS.UNSELECT_DRIVE
+ *   type: ACTIONS.DESELECT_DRIVE
  * });
  */
 const storeReducer = (state = DEFAULT_STATE, action) => {
@@ -162,7 +162,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
         device: selectedDevice
       })) {
         return storeReducer(newState, {
-          type: ACTIONS.UNSELECT_DRIVE
+          type: ACTIONS.DESELECT_DRIVE
         })
       }
 
@@ -429,7 +429,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
           constraints.isDriveSizeRecommended(selectedDrive.toJS(), action.data)
         ])) {
           return storeReducer(state, {
-            type: ACTIONS.UNSELECT_DRIVE
+            type: ACTIONS.DESELECT_DRIVE
           })
         }
 
@@ -437,11 +437,11 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
       }).setIn([ 'selection', 'image' ], Immutable.fromJS(action.data))
     }
 
-    case ACTIONS.UNSELECT_DRIVE: {
+    case ACTIONS.DESELECT_DRIVE: {
       return state.deleteIn([ 'selection', 'drive' ])
     }
 
-    case ACTIONS.UNSELECT_IMAGE: {
+    case ACTIONS.DESELECT_IMAGE: {
       return state.deleteIn([ 'selection', 'image' ])
     }
 

--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -68,8 +68,8 @@ const ACTIONS = _.fromPairs(_.map([
   'UNSET_FLASHING_FLAG',
   'SELECT_DRIVE',
   'SELECT_IMAGE',
-  'REMOVE_DRIVE',
-  'REMOVE_IMAGE',
+  'UNSELECT_DRIVE',
+  'UNSELECT_IMAGE',
   'SET_SETTINGS'
 ], (message) => {
   return [ message, message ]
@@ -108,7 +108,7 @@ const findDrive = (state, device) => {
  *
  * @example
  * const newState = storeReducer(DEFAULT_STATE, {
- *   type: ACTIONS.REMOVE_DRIVE
+ *   type: ACTIONS.UNSELECT_DRIVE
  * });
  */
 const storeReducer = (state = DEFAULT_STATE, action) => {
@@ -162,7 +162,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
         device: selectedDevice
       })) {
         return storeReducer(newState, {
-          type: ACTIONS.REMOVE_DRIVE
+          type: ACTIONS.UNSELECT_DRIVE
         })
       }
 
@@ -429,7 +429,7 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
           constraints.isDriveSizeRecommended(selectedDrive.toJS(), action.data)
         ])) {
           return storeReducer(state, {
-            type: ACTIONS.REMOVE_DRIVE
+            type: ACTIONS.UNSELECT_DRIVE
           })
         }
 
@@ -437,11 +437,11 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
       }).setIn([ 'selection', 'image' ], Immutable.fromJS(action.data))
     }
 
-    case ACTIONS.REMOVE_DRIVE: {
+    case ACTIONS.UNSELECT_DRIVE: {
       return state.deleteIn([ 'selection', 'drive' ])
     }
 
-    case ACTIONS.REMOVE_IMAGE: {
+    case ACTIONS.UNSELECT_IMAGE: {
       return state.deleteIn([ 'selection', 'image' ])
     }
 

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -54,7 +54,7 @@ describe('Browser: MainPage', function () {
           $scope: {}
         })
 
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'rpi.img',
           extension: 'img',
           size: {
@@ -87,7 +87,7 @@ describe('Browser: MainPage', function () {
         })
 
         selectionState.clear()
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'rpi.img',
           extension: 'img',
           size: {
@@ -118,7 +118,7 @@ describe('Browser: MainPage', function () {
         ])
 
         selectionState.clear()
-        selectionState.setDrive('/dev/disk2')
+        selectionState.selectDrive('/dev/disk2')
 
         m.chai.expect(controller.shouldFlashStepBeDisabled()).to.be.true
       })
@@ -139,9 +139,9 @@ describe('Browser: MainPage', function () {
         ])
 
         selectionState.clear()
-        selectionState.setDrive('/dev/disk2')
+        selectionState.selectDrive('/dev/disk2')
 
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'rpi.img',
           extension: 'img',
           size: {
@@ -181,7 +181,7 @@ describe('Browser: MainPage', function () {
           $scope: {}
         })
 
-        selectionState.setImage({
+        selectionState.selectImage({
           path: path.join(__dirname, 'foo', 'bar.img'),
           extension: 'img',
           size: {
@@ -194,7 +194,7 @@ describe('Browser: MainPage', function () {
         })
 
         m.chai.expect(controller.getImageBasename()).to.equal('bar.img')
-        selectionState.removeImage()
+        selectionState.unselectImage()
       })
 
       it('should return an empty string if no selected image', function () {
@@ -202,7 +202,7 @@ describe('Browser: MainPage', function () {
           $scope: {}
         })
 
-        selectionState.removeImage()
+        selectionState.unselectImage()
         m.chai.expect(controller.getImageBasename()).to.equal('')
       })
     })

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -194,7 +194,7 @@ describe('Browser: MainPage', function () {
         })
 
         m.chai.expect(controller.getImageBasename()).to.equal('bar.img')
-        selectionState.unselectImage()
+        selectionState.deselectImage()
       })
 
       it('should return an empty string if no selected image', function () {
@@ -202,7 +202,7 @@ describe('Browser: MainPage', function () {
           $scope: {}
         })
 
-        selectionState.unselectImage()
+        selectionState.deselectImage()
         m.chai.expect(controller.getImageBasename()).to.equal('')
       })
     })

--- a/tests/shared/models/available-drives.spec.js
+++ b/tests/shared/models/available-drives.spec.js
@@ -142,8 +142,8 @@ describe('Model: availableDrives', function () {
 
         describe('given no selected image and no selected drive', function () {
           beforeEach(function () {
-            selectionState.removeDrive()
-            selectionState.removeImage()
+            selectionState.unselectDrive()
+            selectionState.unselectImage()
           })
 
           it('should auto-select a single valid available drive', function () {
@@ -175,8 +175,8 @@ describe('Model: availableDrives', function () {
               this.imagePath = '/mnt/bar/foo.img'
             }
 
-            selectionState.removeDrive()
-            selectionState.setImage({
+            selectionState.unselectDrive()
+            selectionState.selectImage({
               path: this.imagePath,
               extension: 'img',
               size: {
@@ -191,7 +191,7 @@ describe('Model: availableDrives', function () {
           })
 
           afterEach(function () {
-            selectionState.removeImage()
+            selectionState.unselectImage()
           })
 
           it('should not auto-select when there are multiple valid available drives', function () {
@@ -394,11 +394,11 @@ describe('Model: availableDrives', function () {
             }
           ])
 
-          selectionState.setDrive('/dev/sdc')
+          selectionState.selectDrive('/dev/sdc')
         })
 
         afterEach(function () {
-          selectionState.removeDrive()
+          selectionState.unselectDrive()
         })
 
         it('should be deleted if its not contained in the available drives anymore', function () {

--- a/tests/shared/models/available-drives.spec.js
+++ b/tests/shared/models/available-drives.spec.js
@@ -142,8 +142,8 @@ describe('Model: availableDrives', function () {
 
         describe('given no selected image and no selected drive', function () {
           beforeEach(function () {
-            selectionState.unselectDrive()
-            selectionState.unselectImage()
+            selectionState.deselectDrive()
+            selectionState.deselectImage()
           })
 
           it('should auto-select a single valid available drive', function () {
@@ -175,7 +175,7 @@ describe('Model: availableDrives', function () {
               this.imagePath = '/mnt/bar/foo.img'
             }
 
-            selectionState.unselectDrive()
+            selectionState.deselectDrive()
             selectionState.selectImage({
               path: this.imagePath,
               extension: 'img',
@@ -191,7 +191,7 @@ describe('Model: availableDrives', function () {
           })
 
           afterEach(function () {
-            selectionState.unselectImage()
+            selectionState.deselectImage()
           })
 
           it('should not auto-select when there are multiple valid available drives', function () {
@@ -398,7 +398,7 @@ describe('Model: availableDrives', function () {
         })
 
         afterEach(function () {
-          selectionState.unselectDrive()
+          selectionState.deselectDrive()
         })
 
         it('should be deleted if its not contained in the available drives anymore', function () {

--- a/tests/shared/models/selection-state.spec.js
+++ b/tests/shared/models/selection-state.spec.js
@@ -93,7 +93,7 @@ describe('Model: selectionState', function () {
         }
       ])
 
-      selectionState.setDrive('/dev/disk2')
+      selectionState.selectDrive('/dev/disk2')
     })
 
     describe('.getDrive()', function () {
@@ -117,7 +117,7 @@ describe('Model: selectionState', function () {
 
     describe('.setDrive()', function () {
       it('should override the drive', function () {
-        selectionState.setDrive('/dev/disk5')
+        selectionState.selectDrive('/dev/disk5')
         const drive = selectionState.getDrive()
         m.chai.expect(drive).to.deep.equal({
           device: '/dev/disk5',
@@ -130,7 +130,7 @@ describe('Model: selectionState', function () {
 
     describe('.removeDrive()', function () {
       it('should clear the drive', function () {
-        selectionState.removeDrive()
+        selectionState.unselectDrive()
         const drive = selectionState.getDrive()
         m.chai.expect(drive).to.be.undefined
       })
@@ -149,7 +149,7 @@ describe('Model: selectionState', function () {
           }
         ])
 
-        selectionState.setDrive('/dev/disk5')
+        selectionState.selectDrive('/dev/disk5')
         const drive = selectionState.getDrive()
         m.chai.expect(drive).to.deep.equal({
           device: '/dev/disk5',
@@ -170,7 +170,7 @@ describe('Model: selectionState', function () {
         ])
 
         m.chai.expect(function () {
-          selectionState.setDrive('/dev/disk1')
+          selectionState.selectDrive('/dev/disk1')
         }).to.throw('The drive is write-protected')
       })
 
@@ -185,13 +185,13 @@ describe('Model: selectionState', function () {
         ])
 
         m.chai.expect(function () {
-          selectionState.setDrive('/dev/disk5')
+          selectionState.selectDrive('/dev/disk5')
         }).to.throw('The drive is not available: /dev/disk5')
       })
 
       it('should throw if device is not a string', function () {
         m.chai.expect(function () {
-          selectionState.setDrive(123)
+          selectionState.selectDrive(123)
         }).to.throw('Invalid drive: 123')
       })
     })
@@ -216,7 +216,7 @@ describe('Model: selectionState', function () {
         logo: '<svg><text fill="red">Raspbian</text></svg>'
       }
 
-      selectionState.setImage(this.image)
+      selectionState.selectImage(this.image)
     })
 
     describe('.setDrive()', function () {
@@ -231,7 +231,7 @@ describe('Model: selectionState', function () {
         ])
 
         m.chai.expect(function () {
-          selectionState.setDrive('/dev/disk2')
+          selectionState.selectDrive('/dev/disk2')
         }).to.throw('The drive is not large enough')
       })
     })
@@ -300,7 +300,7 @@ describe('Model: selectionState', function () {
 
     describe('.setImage()', function () {
       it('should override the image', function () {
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'bar.img',
           extension: 'img',
           size: {
@@ -321,7 +321,7 @@ describe('Model: selectionState', function () {
 
     describe('.removeImage()', function () {
       it('should clear the image', function () {
-        selectionState.removeImage()
+        selectionState.unselectImage()
 
         const imagePath = selectionState.getImagePath()
         m.chai.expect(imagePath).to.be.undefined
@@ -334,7 +334,7 @@ describe('Model: selectionState', function () {
   describe('given no image', function () {
     describe('.setImage()', function () {
       it('should be able to set an image', function () {
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'foo.img',
           extension: 'img',
           size: {
@@ -353,7 +353,7 @@ describe('Model: selectionState', function () {
       })
 
       it('should be able to set an image with an archive extension', function () {
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'foo.zip',
           extension: 'img',
           archiveExtension: 'zip',
@@ -371,7 +371,7 @@ describe('Model: selectionState', function () {
       })
 
       it('should infer a compressed raw image if the penultimate extension is missing', function () {
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'foo.xz',
           extension: 'img',
           archiveExtension: 'xz',
@@ -389,7 +389,7 @@ describe('Model: selectionState', function () {
       })
 
       it('should infer a compressed raw image if the penultimate extension is not a file extension', function () {
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'something.linux-x86-64.gz',
           extension: 'img',
           archiveExtension: 'gz',
@@ -408,7 +408,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if no path', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             extension: 'img',
             size: {
               original: 999999999,
@@ -423,7 +423,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if path is not a string', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 123,
             extension: 'img',
             size: {
@@ -439,7 +439,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if no extension', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             size: {
               original: 999999999,
@@ -454,7 +454,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if extension is not a string', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 1,
             size: {
@@ -470,7 +470,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the extension doesn\'t match the path and there is no archive extension', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'iso',
             size: {
@@ -486,7 +486,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the extension doesn\'t match the path and the archive extension is not a string', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'iso',
             archiveExtension: 1,
@@ -503,7 +503,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the archive extension doesn\'t match the last path extension in a compressed image', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img.xz',
             extension: 'img',
             archiveExtension: 'gz',
@@ -520,7 +520,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the extension is not recognised in an uncompressed image', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.ifg',
             extension: 'ifg',
             size: {
@@ -536,7 +536,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the extension is not recognised in a compressed image', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.ifg.gz',
             extension: 'ifg',
             archiveExtension: 'gz',
@@ -553,7 +553,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the archive extension is not recognised', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img.ifg',
             extension: 'img',
             archiveExtension: 'ifg',
@@ -570,7 +570,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if no size', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img'
           })
@@ -579,7 +579,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if size is not a plain object', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: 999999999
@@ -589,7 +589,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the original size is not a number', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -605,7 +605,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the original size is a float number', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -621,7 +621,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the original size is negative', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -637,7 +637,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the final size is not a number', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -653,7 +653,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the final size is a float number', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -669,7 +669,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the final size is negative', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -685,7 +685,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if the final size estimation flag is not a boolean', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -701,7 +701,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if url is defined but it\'s not a string', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -718,7 +718,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if name is defined but it\'s not a string', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -735,7 +735,7 @@ describe('Model: selectionState', function () {
 
       it('should throw if logo is defined but it\'s not a string', function () {
         m.chai.expect(function () {
-          selectionState.setImage({
+          selectionState.selectImage({
             path: 'foo.img',
             extension: 'img',
             size: {
@@ -760,10 +760,10 @@ describe('Model: selectionState', function () {
           }
         ])
 
-        selectionState.setDrive('/dev/disk1')
+        selectionState.selectDrive('/dev/disk1')
         m.chai.expect(selectionState.hasDrive()).to.be.true
 
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'foo.img',
           extension: 'img',
           size: {
@@ -776,7 +776,7 @@ describe('Model: selectionState', function () {
         })
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.removeImage()
+        selectionState.unselectImage()
       })
 
       it('should de-select a previously selected not-recommended drive', function () {
@@ -789,10 +789,10 @@ describe('Model: selectionState', function () {
           }
         ])
 
-        selectionState.setDrive('/dev/disk1')
+        selectionState.selectDrive('/dev/disk1')
         m.chai.expect(selectionState.hasDrive()).to.be.true
 
-        selectionState.setImage({
+        selectionState.selectImage({
           path: 'foo.img',
           extension: 'img',
           size: {
@@ -806,7 +806,7 @@ describe('Model: selectionState', function () {
         })
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.removeImage()
+        selectionState.unselectImage()
       })
 
       it('should de-select a previously selected source drive', function () {
@@ -832,10 +832,10 @@ describe('Model: selectionState', function () {
           }
         ])
 
-        selectionState.setDrive('/dev/disk1')
+        selectionState.selectDrive('/dev/disk1')
         m.chai.expect(selectionState.hasDrive()).to.be.true
 
-        selectionState.setImage({
+        selectionState.selectImage({
           path: imagePath,
           extension: 'img',
           size: {
@@ -848,7 +848,7 @@ describe('Model: selectionState', function () {
         })
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.removeImage()
+        selectionState.unselectImage()
       })
     })
   })
@@ -864,9 +864,9 @@ describe('Model: selectionState', function () {
         }
       ])
 
-      selectionState.setDrive('/dev/disk1')
+      selectionState.selectDrive('/dev/disk1')
 
-      selectionState.setImage({
+      selectionState.selectImage({
         path: 'foo.img',
         extension: 'img',
         size: {
@@ -942,7 +942,7 @@ describe('Model: selectionState', function () {
           }
         ])
 
-        selectionState.setDrive('/dev/sdb')
+        selectionState.selectDrive('/dev/sdb')
       })
 
       it('should return false if an undefined value is passed', function () {
@@ -960,7 +960,7 @@ describe('Model: selectionState', function () {
 
     describe('given no selected drive', function () {
       beforeEach(function () {
-        selectionState.removeDrive()
+        selectionState.unselectDrive()
       })
 
       it('should return false if an undefined value is passed', function () {
@@ -998,12 +998,12 @@ describe('Model: selectionState', function () {
           }
         ])
 
-        selectionState.setDrive(this.drive.device)
+        selectionState.selectDrive(this.drive.device)
       })
 
       it('should be able to remove the drive', function () {
         m.chai.expect(selectionState.hasDrive()).to.be.true
-        selectionState.toggleSetDrive(this.drive.device)
+        selectionState.toggleDrive(this.drive.device)
         m.chai.expect(selectionState.hasDrive()).to.be.false
       })
 
@@ -1016,7 +1016,7 @@ describe('Model: selectionState', function () {
         }
 
         m.chai.expect(selectionState.getDrive()).to.deep.equal(this.drive)
-        selectionState.toggleSetDrive(drive.device)
+        selectionState.toggleDrive(drive.device)
         m.chai.expect(selectionState.getDrive()).to.deep.equal(drive)
         m.chai.expect(selectionState.getDrive()).to.not.deep.equal(this.drive)
       })
@@ -1024,7 +1024,7 @@ describe('Model: selectionState', function () {
 
     describe('given no selected drive', function () {
       beforeEach(function () {
-        selectionState.removeDrive()
+        selectionState.unselectDrive()
       })
 
       it('should set the drive', function () {
@@ -1036,7 +1036,7 @@ describe('Model: selectionState', function () {
         }
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.toggleSetDrive(drive.device)
+        selectionState.toggleDrive(drive.device)
         m.chai.expect(selectionState.getDrive()).to.deep.equal(drive)
       })
     })

--- a/tests/shared/models/selection-state.spec.js
+++ b/tests/shared/models/selection-state.spec.js
@@ -130,7 +130,7 @@ describe('Model: selectionState', function () {
 
     describe('.removeDrive()', function () {
       it('should clear the drive', function () {
-        selectionState.unselectDrive()
+        selectionState.deselectDrive()
         const drive = selectionState.getDrive()
         m.chai.expect(drive).to.be.undefined
       })
@@ -321,7 +321,7 @@ describe('Model: selectionState', function () {
 
     describe('.removeImage()', function () {
       it('should clear the image', function () {
-        selectionState.unselectImage()
+        selectionState.deselectImage()
 
         const imagePath = selectionState.getImagePath()
         m.chai.expect(imagePath).to.be.undefined
@@ -776,7 +776,7 @@ describe('Model: selectionState', function () {
         })
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.unselectImage()
+        selectionState.deselectImage()
       })
 
       it('should de-select a previously selected not-recommended drive', function () {
@@ -806,7 +806,7 @@ describe('Model: selectionState', function () {
         })
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.unselectImage()
+        selectionState.deselectImage()
       })
 
       it('should de-select a previously selected source drive', function () {
@@ -848,7 +848,7 @@ describe('Model: selectionState', function () {
         })
 
         m.chai.expect(selectionState.hasDrive()).to.be.false
-        selectionState.unselectImage()
+        selectionState.deselectImage()
       })
     })
   })
@@ -960,7 +960,7 @@ describe('Model: selectionState', function () {
 
     describe('given no selected drive', function () {
       beforeEach(function () {
-        selectionState.unselectDrive()
+        selectionState.deselectDrive()
       })
 
       it('should return false if an undefined value is passed', function () {
@@ -1024,7 +1024,7 @@ describe('Model: selectionState', function () {
 
     describe('given no selected drive', function () {
       beforeEach(function () {
-        selectionState.unselectDrive()
+        selectionState.deselectDrive()
       })
 
       it('should set the drive', function () {


### PR DESCRIPTION
We rename functions in `selection-state` and the `store`.

Change-Type: patch
Changelog-Entry: Rename selection-state and store functions.