### PR TITLE
fix(gui): Ensure image/drive size displayed on new line

### DIFF
--- a/lib/gui/app/pages/main/styles/_main.scss
+++ b/lib/gui/app/pages/main/styles/_main.scss
@@ -108,6 +108,7 @@ svg-icon > img[disabled] {
 }
 
 .page-main .step-name {
+  width: 100%;
   margin-right: 4.5px;
   font-weight: bold;
   color: $palette-theme-primary-foreground;

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6572,6 +6572,7 @@ svg-icon > img[disabled] {
   vertical-align: text-top; }
 
 .page-main .step-name {
+  width: 100%;
   margin-right: 4.5px;
   font-weight: bold;
   color: #fff; }


### PR DESCRIPTION
This forces the image and device size to always be displayed on the
second line for visual consistency.

### Before:

![step-name-before](https://user-images.githubusercontent.com/244907/38327587-e166c3ac-3848-11e8-820f-71212edebb00.png)

### After:

![step-name-name](https://user-images.githubusercontent.com/244907/38327487-9f99f606-3848-11e8-9d24-ffc5c8b5257e.png)

Change-Type: patch