### PR TITLE
fix(store): keep single warning-drives selected

### DIFF
--- a/lib/shared/store.js
+++ b/lib/shared/store.js
@@ -199,7 +199,9 @@ const storeReducer = (state = DEFAULT_STATE, action) => {
 
       const AUTOSELECT_DRIVE_COUNT = 1
       const numberOfDrives = drives.length
-      if (numberOfDrives === AUTOSELECT_DRIVE_COUNT) {
+      const nonStaleSelectedDevices = nonStaleNewState.getIn([ 'selection', 'devices' ]).toJS()
+      const hasSelectedDevices = nonStaleSelectedDevices.length >= AUTOSELECT_DRIVE_COUNT
+      if (numberOfDrives === AUTOSELECT_DRIVE_COUNT && !hasSelectedDevices) {
         const [ drive ] = drives
 
         // Even if there's no image selected, we need to call several

--- a/tests/shared/models/selection-state.spec.js
+++ b/tests/shared/models/selection-state.spec.js
@@ -80,6 +80,40 @@ describe('Model: selectionState', function () {
     })
   })
 
+  describe('given one available drive', function () {
+    beforeEach(function () {
+      this.drives = [
+        {
+          device: '/dev/disk2',
+          name: 'USB Drive',
+          size: 999999999,
+          isReadOnly: false
+        }
+      ]
+    })
+
+    afterEach(function () {
+      selectionState.clear()
+      availableDrives.setDrives([])
+    })
+
+    describe('.selectDrive()', function () {
+      it('should not deselect when warning is attached to image-drive pair', function () {
+        this.drives[0].size = 64e10
+
+        availableDrives.setDrives(this.drives)
+        selectionState.selectDrive('/dev/disk2')
+        availableDrives.setDrives(this.drives)
+        m.chai.expect(selectionState.getCurrentDrive()).to.deep.equal({
+          device: '/dev/disk2',
+          name: 'USB Drive',
+          size: 64e10,
+          isReadOnly: false
+        })
+      })
+    })
+  })
+
   describe('given a drive', function () {
     beforeEach(function () {
       availableDrives.setDrives([


### PR DESCRIPTION
We ensure that drive-image pairs with warnings don't get deselected when
there is only one drive available. This happenened because there was no
check for any previous selected devices. Comes with a test case.

Fixes: https://github.com/resin-io/etcher/issues/2267
Change-Type: patch
Changelog-Entry: Keep single warning-drive-image pairs selected.