### PR TITLE
test(lint): Update codespell 1.11.0 -> 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,7 +489,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixes
 
 - Fix broken image drag and drop functionality.
-- Prevent global shortcuts from interferring with another applications.
+- Prevent global shortcuts from interfering with another applications.
 - Prevent re-activating the "Flash" button with the keyboard shortcuts when a flash is already in process.
 - Fix certain non-removable Windows devices not being filtered out.
 - Display non-mountable Windows drives in the drive selector.

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -16,13 +16,13 @@ Releasing
 #### Preparation
 
 - [Prepare the new version](#preparing-a-new-version)
-- [Generate build artefacts](#generating-binaries) (binaries, archives, etc.)
+- [Generate build artifacts](#generating-binaries) (binaries, archives, etc.)
 - [Draft a release on GitHub](https://github.com/resin-io/etcher/releases)
-    - Upload build artefacts to GitHub release draft
+    - Upload build artifacts to GitHub release draft
 
 #### Testing
 
-- Test the prepared release and build artefacts properly on **all supported operating systems** to prevent regressions that went uncaught by the CI tests (see [MANUAL-TESTING.md](MANUAL-TESTING.md))
+- Test the prepared release and build artifacts properly on **all supported operating systems** to prevent regressions that went uncaught by the CI tests (see [MANUAL-TESTING.md](MANUAL-TESTING.md))
 - If regressions or other issues arise, create issues on the repository for each one, and decide whether to fix them in this release (meaning repeating the process up until this point), or to follow up with a patch release
 
 #### Publishing
@@ -33,7 +33,7 @@ Releasing
 - Wait 2-3 hours for analytics (Sentry, Mixpanel) to trickle in and check for elevated error rates, or regressions
 - If regressions arise; pull the release, and release a patched version, else:
 - [Upload deb & rpm packages to Bintray](#uploading-packages-to-bintray)
-- [Upload build artefacts to Amazon S3](#uploading-binaries-to-amazon-s3)
+- [Upload build artifacts to Amazon S3](#uploading-binaries-to-amazon-s3)
 - Post changelog with `#release-notes` tag on Flowdock
 - If this release packs noteworthy major changes:
   - Write a blog post about it, and / or
@@ -93,7 +93,7 @@ export ANALYTICS_MIXPANEL_TOKEN="xxxxxx"
 ./scripts/build/docker/run-command.sh -r x64 -s . -c "make distclean"
 ```
 
-##### Generating artefacts
+##### Generating artifacts
 
 ```bash
 # x64
@@ -144,7 +144,7 @@ and set `CSC_LINK`, and `CSC_KEY_PASSWORD` to generate signed binaries on Window
 
 **NOTE:**
 - The CLI is not code-signed for either at this time.
-- Keep in mind to also generate artefacts for x86, with `TARGET_ARCH=x86`.
+- Keep in mind to also generate artifacts for x86, with `TARGET_ARCH=x86`.
 
 ```bash
 make electron-develop

--- a/lib/gui/app/components/modal/styles/_modal.scss
+++ b/lib/gui/app/components/modal/styles/_modal.scss
@@ -69,7 +69,7 @@
 // window, causing the window content to overflow and get
 // pushed to the bottom.
 // The `!important` flag is needed since UI Bootstrap inlines
-// the styles programatically to the element.
+// the styles programmatically to the element.
 .modal-open {
   padding-right: 0 !important;
 }

--- a/lib/shared/models/selection-state.js
+++ b/lib/shared/models/selection-state.js
@@ -374,7 +374,7 @@ exports.deselectImage = () => {
 }
 
 /**
- * @summary Unselect all drives
+ * @summary Deselect all drives
  * @function
  * @public
  *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-codespell==1.11.0
+codespell==1.12.0
 cpplint==1.3.0
 awscli==1.11.87
 shyaml==0.5.0

--- a/tests/gui/components/svg-icon.spec.js
+++ b/tests/gui/components/svg-icon.spec.js
@@ -97,7 +97,7 @@ describe('Browser: SVGIcon', function () {
       m.chai.expect(element.children().attr('src')).to.equal(imgData)
     })
 
-    it('should prioritise the contents attribute over the paths attribute', function () {
+    it('should prioritize the contents attribute over the paths attribute', function () {
       const iconContents = '<svg><rect x="10" y="10" height="100" width="100" style="stroke:red;fill:blue;"/></svg>'
       const imgData = `data:image/svg+xml,${encodeURIComponent(iconContents)}`
       $rootScope.iconContents = iconContents

--- a/tests/shared/errors.spec.js
+++ b/tests/shared/errors.spec.js
@@ -85,19 +85,19 @@ describe('Shared: Errors', function () {
       m.chai.expect(errors.getTitle(error)).to.equal('Error code: MYERROR')
     })
 
-    it('should prioritise the message over the code', function () {
+    it('should prioritize the message over the code', function () {
       const error = new Error('Foo bar')
       error.code = 'MYERROR'
       m.chai.expect(errors.getTitle(error)).to.equal('Foo bar')
     })
 
-    it('should prioritise the code over the message if the message is an empty string', function () {
+    it('should prioritize the code over the message if the message is an empty string', function () {
       const error = new Error('')
       error.code = 'MYERROR'
       m.chai.expect(errors.getTitle(error)).to.equal('Error code: MYERROR')
     })
 
-    it('should prioritise the code over the message if the message is a blank string', function () {
+    it('should prioritize the code over the message if the message is a blank string', function () {
       const error = new Error('    ')
       error.code = 'MYERROR'
       m.chai.expect(errors.getTitle(error)).to.equal('Error code: MYERROR')


### PR DESCRIPTION
This updates codespell, and fixes new spelling error detections

```
lib/shared/models/selection-state.js:377: Unselect  ==> Deselect
lib/gui/app/components/modal/styles/_modal.scss:72: programatically  ==> programmatically
tests/shared/errors.spec.js:88: prioritise  ==> prioritize
tests/shared/errors.spec.js:94: prioritise  ==> prioritize
tests/shared/errors.spec.js:100: prioritise  ==> prioritize
tests/gui/components/svg-icon.spec.js:100: prioritise  ==> prioritize
docs/MAINTAINERS.md:19: artefacts  ==> artifacts
docs/MAINTAINERS.md:21: artefacts  ==> artifacts
docs/MAINTAINERS.md:25: artefacts  ==> artifacts
docs/MAINTAINERS.md:36: artefacts  ==> artifacts
docs/MAINTAINERS.md:96: artefacts  ==> artifacts
docs/MAINTAINERS.md:147: artefacts  ==> artifacts
CHANGELOG.md:492: interferring  ==> interfering
```

Change-Type: patch