### PR TITLE
refactor: remove stale invalid key check in store

### DIFF
--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -458,16 +458,6 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
         })
       }
 
-      const invalidKey = _.find(_.keys(action.data), (key) => {
-        return !_.isString(key)
-      })
-
-      if (!_.isNil(invalidKey)) {
-        throw errors.createError({
-          title: `Invalid setting key: ${invalidKey}`
-        })
-      }
-
       const invalidPair = _.find(_.toPairs(action.data), (pair) => {
         return _.isObject(_.last(pair))
       })


### PR DESCRIPTION
We remove a piece of code checking whether `_.keys` returns any non-string
values in its array, but per the Lodash documentation `_.keys` always returns an
array of strings.

Change-Type: patch
Changelog-Entry: Remove stale `invalidKey` check in store.