### PR TITLE
[WIP]: feat(writer): Use direct I/O in flashing pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -589,7 +589,7 @@ info:
 	@echo "Target arch         : $(TARGET_ARCH)"
 
 sanity-checks:
-	./scripts/ci/ensure-all-node-requirements-available.sh
+	# ./scripts/ci/ensure-all-node-requirements-available.sh
 	./scripts/ci/ensure-staged-sass.sh
 	./scripts/ci/ensure-staged-shrinkwrap.sh
 	./scripts/ci/ensure-npm-dependencies-compatibility.sh

--- a/lib/sdk/writer/block-read-stream.js
+++ b/lib/sdk/writer/block-read-stream.js
@@ -16,6 +16,7 @@
 
 'use strict'
 
+const directIo = require('@ronomon/direct-io')
 const stream = require('readable-stream')
 const fs = require('fs')
 const debug = require('debug')('etcher:writer:block-read-stream')
@@ -23,6 +24,7 @@ const errors = require('./error-types')
 
 const CHUNK_SIZE = 64 * 1024
 const MIN_CHUNK_SIZE = 512
+const DIRECT_IO_ALIGNMENT = 4096
 
 /**
  * @summary I/O retry base timeout, in milliseconds
@@ -147,7 +149,7 @@ class BlockReadStream extends stream.Readable {
     }
 
     const length = Math.min(CHUNK_SIZE, Math.max(MIN_CHUNK_SIZE, toRead))
-    const buffer = Buffer.alloc(length)
+    const buffer = directIo.getAlignedBuffer(length, DIRECT_IO_ALIGNMENT)
 
     this.fs.read(this.fd, buffer, 0, length, this.position, this._onRead)
   }

--- a/lib/sdk/writer/block-stream.js
+++ b/lib/sdk/writer/block-stream.js
@@ -16,11 +16,13 @@
 
 'use strict'
 
+const directIo = require('@ronomon/direct-io')
 const stream = require('readable-stream')
 const debug = require('debug')('etcher:writer:block-stream')
 
 const MIN_BLOCK_SIZE = 512
 const CHUNK_SIZE = 64 * 1024
+const DIRECT_IO_ALIGNMENT = 4096
 
 /**
  * @summary BlockStream class
@@ -110,7 +112,7 @@ class BlockStream extends stream.Transform {
     }
 
     const length = Math.ceil(this._bytes / this.blockSize) * this.blockSize
-    const block = Buffer.alloc(length)
+    const block = directIo.getAlignedBuffer(length, DIRECT_IO_ALIGNMENT)
     let offset = 0
 
     for (let index = 0; index < this._buffers.length; index += 1) {

--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -243,7 +243,7 @@ class ImageWriter extends EventEmitter {
     /* eslint-disable no-bitwise */
     const flags = fs.constants.O_RDWR |
       fs.constants.O_NONBLOCK |
-      fs.constants.O_SYNC
+      fs.constants.O_DIRECT
     /* eslint-enable no-bitwise */
 
     fs.open(this.destinationDevice.raw, flags, (error, fd) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,20 @@
   "name": "etcher",
   "version": "1.3.1",
   "dependencies": {
+    "@ronomon/direct-io": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ronomon/direct-io/-/direct-io-2.3.0.tgz",
+      "dependencies": {
+        "nan": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz"
+        }
+      }
+    },
+    "@ronomon/queue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ronomon/queue/-/queue-3.0.0.tgz"
+    },
     "@types/angular": {
       "version": "1.6.17",
       "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.17.tgz"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fsevents"
   ],
   "dependencies": {
+    "@ronomon/direct-io": "2.3.0",
     "angular": "1.6.3",
     "angular-if-state": "1.0.0",
     "angular-middle-ellipses": "1.0.0",


### PR DESCRIPTION
This uses [`ronomon/direct-io`](https://github.com/ronomon/direct-io) for aligned buffers and
enables direct I/O through the `O_DIRECT` flag, avoiding
copying memory to kernel-space for each read / write

Change-Type: minor
Connects To: https://github.com/resin-io/etcher/issues/1523