### PR TITLE
feat(GUI): add spacing to drive-selector labels

### DIFF
--- a/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -31,9 +31,7 @@
               ng-class="{
                 'label-warning': status.type === modal.constraints.COMPATIBILITY_STATUS_TYPES.WARNING,
                 'label-danger': status.type === modal.constraints.COMPATIBILITY_STATUS_TYPES.ERROR
-              }">
-              {{ status.message }}
-            </span>
+              }">{{ status.message }}</span>
 
           </footer>
           <progress ng-if="drive.progress" value="{{ drive.progress }}" max="100"></progress>

--- a/lib/gui/app/scss/components/_label.scss
+++ b/lib/gui/app/scss/components/_label.scss
@@ -16,6 +16,7 @@
 
 .label {
   font-size: 9px;
+  margin-right: 4.5px;
 }
 
 .label-big {

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6037,7 +6037,8 @@ body {
  * limitations under the License.
  */
 .label {
-  font-size: 9px; }
+  font-size: 9px;
+  margin-right: 4.5px; }
 
 .label-big {
   font-size: 11px;


### PR DESCRIPTION
We add a right margin to the drive-selector labels so they look nicer
when there are multiple.

Change-Type: patch
Changelog-Entry: Add spacing to the drive-selector warning/error labels.