### PR TITLE
fix(GUI): pass empty string fallback to middle-ellipsis filter

### DIFF
--- a/lib/gui/app/pages/main/templates/main.tpl.html
+++ b/lib/gui/app/pages/main/templates/main.tpl.html
@@ -24,7 +24,7 @@
             <span
               ng-click="main.showSelectedImageDetails()"
               class="step-image step-name"
-              ng-bind="main.selection.getImageName() || image.getImageBasename() | middleEllipsis:20"
+              ng-bind="(main.selection.getImageName() || image.getImageBasename() || '') | middleEllipsis:20"
               uib-tooltip="{{ image.getImageBasename() }}"></span>
             <span class="step-image step-size">{{ main.selection.getImageSize() | closestUnit }}</span>
           </div>
@@ -68,7 +68,7 @@
             <span class="drive-step step-name"
               uib-tooltip="{{ drive.getDriveListLabel() }}">
               <!-- middleEllipsis errors on undefined, therefore fallback to empty string -->
-              {{ drive.getDrivesTitle() | middleEllipsis:20 }}
+              {{ (drive.getDrivesTitle() || '') | middleEllipsis:20 }}
             </span>
             <span
               ng-if="main.selection.getSelectedDevices().length === 1"


### PR DESCRIPTION
We ensure that the middle-ellipsis filter doesn't explode when it's
passed an undefined value by passing a default empty string in those
template functions.

Change-Type: patch