### PR TITLE
fix(package): Add fsevents to platform specific deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "platformSpecificDependencies": [
     "7zip-bin-mac",
     "7zip-bin-win",
-    "7zip-bin-linux"
+    "7zip-bin-linux",
+    "fsevents"
   ],
   "dependencies": {
     "angular": "1.6.3",


### PR DESCRIPTION
This adds `fsevents` to the platform specific dependencies,
in order to avoid shrinkwrap disagreements between platforms.

Change-Type: patch