### PR TITLE
feat(writer): Increase UV_THREADPOOL_SIZE

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -32,6 +32,13 @@ const analytics = require('../modules/analytics')
 const packageJSON = require('../../../../package.json')
 
 /**
+ * @summary Number of threads per CPU to allocate to the UV_THREADPOOL
+ * @type {Number}
+ * @constant
+ */
+const THREADS_PER_CPU = 4
+
+/**
  * @summary Get application entry point
  * @function
  * @private
@@ -165,6 +172,7 @@ exports.performWrite = (image, drive, onProgress) => {
           IPC_CLIENT_ID,
           IPC_SOCKET_ROOT: ipc.config.socketRoot,
           ELECTRON_RUN_AS_NODE: 1,
+          UV_THREADPOOL_SIZE: os.cpus().length * THREADS_PER_CPU,
 
           // Casting to Number nicely converts booleans to 0 or 1.
           OPTION_VALIDATE: Number(settings.get('validateWriteOnSuccess')),


### PR DESCRIPTION
This increases the UV_THREADPOOL_SIZE to CPUs * 4 to
facilitate full write speeds when writing to multiple destinations,
in preparation for integrating multi-writes.

Change-Type: patch
Changelog-Entry: Increase UV_THREADPOOL_SIZE to allocate 4 threads per CPU