### PR TITLE
fix(drive-scanner): Fix usbboot blob path when bundled

### DIFF
--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -30,9 +30,14 @@ const packageJSON = require('../../../../package.json')
  * @type {String}
  * @constant
  */
-const BLOBS_DIRECTORY = packageJSON.packageType === 'AppImage'
-  ? 'bin/resources/app.asar/lib/blobs'
-  : path.join(__dirname, '..', '..', '..', 'blobs')
+let BLOBS_DIRECTORY = path.join(__dirname, '..', '..', '..', 'blobs')
+
+// FIXME: When bundled & packaged, the blob path differs
+if (packageJSON.packageType !== 'local') {
+  BLOBS_DIRECTORY = packageJSON.packageType === 'AppImage'
+    ? 'bin/resources/app.asar/lib/blobs'
+    : path.join(__dirname, '..', '..', 'blobs')
+}
 
 const scanner = SDK.createScanner({
   blockdevice: {


### PR DESCRIPTION
This fixes the usbboot blobs path when the application is bundled & packaged.

Change-Type: fix
Changelog-Entry: Fix usbboot blob loading
Connects To: #2197