### PR TITLE
minifeat(GUI): prefix multiple devices label with quantity

### DIFF
--- a/lib/gui/app/pages/main/controllers/drive-selection.js
+++ b/lib/gui/app/pages/main/controllers/drive-selection.js
@@ -42,7 +42,7 @@ module.exports = function (DriveSelectorService) {
       return _.head(drives).description
     }
 
-    return `Multiple Devices (${drives.length})`
+    return `${drives.length} Devices`
   }
 
   /**

--- a/tests/gui/pages/main.spec.js
+++ b/tests/gui/pages/main.spec.js
@@ -305,7 +305,7 @@ describe('Browser: MainPage', function () {
       it('should return a consolidated title with quantity when there are multiple drives', function () {
         selectionState.selectDrive(drives[0].device)
         selectionState.selectDrive(drives[1].device)
-        m.chai.expect(DriveSelectionController.getDrivesTitle()).to.equal('Multiple Devices (2)')
+        m.chai.expect(DriveSelectionController.getDrivesTitle()).to.equal('2 Devices')
       })
     })
 


### PR DESCRIPTION
Change the `Multiple Devices (n)` label on selected devices to a
quantity-prefixed form `n Devices`.

Change-Type: patch