### PR TITLE
minifix: add missing parameter to verifyNoNilFields example

### DIFF
--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -40,7 +40,7 @@ const packageJSON = require('../../package.json')
  *
  * @example
  * const fields = [ 'type', 'percentage' ]
- * verifyNoNilFields(action.data, fields)
+ * verifyNoNilFields(action.data, fields, 'flash')
  */
 const verifyNoNilFields = (object, fields, name) => {
   const nilFields = _.filter(fields, (field) => {


### PR DESCRIPTION
We add the missing `name` parameter to the `verifyNoNilFields` JSDoc
example.

Change-Type: patch
Changelog-Entry: Add missing name param to verifyNoNilFields JSDoc example.