### PR TITLE
fix(webpack): don't rewrite import paths inside node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,16 @@ module.exports = {
   },
   externals: [
     (context, request, callback) => {
+      // eslint-disable-next-line lodash/prefer-lodash-method
+      const absoluteContext = path.resolve(context)
+      const absoluteNodeModules = path.resolve('node_modules')
+
+      // We shouldn't rewrite any node_modules import paths
+      // eslint-disable-next-line lodash/prefer-lodash-method
+      if (!path.relative(absoluteNodeModules, absoluteContext).startsWith('..')) {
+        return callback()
+      }
+
       // We want to keep the SDK code outside the GUI bundle.
       // This piece of code allows us to run the GUI directly
       // on the tree (for testing purposes) or inside a generated


### PR DESCRIPTION
We ensure that paths inside node_modules files are kept untouched, as
currently the RegExp can match 'shared' folders inside those and rewrite
paths, breaking them.

Change-Type: patch