### PR TITLE
doc(README): Remove Mac OS from Travis CI badge label

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ was written correctly and much more.
 
 [![Current Release](https://img.shields.io/github/release/resin-io/etcher.svg?style=flat-square)](https://etcher.io)
 ![License](https://img.shields.io/github/license/resin-io/etcher.svg?style=flat-square)
-[![Travis CI status](https://img.shields.io/travis/resin-io/etcher/master.svg?style=flat-square&label=linux%20|%20mac)](https://travis-ci.org/resin-io/etcher/branches)
+[![Travis CI status](https://img.shields.io/travis/resin-io/etcher/master.svg?style=flat-square&label=linux)](https://travis-ci.org/resin-io/etcher/branches)
 [![AppVeyor status](https://img.shields.io/appveyor/ci/resin-io/etcher/master.svg?style=flat-square&label=windows)](https://ci.appveyor.com/project/resin-io/etcher/branch/master)
 [![Dependency status](https://img.shields.io/david/resin-io/etcher.svg?style=flat-square)](https://david-dm.org/resin-io/etcher)
 [![Resin.io Forums](https://img.shields.io/discourse/https/forums.resin.io/topics.svg?style=flat-square&label=resin.io%20forums)](https://forums.resin.io/c/etcher)


### PR DESCRIPTION
This removes the "mac" from the Travis CI badge label, as we're not
running Mac OS builds on Travis CI anymore.

Change-Type: none
Connects To: https://github.com/resin-io/etcher/issues/2168