### PR TITLE
fix: ensure flash quantity fields are finite

### DIFF
--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -246,14 +246,14 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
 
       verifyNoNilFields(action.data, flashStateNoNilFields, 'flash')
 
-      if (_.every(_.pick(action.data, [
+      if (!_.every(_.pick(action.data, [
         'flashing',
         'verifying',
         'succeeded',
         'failed'
-      ]), _.identity)) {
+      ]), _.isFinite)) {
         throw errors.createError({
-          title: 'Missing state quantity field(s)'
+          title: 'State quantity field(s) not finite number'
         })
       }
 

--- a/tests/shared/models/flash-state.spec.js
+++ b/tests/shared/models/flash-state.spec.js
@@ -29,7 +29,7 @@ describe('Model: flashState', function () {
       it('should be able to reset the progress state', function () {
         flashState.setFlashingFlag()
         flashState.setProgressState({
-          flashing: 0,
+          flashing: 2,
           verifying: 0,
           succeeded: 0,
           failed: 0,
@@ -324,6 +324,38 @@ describe('Model: flashState', function () {
         })
 
         m.chai.expect(flashState.getFlashState().percentage).to.equal(50)
+      })
+
+      it('should error when any field is non-nil but not a finite number', function () {
+        m.chai.expect(() => {
+          flashState.setFlashingFlag()
+          flashState.setProgressState({
+            flashing: {},
+            verifying: [],
+            succeeded: true,
+            failed: 'string',
+            percentage: 0,
+            eta: 0,
+            speed: 0,
+            totalSpeed: 0
+          })
+        }).to.throw('State quantity field(s) not finite number')
+      })
+
+      it('should not error when all quantity fields are zero', function () {
+        m.chai.expect(() => {
+          flashState.setFlashingFlag()
+          flashState.setProgressState({
+            flashing: 0,
+            verifying: 0,
+            succeeded: 0,
+            failed: 0,
+            percentage: 0,
+            eta: 0,
+            speed: 0,
+            totalSpeed: 0
+          })
+        }).to.not.throw()
       })
     })
 


### PR DESCRIPTION
We replace the `_.identity` predicate with `_.isFinite` to ensure
the flash quantity fields are numbers.

Change-Type: patch
Changelog-Entry: Ensure flash quantity fields are finite.