### PR TITLE
fix(gui): Fix zero-zero devices when verify is disabled

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -126,12 +126,7 @@ exports.performWrite = (image, drives, onProgress) => {
       console.log(message)
     })
 
-    const flashResults = {
-      devices: {
-        succeeded: 0,
-        failed: 0
-      }
-    }
+    const flashResults = {}
 
     ipc.server.on('fail', (error) => {
       console.log('Fail:', error)
@@ -144,11 +139,7 @@ exports.performWrite = (image, drives, onProgress) => {
       _.merge(flashResults, event)
     })
 
-    ipc.server.on('state', (progress) => {
-      flashResults.devices.succeeded = progress.succeeded
-      flashResults.devices.failed = progress.failed
-      onProgress(progress)
-    })
+    ipc.server.on('state', onProgress)
 
     ipc.server.on('ready', (data, socket) => {
       ipc.server.emit(socket, 'write', {

--- a/lib/gui/app/pages/finish/templates/success.tpl.html
+++ b/lib/gui/app/pages/finish/templates/success.tpl.html
@@ -6,7 +6,7 @@
         <div uib-tooltip="{{ finish.formattedErrors() }}" tooltip-placement="bottom" class="title-wrap">
           <h3 class="title">Flash Complete!</h3>
           <div class="target-status-line target-status-{{ type }}"
-            ng-repeat="(type, quantity) in finish.flash.getFlashResults().devices">
+            ng-repeat="(type, quantity) in finish.flash.getFlashResults().results.devices">
             <span class="target-status-dot"></span>
             <span class="target-status-quantity">{{ quantity }}</span>
             <span class="target-status-message">{{ finish.progressMessage[type](quantity) }}</span>

--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -350,6 +350,7 @@ class ImageWriter extends EventEmitter {
 
         // Generate preparation tasks for all destinations
         const tasks = destinations.map((destination) => {
+          destination.verified = !this.verifyChecksums
           this.destinations.set(destination.device.device, destination)
           return (next) => {
             runSeries([
@@ -632,17 +633,27 @@ class ImageWriter extends EventEmitter {
    */
   _finish () {
     this._cleanup(() => {
+      const failures = []
+      let succeeded = 0
+      let failed = 0
+
       this.finished = true
+
+      this.destinations.forEach((dest) => {
+        succeeded += dest.finished && dest.verified && !dest.error ? 1 : 0
+        failed += dest.error ? 1 : 0
+        if (dest.error) {
+          dest.error.device = dest.device.device
+          failures.push(dest.error)
+        }
+      })
+
       this.emit('finish', {
+        devices: { succeeded, failed },
         bytesRead: this.bytesRead,
         bytesWritten: this.bytesWritten,
         checksum: this.checksum,
-        errors: Array.from(this.destinations).filter(([ device, dest ]) => {
-          return dest.error
-        }).map(([ device, dest ]) => {
-          dest.error.device = device
-          return dest.error
-        })
+        errors: failures
       })
     })
   }


### PR DESCRIPTION
This fixes a state where the success screen would display
zero succeeded and zero failed devices if verification was
turned off. This could occur due to the "done" event being
emitted before the next progress event could set the relevant data.

Change-Type: patch