### PR TITLE
fix(GUI): make all class label text bold

### DIFF
--- a/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -32,7 +32,7 @@
                 'label-warning': status.type === modal.constraints.COMPATIBILITY_STATUS_TYPES.WARNING,
                 'label-danger': status.type === modal.constraints.COMPATIBILITY_STATUS_TYPES.ERROR
               }">
-              <b>{{ status.message }}</b>
+              {{ status.message }}
             </span>
 
           </footer>

--- a/lib/gui/app/scss/components/_label.scss
+++ b/lib/gui/app/scss/components/_label.scss
@@ -16,7 +16,6 @@
 
 .label {
   font-size: 9px;
-  font-weight: normal;
 }
 
 .label-big {

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6037,8 +6037,7 @@ body {
  * limitations under the License.
  */
 .label {
-  font-size: 9px;
-  font-weight: normal; }
+  font-size: 9px; }
 
 .label-big {
   font-size: 11px;


### PR DESCRIPTION
We make all tags with `.label` have bold text and remove the need for
`<b>` tags.

Change-Type: patch
Changelog-Entry: Make all `.label` tags' text bold and remove need for `<b>` tags.