### PR TITLE
fix(child-writer): Fix handling of user errors over IPC

### DIFF
--- a/lib/gui/modules/child-writer.js
+++ b/lib/gui/modules/child-writer.js
@@ -151,7 +151,7 @@ ipc.connectTo(IPC_SERVER_ID, () => {
     const onError = (error) => {
       log(`Error: ${error.message}`)
       exitCode = EXIT_CODES.GENERAL_ERROR
-      ipc.of[IPC_SERVER_ID].emit('error', error)
+      ipc.of[IPC_SERVER_ID].emit('error', errors.toJSON(error))
     }
 
     /**
@@ -163,15 +163,7 @@ ipc.connectTo(IPC_SERVER_ID, () => {
     const onFail = (event) => {
       ipc.of[IPC_SERVER_ID].emit('fail', {
         device: event.device,
-        error: {
-          name: event.error.name,
-          message: event.error.message,
-          code: event.error.code,
-          syscall: event.error.syscall,
-          errno: event.error.errno,
-          stack: event.error.stack,
-          stdout: event.error.stdout
-        }
+        error: errors.toJSON(event.error)
       })
     }
 

--- a/lib/shared/errors.js
+++ b/lib/shared/errors.js
@@ -336,11 +336,16 @@ exports.toJSON = (error) => {
   const errorObject = isErrorLike ? error : new Error(error)
 
   return {
+    name: errorObject.name,
     message: errorObject.message,
     description: errorObject.description,
     stack: errorObject.stack,
     report: errorObject.report,
-    code: errorObject.code
+    code: errorObject.code,
+    syscall: errorObject.syscall,
+    errno: errorObject.errno,
+    stdout: errorObject.stdout,
+    stderr: errorObject.stderr
   }
 }
 

--- a/tests/shared/errors.spec.js
+++ b/tests/shared/errors.spec.js
@@ -646,7 +646,12 @@ describe('Shared: Errors', function () {
         description: undefined,
         message: 'My error',
         stack: error.stack,
-        report: undefined
+        report: undefined,
+        stderr: undefined,
+        stdout: undefined,
+        syscall: undefined,
+        name: 'Error',
+        errno: undefined
       })
     })
 
@@ -659,7 +664,12 @@ describe('Shared: Errors', function () {
         description: 'My description',
         message: 'My error',
         stack: error.stack,
-        report: undefined
+        report: undefined,
+        stderr: undefined,
+        stdout: undefined,
+        syscall: undefined,
+        name: 'Error',
+        errno: undefined
       })
     })
 
@@ -672,7 +682,12 @@ describe('Shared: Errors', function () {
         description: undefined,
         message: 'My error',
         stack: error.stack,
-        report: undefined
+        report: undefined,
+        stderr: undefined,
+        stdout: undefined,
+        syscall: undefined,
+        name: 'Error',
+        errno: undefined
       })
     })
 
@@ -686,7 +701,12 @@ describe('Shared: Errors', function () {
         description: 'My description',
         message: 'My error',
         stack: error.stack,
-        report: undefined
+        report: undefined,
+        stderr: undefined,
+        stdout: undefined,
+        syscall: undefined,
+        name: 'Error',
+        errno: undefined
       })
     })
 
@@ -699,7 +719,12 @@ describe('Shared: Errors', function () {
         description: undefined,
         message: 'My error',
         stack: error.stack,
-        report: true
+        report: true,
+        stderr: undefined,
+        stdout: undefined,
+        syscall: undefined,
+        name: 'Error',
+        errno: undefined
       })
     })
 
@@ -711,7 +736,12 @@ describe('Shared: Errors', function () {
         description: undefined,
         message: '',
         stack: error.stack,
-        report: undefined
+        report: undefined,
+        stderr: undefined,
+        stdout: undefined,
+        syscall: undefined,
+        name: 'Error',
+        errno: undefined
       })
     })
   })


### PR DESCRIPTION
This fixes transmission of user errors over IPC, as the `report`
property was previously missing. Further it also adds more properties
to `errors.toJSON`, like `syscall`, `errno`, etc. and re-uses the method
for failure signalling.

Change-Type: patch