### PR TITLE
upgrade(package): Update resin-cli-visuals to 1.4.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1563,8 +1563,8 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-spinner": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.6.tgz"
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/cli-spinner/-/cli-spinner-0.2.7.tgz"
     },
     "cli-width": {
       "version": "1.1.1",
@@ -1599,13 +1599,11 @@
     },
     "color-convert": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
     },
     "columnify": {
       "version": "1.5.4",
@@ -5695,8 +5693,8 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "moment-duration-format": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-1.3.0.tgz"
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz"
     },
     "mountutils": {
       "version": "1.3.10",
@@ -6844,52 +6842,32 @@
       }
     },
     "resin-cli-visuals": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.3.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/resin-cli-visuals/-/resin-cli-visuals-1.4.1.tgz",
       "dependencies": {
-        "bindings": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
         },
         "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
         },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz"
         },
-        "drivelist": {
-          "version": "5.2.12",
-          "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-5.2.12.tgz"
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
         },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-        },
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
-        },
-        "prebuild-install": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.4.1.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "redux": "3.5.2",
     "request": "2.81.0",
     "resin-cli-form": "1.4.1",
-    "resin-cli-visuals": "1.3.1",
+    "resin-cli-visuals": "1.4.1",
     "resin-corvus": "1.0.0-beta.31",
     "semver": "5.1.1",
     "speedometer": "1.0.0",


### PR DESCRIPTION
This updates `resin-cli-visuals` in order to fix drive selection in
the CLI, which was caused by incompatibility of two different `drivelist` versions

Change-Type: patch
Connects To: #1990, #1697