### PR TITLE
feat(GUI): allow disabling links and hiding help link

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -312,6 +312,20 @@ app.controller('HeaderController', function (OSOpenExternalService) {
     const supportUrl = selectionState.getImageSupportUrl() || DEFAULT_SUPPORT_URL
     OSOpenExternalService.open(supportUrl)
   }
+
+  /**
+   * @summary Whether to show the help link
+   * @function
+   * @public
+   *
+   * @returns {Boolean}
+   *
+   * @example
+   * HeaderController.shouldShowHelp()
+   */
+  this.shouldShowHelp = () => {
+    return Boolean(process.env.ETCHER_DISABLE_EXTERNAL_LINKS)
+  }
 })
 
 app.controller('StateController', function ($rootScope, $scope) {

--- a/lib/gui/app/components/safe-webview.js
+++ b/lib/gui/app/components/safe-webview.js
@@ -212,7 +212,10 @@ class SafeWebview extends react.PureComponent {
 
     if (_.every([
       url.protocol === 'http:' || url.protocol === 'https:',
-      event.disposition === 'foreground-tab'
+      event.disposition === 'foreground-tab',
+
+      // Don't open links if they're disabled by the env var
+      !process.env.ETCHER_DISABLE_EXTERNAL_LINKS
     ])) {
       electron.shell.openExternal(url.href)
     }

--- a/lib/gui/app/index.html
+++ b/lib/gui/app/index.html
@@ -12,6 +12,7 @@
   <body>
     <header class="section-header" ng-controller="HeaderController as header">
       <button class="button button-link"
+        ng-if="header.shouldShowHelp()"
         ng-click="header.openHelpPage()"
         tabindex="4">
         <span class="glyphicon glyphicon-question-sign"></span>

--- a/lib/gui/app/os/open-external/services/open-external.js
+++ b/lib/gui/app/os/open-external/services/open-external.js
@@ -31,6 +31,11 @@ module.exports = function () {
    * OSOpenExternalService.open('https://www.google.com');
    */
   this.open = (url) => {
+    // Don't open links if they're disabled by the env var
+    if (process.env.ETCHER_DISABLE_EXTERNAL_LINKS) {
+      return
+    }
+
     analytics.logEvent('Open external link', {
       url
     })


### PR DESCRIPTION
We allow users to pass an env var `ETCHER_DISABLE_EXTERNAL_LINKS` to
disable external links and hide links rendered useless by the change
such as the help icon.

Closes: https://github.com/resin-io/etcher/issues/2246
Closes: https://github.com/resin-io/etcher/issues/2247
Change-Type: patch
Changelog-Entry: Allow disabling links and hiding help link with an env var.