### PR TITLE
fix(image-writer): Fix missing error argv

### DIFF
--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -273,7 +273,7 @@ class ImageWriter extends EventEmitter {
 
     runSeries(tasks, (error) => {
       if (error) {
-        this.emit('error')
+        this.emit('error', error)
         return
       }
 


### PR DESCRIPTION
This fixes a missing error argument being passed in .emit()

Change-Type: patch
Connects To: https://github.com/resin-io/etcher/issues/1990, https://github.com/resin-io/etcher/issues/1697