### PR TITLE
fix(writer): Fix succeeded flash count in progress state

### DIFF
--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -397,6 +397,7 @@ class ImageWriter extends EventEmitter {
       state.flashing += !dest.error && !dest.finished ? 1 : 0
       state.verifying += !dest.error && dest.finished && !dest.verified ? 1 : 0
       state.failed += dest.error ? 1 : 0
+      state.succeeded += !dest.error && dest.finished && (dest.verified || !this.verifyChecksums) ? 1 : 0
       if (!(dest.finished && dest.verified) && !dest.error) {
         state.totalSpeed += state.type === 'write'
           ? dest.stream.speed
@@ -409,7 +410,6 @@ class ImageWriter extends EventEmitter {
       ? state.totalSpeed / state.active
       : state.active
 
-    state.succeeded = state.active - state.failed - state.flashing - state.verifying
     state.eta = state.speed ? state.remaining / state.speed : 0
 
     this.emit('progress', state)


### PR DESCRIPTION
This fixes a bug where succeeded flashes could become negative due to
improper math

Change-Type: patch