### PR TITLE
Enable nodeGypRebuild for Etcher builds

### DIFF
--- a/.resinci.json
+++ b/.resinci.json
@@ -21,6 +21,7 @@
       "appId": "io.resin.etcher",
       "copyright": "Copyright 2016-2018 Resinio Ltd",
       "productName": "Etcher",
+      "nodeGypRebuild": true,
       "files": [
         "!lib/gui/app",
         "lib/gui/app/index.html",


### PR DESCRIPTION
This will ensure we have all bindings built, even when using cached
modules.

Change-Type: patch