### PR TITLE
fix(ci): Fix pip installation

### DIFF
--- a/scripts/build/docker/Dockerfile-armv7hf
+++ b/scripts/build/docker/Dockerfile-armv7hf
@@ -53,7 +53,7 @@ RUN npm config set spin=false
 COPY requirements.txt requirements.txt
 
 # FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
-RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+RUN curl -vvv -L "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
   && tar xvfz pip-9.0.1.tar.gz \
   && cd pip-9.0.1 \
   && python setup.py install

--- a/scripts/build/docker/Dockerfile-i686
+++ b/scripts/build/docker/Dockerfile-i686
@@ -67,7 +67,7 @@ RUN npm config set spin=false
 COPY requirements.txt requirements.txt
 
 # FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
-RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+RUN curl -vvv -L "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
   && tar xvfz pip-9.0.1.tar.gz \
   && cd pip-9.0.1 \
   && python setup.py install

--- a/scripts/build/docker/Dockerfile-x86_64
+++ b/scripts/build/docker/Dockerfile-x86_64
@@ -66,7 +66,7 @@ RUN npm config set spin=false
 COPY requirements.txt requirements.txt
 
 # FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
-RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+RUN curl -vvv -L "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
   && tar xvfz pip-9.0.1.tar.gz \
   && cd pip-9.0.1 \
   && python setup.py install

--- a/scripts/build/docker/Dockerfile.template
+++ b/scripts/build/docker/Dockerfile.template
@@ -71,7 +71,7 @@ RUN npm config set spin=false
 COPY requirements.txt requirements.txt
 
 # FIXME: Work around "Cannot fetch index base URL http://pypi.python.org/simple/" error
-RUN curl "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
+RUN curl -vvv -L "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz" > pip-9.0.1.tar.gz \
   && tar xvfz pip-9.0.1.tar.gz \
   && cd pip-9.0.1 \
   && python setup.py install


### PR DESCRIPTION
The pip tarball URL now redirects to another location, which
caused `curl` to fail, as the follow-redirects option wasn't specified.

Change-Type: patch