### PR TITLE
fix(sdk): load usbboot adapter on start

### DIFF
--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -18,7 +18,6 @@
 
 const settings = require('../models/settings')
 const SDK = require('../../../sdk')
-const permissions = require('../../../shared/permissions')
 
 const scanner = SDK.createScanner({
   blockdevice: {
@@ -27,19 +26,6 @@ const scanner = SDK.createScanner({
     }
   },
   usbboot: {}
-})
-
-// NOTE: Enable USBBoot on Linux if run as root
-permissions.isElevated().then((elevated) => {
-  if (elevated && process.platform === 'linux') {
-    const UsbbootAdapter = require('../../../sdk/adapters/usbboot')
-    const adapter = new UsbbootAdapter()
-    scanner.stop()
-    scanner.subscribe(adapter)
-    scanner.start()
-  }
-}).catch((error) => {
-  console.warn('Could not add usbboot adapter:', error)
 })
 
 module.exports = scanner

--- a/lib/sdk/adapters/index.js
+++ b/lib/sdk/adapters/index.js
@@ -19,6 +19,8 @@
 const _ = require('lodash')
 const os = require('os')
 
+const permissions = require('../../shared/permissions')
+
 /**
  * @summary The list of loaded adapters
  * @type {Object[]}
@@ -28,10 +30,8 @@ const ADAPTERS = [
   require('./blockdevice')
 ]
 
-// We don't support usbboot on GNU/Linux yet, given
-// that some distributions require root permissions
-// to open USB devices.
-if (os.platform() !== 'linux') {
+// On GNU/Linux, we only support usbboot when running as root.
+if ((os.platform() !== 'linux') || permissions.isElevatedUnixSync()) {
   ADAPTERS.push(require('./usbboot'))
 }
 

--- a/lib/shared/permissions.js
+++ b/lib/shared/permissions.js
@@ -71,6 +71,26 @@ exports.isElevated = () => {
 }
 
 /**
+ * @summary Check if the current process is running with elevated permissions
+ * @function
+ * @public
+ *
+ * @description
+ *
+ * @returns {Boolean}
+ *
+ * @example
+ * permissions.isElevatedUnixSync()
+ *   if (isElevated) {
+ *     console.log('This process has elevated permissions');
+ *   }
+ * });
+ */
+exports.isElevatedUnixSync = () => {
+  return (process.geteuid() === UNIX_SUPERUSER_USER_ID)
+}
+
+/**
  * @summary Get environment command prefix
  * @function
  * @private


### PR DESCRIPTION
For some reason loading it later didn't work

Change-Type: patch
Changelog-Entry: Load usbboot adapter on start on GNU/Linux if running
as root.