### PR TITLE
fix(image-writer): Remove use of _.isError

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -118,7 +118,7 @@ exports.performWrite = (image, drives, onProgress) => {
   return new Bluebird((resolve, reject) => {
     ipc.server.on('error', (error) => {
       terminateServer()
-      const errorObject = _.isError(error) ? error : errors.fromJSON(error)
+      const errorObject = errors.fromJSON(error)
       reject(errorObject)
     })
 


### PR DESCRIPTION
`_.isError()` returns `true` for anything that has a `name` and `message`
property, causing the check here to always keep the plain object as error.

Change-Type: patch