### PR TITLE
fix: use correct usbbot blob path in appimages

### DIFF
--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -23,13 +23,16 @@ const path = require('path')
 const settings = require('../models/settings')
 const SDK = require('../../../sdk')
 const permissions = require('../../../shared/permissions')
+const packageJSON = require('../../../../package.json')
 
 /**
  * @summary The Etcher "blobs" directory path
  * @type {String}
  * @constant
  */
-const BLOBS_DIRECTORY = path.join(__dirname, '..', '..', '..', 'blobs')
+const BLOBS_DIRECTORY = packageJSON.packageType === 'AppImage'
+  ? 'bin/resources/app.asar/lib/blobs'
+  : path.join(__dirname, '..', '..', '..', 'blobs')
 
 const scanner = SDK.createScanner({
   blockdevice: {


### PR DESCRIPTION
We use the `app.asar` relative path to read the usbboot blob files
instead of relative to the normal project root.

Change-Type: patch
Changelog-Entry: Use correct usbboot blob path in AppImages.