### PR TITLE
fix(writer): Fix writer progress state values

### DIFF
--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -400,15 +400,15 @@ class ImageWriter extends EventEmitter {
       state.succeeded += !dest.error && dest.finished && (dest.verified || !this.verifyChecksums) ? 1 : 0
       if (!(dest.finished && dest.verified) && !dest.error) {
         state.totalSpeed += state.type === 'write'
-          ? dest.stream.speed
-          : dest.progress.state.speed
+          ? (dest.stream.speed || 0)
+          : (dest.progress.state.speed || 0)
         state.active += 1
       }
     })
 
     state.speed = state.active
       ? state.totalSpeed / state.active
-      : state.active
+      : state.totalSpeed
 
     state.eta = state.speed ? state.remaining / state.speed : 0
 

--- a/lib/sdk/writer/progress-stream.js
+++ b/lib/sdk/writer/progress-stream.js
@@ -56,6 +56,7 @@ class ProgressStream extends Stream.Transform {
       remaining: 0,
       runtime: 0,
       speed: 0,
+      totalSpeed: 0,
       transferred: 0
     }
 


### PR DESCRIPTION
This force-defaults the individual stream speeds to zero,
in order to avoid null values when not available yet.

Change-Type: patch