### PR TITLE
fix(GUI): line wrap selector size subtitles wholly

### DIFF
--- a/lib/gui/app/pages/main/styles/_main.scss
+++ b/lib/gui/app/pages/main/styles/_main.scss
@@ -23,6 +23,9 @@ svg-icon > img[disabled] {
 }
 
 .page-main .step-selection-text {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   color: $palette-theme-dark-foreground;
 }
 
@@ -101,6 +104,7 @@ svg-icon > img[disabled] {
 }
 
 .page-main .step-name {
+  margin-right: 4.5px;
   font-weight: bold;
   color: $palette-theme-primary-foreground;
 }

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6505,6 +6505,9 @@ svg-icon > img[disabled] {
   opacity: 0.2; }
 
 .page-main .step-selection-text {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   color: #fff; }
 
 .page-main .text-disabled > span {
@@ -6566,6 +6569,7 @@ svg-icon > img[disabled] {
   vertical-align: text-top; }
 
 .page-main .step-name {
+  margin-right: 4.5px;
   font-weight: bold;
   color: #fff; }
 


### PR DESCRIPTION
We line wrap the main-page image and drive size labels as a whole
instead of partially, if the drive or image title is long enough for a
line wrap.

Change-Type: patch
Changelog-Entry: Line wrap selector size subtitles wholly