### PR TITLE
minifix: use svg contents list in main template

### DIFF
--- a/lib/gui/app/pages/main/templates/main.tpl.html
+++ b/lib/gui/app/pages/main/templates/main.tpl.html
@@ -3,7 +3,7 @@
     <div class="box text-center relative" os-dropzone="image.selectImageByPath($file)">
 
       <div class="center-block">
-        <svg-icon contents="main.selection.getImageLogo()" paths="[ '../../assets/image.svg' ]"></svg-icon>
+        <svg-icon contents="[ main.selection.getImageLogo() ]" paths="[ '../../assets/image.svg' ]"></svg-icon>
       </div>
 
       <div class="space-vertical-large">


### PR DESCRIPTION
We use a list instead of element with `svg-icon` in `main.tpl.html`, as
required by the `svg-icon` component and will return an error
otherwise.

Fixes: https://github.com/resin-io/etcher/issues/2078
Change-Type: patch
Changelog-Entry: Use SVG contents list in main template.