### PR TITLE
fix(GUI): hide the size label given multiple devices

### DIFF
--- a/lib/gui/app/pages/main/templates/main.tpl.html
+++ b/lib/gui/app/pages/main/templates/main.tpl.html
@@ -70,7 +70,11 @@
               <!-- middleEllipses errors on undefined, therefore fallback to empty string -->
               {{ drive.getDrivesTitle() | middleEllipses:20 }}
             </span>
-            <span class="step-drive step-size">{{ main.selection.getCurrentDrive().size | closestUnit }}</span>
+            <span
+              ng-if="main.selection.getSelectedDevices().length === 1"
+              class="step-drive step-size">
+              {{ main.selection.getCurrentDrive().size | closestUnit }}
+            </span>
             <span class="step-drive step-warning glyphicon glyphicon-exclamation-sign"
               uib-tooltip="{{ main.constraints.getListDriveImageCompatibilityStatuses(main.selection.getSelectedDrives(), main.selection.getImage())[0].message }}"
               ng-show="main.constraints.hasListDriveImageCompatibilityStatus(main.selection.getSelectedDrives(), main.selection.getImage())"></span>


### PR DESCRIPTION
We hide the size label when there are multiple selected devices, as this
doesn't make sense because you could only logically show the sum size,
which isn't very helpful on its own.

Change-Type: patch
Changelog-Entry: Hide the size label given multiple devices.