### PR TITLE
fix(cli): Remove O_DIRECT & O_EXCL

### DIFF
--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -88,10 +88,8 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
     }).then(() => {
       /* eslint-disable no-bitwise */
       const flags = fs.constants.O_RDWR |
-        fs.constants.O_EXCL |
         fs.constants.O_NONBLOCK |
-        fs.constants.O_SYNC |
-        fs.constants.O_DIRECT
+        fs.constants.O_SYNC
       /* eslint-enable no-bitwise */
 
       return fs.openAsync(driveObject.raw, flags)


### PR DESCRIPTION
This removes O_DIRECT and O_EXCL flags from the writer,
as O_DIRECT can lead to EINVAL under quite a few circumstances,
and O_EXCL has proven to be useless.

Change-Type: patch