### PR TITLE
fix(GUI): fix multi-writes analytics

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -61,6 +61,35 @@ const getApplicationEntryPoint = () => {
 }
 
 /**
+ * @summary Handle a flash  error and log it to analytics
+ * @function
+ * @private
+ *
+ * @param {Error} error - error object
+ * @param {Object} analyticsData - analytics object
+ *
+ * @example
+ * handleErrorLogging({ code: 'EUNPLUGGED' }, { image: 'resin.img' })
+ */
+const handleErrorLogging = (error, analyticsData) => {
+  if (error.code === 'EVALIDATION') {
+    analytics.logEvent('Validation error', analyticsData)
+  } else if (error.code === 'EUNPLUGGED') {
+    analytics.logEvent('Drive unplugged', analyticsData)
+  } else if (error.code === 'EIO') {
+    analytics.logEvent('Input/output error', analyticsData)
+  } else if (error.code === 'ENOSPC') {
+    analytics.logEvent('Out of space', analyticsData)
+  } else if (error.code === 'ECHILDDIED') {
+    analytics.logEvent('Child died unexpectedly', analyticsData)
+  } else {
+    analytics.logEvent('Flash error', _.merge({
+      error: errors.toJSON(error)
+    }, analyticsData))
+  }
+}
+
+/**
  * @summary Perform write operation
  * @function
  * @private
@@ -127,9 +156,16 @@ exports.performWrite = (image, drives, onProgress) => {
     })
 
     const flashResults = {}
+    const analyticsData = {
+      image,
+      drives,
+      uuid: flashState.getFlashUuid(),
+      unmountOnSuccess: settings.get('unmountOnSuccess'),
+      validateWriteOnSuccess: settings.get('validateWriteOnSuccess')
+    }
 
-    ipc.server.on('fail', (error) => {
-      console.log('Fail:', error)
+    ipc.server.on('fail', ({ device, error }) => {
+      handleErrorLogging(error, analyticsData)
     })
 
     ipc.server.on('done', (event) => {
@@ -275,20 +311,9 @@ exports.flash = (image, drives) => {
       errorCode: error.code
     })
 
-    if (error.code === 'EVALIDATION') {
-      analytics.logEvent('Validation error', analyticsData)
-    } else if (error.code === 'EUNPLUGGED') {
-      analytics.logEvent('Drive unplugged', analyticsData)
-    } else if (error.code === 'EIO') {
-      analytics.logEvent('Input/output error', analyticsData)
-    } else if (error.code === 'ENOSPC') {
-      analytics.logEvent('Out of space', analyticsData)
-    } else if (error.code === 'ECHILDDIED') {
-      analytics.logEvent('Child died unexpectedly', analyticsData)
-    } else {
-      analytics.logEvent('Flash error', _.merge({
-        error: errors.toJSON(error)
-      }, analyticsData))
+    // eslint-disable-next-line no-magic-numbers
+    if (drives.length > 1) {
+      analytics.logEvent('Write failed', analyticsData)
     }
 
     return Bluebird.reject(error)


### PR DESCRIPTION
We make the analytics block into a function `handleErrorLogging` and
use it in the fail event that happens during multi-writes. Previously
error events would only be handled when single drives were flashed.

Change-Type: patch
Changelog-Entry: Fix multi-writes analytics by reusing existing logic in
multi-write events.