### PR TITLE
fix(image-writer): Don't inherit environment on Windows

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -173,20 +173,22 @@ exports.performWrite = (image, drives, onProgress) => {
     ipc.server.on('start', () => {
       console.log(`Elevating command: ${_.join(argv, ' ')}`)
 
+      const env = _.assign({}, process.platform === 'win32' ? {} : process.env, {
+        IPC_SERVER_ID,
+        IPC_CLIENT_ID,
+        IPC_SOCKET_ROOT: ipc.config.socketRoot,
+        ELECTRON_RUN_AS_NODE: 1,
+        UV_THREADPOOL_SIZE: os.cpus().length * THREADS_PER_CPU,
+
+        // This environment variable prevents the AppImages
+        // desktop integration script from presenting the
+        // "installation" dialog
+        SKIP: 1
+      })
+
       permissions.elevateCommand(argv, {
         applicationName: packageJSON.displayName,
-        environment: _.assign({}, process.env, {
-          IPC_SERVER_ID,
-          IPC_CLIENT_ID,
-          IPC_SOCKET_ROOT: ipc.config.socketRoot,
-          ELECTRON_RUN_AS_NODE: 1,
-          UV_THREADPOOL_SIZE: os.cpus().length * THREADS_PER_CPU,
-
-          // This environment variable prevents the AppImages
-          // desktop integration script from presenting the
-          // "installation" dialog
-          SKIP: 1
-        })
+        environment: env
       }).then((results) => {
         flashResults.cancelled = results.cancelled
         console.log('Flash results', flashResults)


### PR DESCRIPTION
Due to improper command escaping, cmd metacharacters lead to failure
in spawning the child writer process on Windows when the entire environment
is passed through the command line. The user's environment will still
be inherited by default on Windows.

Change-Type: patch