### PR TITLE
test: ensure no leftover template expressions

### DIFF
--- a/tests/shared/messages.spec.js
+++ b/tests/shared/messages.spec.js
@@ -30,4 +30,14 @@ describe('Shared: Messages', function () {
       m.chai.expect(_.every(_.map(category, _.isFunction))).to.be.true
     })
   })
+
+  it('should not contain leftover template expressions', function () {
+    _.each(messages, (subMessages) => {
+      _.each(subMessages, (messageFunc) => {
+        const message = messageFunc(..._.fill(Array(10), ''))
+        m.chai.expect(message).to.not.contain('${')
+        m.chai.expect(message).to.not.contain('<%=')
+      })
+    })
+  })
 })


### PR DESCRIPTION
We test for leftover template expressions, including Angluar and
CommonJS template literals. This will ensure we correctly and only
use template literals instead of accidental pure strings or Angular
templates.

Change-Type: patch
Changelog-Entry: Test and ensure there are no leftover template expressions.