### PR TITLE
upgrade(package): Bump Electron to v1.7.13

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -31,8 +31,8 @@
       "resolved": "https://registry.npmjs.org/@types/lodash.some/-/lodash.some-4.6.2.tgz"
     },
     "@types/node": {
-      "version": "7.0.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
+      "version": "7.0.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.58.tgz",
       "dev": true
     },
     "@types/react": {
@@ -2458,30 +2458,23 @@
       "dev": true
     },
     "electron": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
+      "version": "1.7.13",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.13.tgz",
       "dev": true,
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "dev": true
+        },
         "electron-download": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
-          "dev": true,
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "dev": true
-            }
-          }
+          "dev": true
         },
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         },
         "semver": {
@@ -7765,11 +7758,6 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
-    "electron": "1.7.11",
+    "electron": "1.7.13",
     "electron-builder": "19.40.0",
     "electron-mocha": "6.0.1",
     "eslint": "4.17.0",


### PR DESCRIPTION
This updates Electron to v1.7.13 in order to mitigate 2 vulnerabilities:
[CVE-2018-1000136] and [CVE-2018-1000118]

[CVE-2018-1000136]: https://nvd.nist.gov/vuln/detail/CVE-2018-1000136
[CVE-2018-1000118]: https://nvd.nist.gov/vuln/detail/CVE-2018-1000118

Change-Type: patch
Changelog-Entry: Update Electron to v1.7.13