### PR TITLE
fix(windows): Disable rebuilding bindings in electron-builder

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,8 +1,8 @@
 appId: io.resin.etcher
 copyright: Copyright 2016-2018 Resinio Ltd
 productName: Etcher
-npmRebuild: true
-nodeGypRebuild: true
+npmRebuild: false
+nodeGypRebuild: false
 publish: null
 files:
   - lib


### PR DESCRIPTION
We disable `npm rebuild` and `node-gyp rebuild` being run through
`electron-builder`, as we already rebuild native bindings against
the respective CPU arch through `make electron-develop`, and
electron-builder doesn't appear to respect package's install / rebuild scripts.

Change-Type: patch