### PR TITLE
upgrade(package): Update drivelist 6.1.5 -> 6.1.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2405,8 +2405,8 @@
       "dev": true
     },
     "drivelist": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-6.1.5.tgz",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-6.1.7.tgz",
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
@@ -2425,8 +2425,8 @@
           "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz"
         },
         "prebuild-install": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz"
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz"
         },
         "pump": {
           "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chalk": "1.1.3",
     "command-join": "2.0.0",
     "debug": "3.1.0",
-    "drivelist": "6.1.5",
+    "drivelist": "6.1.7",
     "electron-is-running-in-asar": "1.0.0",
     "file-type": "4.1.0",
     "flexboxgrid": "6.3.0",


### PR DESCRIPTION
This fixes a ReferenceError that could occur when the DeviceNode was null,
as well as devices being null when run after the system recovers from sleep / standby.

Change-Type: patch