### PR TITLE
refactor(GUI): remove selection-state clear options to simplify

### DIFF
--- a/lib/gui/app/pages/finish/controllers/finish.js
+++ b/lib/gui/app/pages/finish/controllers/finish.js
@@ -48,7 +48,10 @@ module.exports = function ($state) {
    * FinishController.restart({ preserveImage: true });
    */
   this.restart = (options) => {
-    selectionState.clear(options)
+    if (!options.preserveImage) {
+      selectionState.deselectImage()
+    }
+    selectionState.deselectDrive()
     analytics.logEvent('Restart', options)
     $state.go('main')
   }

--- a/lib/shared/models/selection-state.js
+++ b/lib/shared/models/selection-state.js
@@ -304,25 +304,15 @@ exports.deselectImage = () => {
  * @function
  * @public
  *
- * @param {Object} options - options
- * @param {Boolean} [options.preserveImage] - preserve image
- *
  * @example
  * selectionState.clear();
  *
  * @example
  * selectionState.clear({ preserveImage: true });
  */
-exports.clear = (options = {}) => {
-  if (!options.preserveImage) {
-    store.dispatch({
-      type: store.Actions.DESELECT_IMAGE
-    })
-  }
-
-  store.dispatch({
-    type: store.Actions.DESELECT_DRIVE
-  })
+exports.clear = () => {
+  exports.deselectImage()
+  exports.deselectDrive()
 }
 
 /**

--- a/tests/shared/models/selection-state.spec.js
+++ b/tests/shared/models/selection-state.spec.js
@@ -853,7 +853,7 @@ describe('Model: selectionState', function () {
     })
   })
 
-  describe('given a drive', function () {
+  describe('given a drive and an image', function () {
     beforeEach(function () {
       availableDrives.setDrives([
         {
@@ -890,37 +890,16 @@ describe('Model: selectionState', function () {
         m.chai.expect(selectionState.hasImage()).to.be.false
       })
     })
-
-    describe('given the preserveImage option', function () {
-      beforeEach(function () {
-        selectionState.clear({
-          preserveImage: true
-        })
+    describe('.deselectImage()', function () {
+      it('should not clear any drives', function () {
+        selectionState.deselectImage()
+        m.chai.expect(selectionState.hasDrive()).to.be.true
       })
-
-      it('getDrive() should return undefined', function () {
-        const drive = selectionState.getDrive()
-        m.chai.expect(drive).to.be.undefined
-      })
-
-      it('getImagePath() should return the image path', function () {
-        const imagePath = selectionState.getImagePath()
-        m.chai.expect(imagePath).to.equal('foo.img')
-      })
-
-      it('getImageSize() should return the image size', function () {
-        const imageSize = selectionState.getImageSize()
-        m.chai.expect(imageSize).to.equal(999999999)
-      })
-
-      it('hasDrive() should return false', function () {
-        const hasDrive = selectionState.hasDrive()
-        m.chai.expect(hasDrive).to.be.false
-      })
-
-      it('hasImage() should return true', function () {
-        const hasImage = selectionState.hasImage()
-        m.chai.expect(hasImage).to.be.true
+    })
+    describe('.deselectDrive()', function () {
+      it('should not clear the image', function () {
+        selectionState.deselectDrive()
+        m.chai.expect(selectionState.hasImage()).to.be.true
       })
     })
   })


### PR DESCRIPTION
We refactor and simplify the selection-state `.clear()` by removing the
options argument.

Change-Type: patch
Changelog-Entry: Remove `selectionState.clear()` options argument to
simplify.