### PR TITLE
fix: stop autoselecting empty value in store

### DIFF
--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -175,6 +175,23 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
       }
 
       const newState = state.set('availableDrives', Immutable.fromJS(drives))
+      const selectedDevices = newState.getIn([ 'selection', 'devices' ]).toJS()
+
+      // Remove selected drives that are stale, i.e. missing from availableDrives
+      const nonStaleNewState = _.reduce(selectedDevices, (accState, device) => {
+        // Check whether the drive still exists in availableDrives
+        if (device && !_.find(drives, {
+          device
+        })) {
+          // Deselect this drive gone from availableDrives
+          return storeReducer(accState, {
+            type: ACTIONS.DESELECT_DRIVE,
+            data: device
+          })
+        }
+
+        return accState
+      }, newState)
 
       const AUTOSELECT_DRIVE_COUNT = 1
       const numberOfDrives = drives.length
@@ -198,36 +215,20 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
 
         ])) {
           // Auto-select this drive
-          return storeReducer(newState, {
+          return storeReducer(nonStaleNewState, {
             type: ACTIONS.SELECT_DRIVE,
             data: drive.device
           })
         }
 
         // Deselect this drive in case it still is selected
-        return storeReducer(newState, {
+        return storeReducer(nonStaleNewState, {
           type: ACTIONS.DESELECT_DRIVE,
           data: drive.device
         })
       }
 
-      const selectedDevices = newState.getIn([ 'selection', 'devices' ]).toJS()
-
-      // Remove selected drives that are stale, i.e. missing from availableDrives
-      return _.reduce(selectedDevices, (accState, device) => {
-        // Check whether the drive still exists in availableDrives
-        if (device && !_.find(drives, {
-          device
-        })) {
-          // Deselect this drive gone from availableDrives
-          return storeReducer(accState, {
-            type: ACTIONS.DESELECT_DRIVE,
-            data: device
-          })
-        }
-
-        return accState
-      }, newState)
+      return nonStaleNewState
     }
 
     case ACTIONS.SET_FLASH_STATE: {


### PR DESCRIPTION
We fix store autoselection, which selects an empty value when one
drive is selected and then ejected, leaving one drive that is
supposed to be autoselectable. Now it instead properly autoselects the
last drive.

Change-Type: patch
Changelog-Entry: Stop store autoselection from selecting empty values on
drive ejection.