### PR TITLE
fix(gui): Disable throttling timers when in background

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -46,7 +46,10 @@ electron.app.on('ready', () => {
     fullscreenable: false,
     autoHideMenuBar: true,
     titleBarStyle: 'hidden-inset',
-    icon: path.join(__dirname, '..', '..', 'assets', 'icon.png')
+    icon: path.join(__dirname, '..', '..', 'assets', 'icon.png'),
+    webPreferences: {
+      backgroundThrottling: false
+    }
   })
 
   buildWindowMenu(mainWindow)


### PR DESCRIPTION
This disables Electron throttling timers when not in the foreground.

Change-Type: patch