### PR TITLE
fix(perf): Remove support for CRC32 checksumming

### DIFF
--- a/lib/cli/etcher.js
+++ b/lib/cli/etcher.js
@@ -90,8 +90,8 @@ permissions.isElevated().then((elevated) => {
   return Bluebird.try(() => {
     console.log(messages.info.flashComplete(path.basename(results.imagePath), results.flash.drive))
 
-    if (results.flash.checksum.crc32) {
-      console.log(`Checksum: ${results.flash.checksum.crc32}`)
+    if (results.flash.checksum.md5) {
+      console.log(`Checksum: ${results.flash.checksum.md5}`)
     }
 
     return Bluebird.resolve()

--- a/lib/cli/writer.js
+++ b/lib/cli/writer.js
@@ -49,7 +49,7 @@ exports.writeImage = (imagePath, drive, options, onProgress) => {
     path: drive,
     imagePath,
     verify: options.validateWriteOnSuccess,
-    checksumAlgorithms: [ 'crc32' ],
+    checksumAlgorithms: [ 'md5' ],
     unmountOnSuccess: options.unmountOnSuccess
   })
 

--- a/lib/sdk/writer/checksum-stream.js
+++ b/lib/sdk/writer/checksum-stream.js
@@ -18,25 +18,7 @@
 
 const stream = require('readable-stream')
 const crypto = require('crypto')
-const CRC32Stream = require('crc32-stream')
 const _ = require('lodash')
-
-/**
- * @summary Get a hash stream
- * @function
- * @private
- * @example
- * var md5Stream = getHashStream('md5')
- *
- * @param {String} algorithm - either `crc32` or anything supported by `crypto.Hash`
- * @returns {Stream.Transform}
- */
-const getHashStream = (algorithm) => {
-  if (algorithm === 'crc32') {
-    return new CRC32Stream()
-  }
-  return crypto.createHash(algorithm)
-}
 
 /**
  * @summary Create an instance of ChecksumStream
@@ -52,13 +34,12 @@ class ChecksumStream extends stream.Transform {
    * @param {String[]} options.algorithms - hash algorithms
    * @example
    * var checksum = new ChecksumStream({
-   *   algorithms: [ 'crc32', 'md5' ]
+   *   algorithms: [ 'md5' ]
    * })
    *
    * checksum.once('checksum', (checksum) => {
    *   // checksum: {
-   *   //   crc32: 'EF28AF1C',
-   *   //   md5: ''
+   *   //   md5: '55a4eb779e08f604c41ba1cbfff47ada'
    *   // }
    * })
    *
@@ -85,7 +66,7 @@ class ChecksumStream extends stream.Transform {
    * const hash = this._createHash(algorithm)
    */
   _createHash (algorithm) {
-    const hash = _.attempt(getHashStream, algorithm)
+    const hash = _.attempt(crypto.createHash, algorithm)
 
     if (_.isError(hash)) {
       hash.message += ` "${algorithm}"`
@@ -108,18 +89,10 @@ class ChecksumStream extends stream.Transform {
       return this.emit('error', error)
     })
 
-    if (algorithm === 'crc32') {
-      hash.once('end', () => {
-        this.results[algorithm] = hash.digest('hex')
-        check()
-      })
-      hash.resume()
-    } else {
-      hash.once('readable', () => {
-        this.results[algorithm] = hash.read().toString('hex')
-        check()
-      })
-    }
+    hash.once('readable', () => {
+      this.results[algorithm] = hash.read().toString('hex')
+      check()
+    })
 
     return hash
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1706,12 +1706,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "crc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz"
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "dev": true
     },
     "crc32-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "dev": true
     },
     "create-ecdh": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "bootstrap-sass": "3.3.6",
     "chalk": "1.1.3",
     "command-join": "2.0.0",
-    "crc32-stream": "2.0.0",
     "debug": "3.1.0",
     "drivelist": "6.0.4",
     "electron-is-running-in-asar": "1.0.0",


### PR DESCRIPTION
As crc32-stream was identified as a massive performance bottleneck,
we remove it, and default to Node's crypto API with md5 instead.

Change-Type: minor