### PR TITLE
fix(adapters): Always ignore RAID attached devices

### DIFF
--- a/lib/sdk/adapters/blockdevice/index.js
+++ b/lib/sdk/adapters/blockdevice/index.js
@@ -79,6 +79,11 @@ class BlockDeviceAdapter extends EventEmitter {
       this.emit('error', error)
       callback && callback(error)
     }).filter((drive) => {
+      // Always ignore RAID attached devices, as they are in danger-country;
+      // Even flashing RAIDs intentionally can have unintended effects
+      if (drive.busType === 'RAID') {
+        return false
+      }
       return !drive.error && (options.includeSystemDrives || !drive.isSystem)
     }).map((drive) => {
       drive.displayName = drive.device


### PR DESCRIPTION
This force-ignores RAID attached devices, to ensure they aren't flashed, not even intentionally,
as that can have yet unknown consequences.

Change-Type: patch
Changelog-Entry: Exclude RAID devices from drive selection list
Connects To: https://github.com/resin-io/etcher/issues/2071