### PR TITLE
fix(lint): Fix html-lint error about "lang" attr

### DIFF
--- a/scripts/html-lint.js
+++ b/scripts/html-lint.js
@@ -45,7 +45,8 @@ angularValidate.validate(
     reportpath: null,
     reportCheckstylePath: null,
     relaxerror: [
-      'Expected a minus sign or a digit'
+      'Expected a minus sign or a digit',
+      'Consider adding a “lang” attribute to the “html” start tag to declare the language of this document.'
     ]
   }
 ).then((result) => {


### PR DESCRIPTION
This avoids a new error from `html-lint` about the "lang" attr
on `<html>` tags, which isn't applicable to templates.

Change-Type: patch
Depends On: #2167 