### PR TITLE
feat(GUI): add drive quantity to flash analytics

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -160,6 +160,7 @@ exports.performWrite = (image, drives, onProgress) => {
     const analyticsData = {
       image,
       drives,
+      driveCount: drives.length,
       uuid: flashState.getFlashUuid(),
       unmountOnSuccess: settings.get('unmountOnSuccess'),
       validateWriteOnSuccess: settings.get('validateWriteOnSuccess')
@@ -299,6 +300,7 @@ exports.flash = (image, drives) => {
   const analyticsData = {
     image,
     drives,
+    driveCount: drives.length,
     uuid: flashState.getFlashUuid(),
     unmountOnSuccess: settings.get('unmountOnSuccess'),
     validateWriteOnSuccess: settings.get('validateWriteOnSuccess')
@@ -339,9 +341,11 @@ exports.flash = (image, drives) => {
  * imageWriter.cancel()
  */
 exports.cancel = () => {
+  const drives = selectionState.getSelectedDevices()
   analytics.logEvent('Cancel', {
     image: selectionState.getImagePath(),
-    drives: selectionState.getSelectedDevices(),
+    drives,
+    driveCount: drives.length,
     uuid: flashState.getFlashUuid(),
     unmountOnSuccess: settings.get('unmountOnSuccess'),
     validateWriteOnSuccess: settings.get('validateWriteOnSuccess')


### PR DESCRIPTION
We add a field `driveAmount` to the flash analytics events in the image
writer.

Change-Type: patch