### PR TITLE
fix(GUI): display untitled device when device lacks description

### DIFF
--- a/lib/gui/app/pages/main/controllers/drive-selection.js
+++ b/lib/gui/app/pages/main/controllers/drive-selection.js
@@ -39,7 +39,7 @@ module.exports = function (DriveSelectorService) {
 
     // eslint-disable-next-line no-magic-numbers
     if (drives.length === 1) {
-      return _.head(drives).description
+      return _.head(drives).description || 'Untitled Device'
     }
 
     return `${drives.length} Devices`

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -260,8 +260,8 @@ describe('Browser: MainPage', function () {
     let DriveSelectionController
 
     const drivePaths = process.platform === 'win32'
-      ? [ 'E:\\', 'F:\\' ]
-      : [ '/dev/disk1', '/dev/disk2' ]
+      ? [ '\\\\.\\PhysicalDrive1', '\\\\.\\PhysicalDrive2', '\\\\.\\PhysicalDrive3' ]
+      : [ '/dev/disk1', '/dev/disk2', '/dev/disk3' ]
     const drives = [
       {
         device: drivePaths[0],
@@ -278,6 +278,14 @@ describe('Browser: MainPage', function () {
         size: 987654321,
         displayName: drivePaths[1],
         mountpoints: [ drivePaths[1] ],
+        isSystem: false,
+        isReadOnly: false
+      },
+      {
+        device: drivePaths[2],
+        size: 987654321,
+        displayName: drivePaths[2],
+        mountpoints: [],
         isSystem: false,
         isReadOnly: false
       }
@@ -300,6 +308,11 @@ describe('Browser: MainPage', function () {
       it('should return the drive description when there is one drive', function () {
         selectionState.selectDrive(drives[0].device)
         m.chai.expect(DriveSelectionController.getDrivesTitle()).to.equal(drives[0].description)
+      })
+
+      it('should return untitled when there is no description', function () {
+        selectionState.selectDrive(drives[2].device)
+        m.chai.expect(DriveSelectionController.getDrivesTitle()).to.equal('Untitled Device')
       })
 
       it('should return a consolidated title with quantity when there are multiple drives', function () {


### PR DESCRIPTION
We fallback to `'Untitled Device'` when the device lacks a
`.description` field.

Change-Type: patch
Changelog-Entry: Display Untitled Device when the device lacks a
description field.