### PR TITLE
fix(scanner): Enable usbboot on Linux if run as root

### DIFF
--- a/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
+++ b/lib/gui/app/components/drive-selector/templates/drive-selector-modal.tpl.html
@@ -11,7 +11,7 @@
       ng-click="modal.toggleDrive(drive)">
         <img class="list-group-item-section" alt="Drive device type logo"
           ng-if="drive.icon"
-          ng-src="./assets/{{drive.icon}}.svg"
+          ng-src="../assets/{{drive.icon}}.svg"
           width="25"
           height="30">
         <div

--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -61,6 +61,8 @@ permissions.isElevated().then((elevated) => {
     scanner.subscribe(adapter)
     scanner.start()
   }
-}).catch(_.noop)
+}).catch((error) => {
+  console.warn('Could not add usbboot adapter:', error)
+})
 
 module.exports = scanner

--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -29,7 +29,7 @@ const permissions = require('../../../shared/permissions')
  * @type {String}
  * @constant
  */
-const BLOBS_DIRECTORY = path.join(__dirname, '..', '..', 'blobs')
+const BLOBS_DIRECTORY = path.join(__dirname, '..', '..', '..', 'blobs')
 
 const scanner = SDK.createScanner({
   blockdevice: {

--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -22,6 +22,7 @@ const fs = Bluebird.promisifyAll(require('fs'))
 const path = require('path')
 const settings = require('../models/settings')
 const SDK = require('../../../sdk')
+const permissions = require('../../../shared/permissions')
 
 /**
  * @summary The Etcher "blobs" directory path
@@ -50,5 +51,16 @@ const scanner = SDK.createScanner({
     }
   }
 })
+
+// NOTE: Enable USBBoot on Linux if run as root
+permissions.isElevated().then((elevated) => {
+  if (elevated && process.platform === 'linux') {
+    const UsbbootAdapter = require('../../../sdk/adapters/usbboot')
+    const adapter = new UsbbootAdapter()
+    scanner.stop()
+    scanner.subscribe(adapter)
+    scanner.start()
+  }
+}).catch(_.noop)
 
 module.exports = scanner


### PR DESCRIPTION
This re-enables the usbboot scanner dynamically if Etcher
is run as root on Linux.

Change-Type: patch