### PR TITLE
fix(GUI): remove success screen dots with a quantity of zero

### DIFF
--- a/lib/gui/app/pages/finish/templates/success.tpl.html
+++ b/lib/gui/app/pages/finish/templates/success.tpl.html
@@ -6,7 +6,8 @@
         <div uib-tooltip="{{ finish.formattedErrors() }}" tooltip-placement="bottom" class="title-wrap">
           <h3 class="title">Flash Complete!</h3>
           <div class="target-status-line target-status-{{ type }}"
-            ng-repeat="(type, quantity) in finish.flash.getFlashResults().results.devices">
+            ng-repeat="(type, quantity) in finish.flash.getFlashResults().results.devices"
+            ng-if="quantity">
             <span class="target-status-dot"></span>
             <span class="target-status-quantity">{{ quantity }}</span>
             <span class="target-status-message">{{ finish.progressMessage[type](quantity) }}</span>


### PR DESCRIPTION
We remove success screen dots that are zero, which mainly means that the
error dot disappears as it shouldn't currently be possible to end up
with zero successful devices on that screen.

Change-Type: patch