### PR TITLE
feat(GUI): add button to cancel flash process

### DIFF
--- a/lib/gui/app/modules/image-writer.js
+++ b/lib/gui/app/modules/image-writer.js
@@ -30,6 +30,7 @@ const permissions = require('../../../shared/permissions')
 const windowProgress = require('../os/window-progress')
 const analytics = require('../modules/analytics')
 const packageJSON = require('../../../../package.json')
+const selectionState = require('../../../shared/models/selection-state')
 
 /**
  * @summary Number of threads per CPU to allocate to the UV_THREADPOOL
@@ -137,6 +138,13 @@ exports.performWrite = (image, drives, onProgress) => {
         return errors.fromJSON(data)
       })
       _.merge(flashResults, event)
+    })
+
+    ipc.server.on('abort', () => {
+      terminateServer()
+      resolve({
+        cancelled: true
+      })
     })
 
     ipc.server.on('state', onProgress)
@@ -295,4 +303,29 @@ exports.flash = (image, drives) => {
   }).finally(() => {
     windowProgress.clear()
   })
+}
+
+/**
+ * @summary Cancel write operation
+ * @function
+ * @public
+ *
+ * @example
+ * imageWriter.cancel()
+ */
+exports.cancel = () => {
+  analytics.logEvent('Cancel', {
+    image: selectionState.getImagePath(),
+    drives: selectionState.getSelectedDevices(),
+    uuid: flashState.getFlashUuid(),
+    unmountOnSuccess: settings.get('unmountOnSuccess'),
+    validateWriteOnSuccess: settings.get('validateWriteOnSuccess')
+  })
+
+  try {
+    const [ socket ] = ipc.server.sockets
+    ipc.server.emit(socket, 'cancel')
+  } catch (error) {
+    analytics.logException(error)
+  }
 }

--- a/lib/gui/app/pages/main/controllers/flash.js
+++ b/lib/gui/app/pages/main/controllers/flash.js
@@ -209,4 +209,14 @@ module.exports = function (
 
     return progressStatus.fromFlashState(flashState.getFlashState())
   }
+
+  /**
+   * @summary Abort write process
+   * @function
+   * @public
+   *
+   * @example
+   * FlashController.cancelFlash()
+   */
+  this.cancelFlash = imageWriter.cancel
 }

--- a/lib/gui/app/pages/main/styles/_main.scss
+++ b/lib/gui/app/pages/main/styles/_main.scss
@@ -41,6 +41,10 @@ svg-icon > img[disabled] {
   min-width: $btn-min-width;
 }
 
+.page-main .button-abort-write {
+  margin-right: -35px;
+}
+
 %step-border {
   height: 2px;
   background-color: $palette-theme-dark-foreground;

--- a/lib/gui/app/pages/main/templates/main.tpl.html
+++ b/lib/gui/app/pages/main/templates/main.tpl.html
@@ -106,6 +106,12 @@
             <span ng-bind="flash.getProgressButtonLabel()"></span>
         </progress-button>
 
+        <button class="button button-link button-abort-write"
+          ng-if="main.state.isFlashing()"
+          ng-click="flash.cancelFlash()">
+          <span class="glyphicon glyphicon-remove-sign"></span>
+        </button>
+
         <p class="step-footer step-footer-split" ng-if="main.state.getFlashState().speed && main.state.getFlashState().percentage != 100">
           <span ng-bind="main.state.getFlashState().speed.toFixed(2) + ' MB/s'"></span>
           <span>ETA: {{ main.state.getFlashState().eta | secondsToDate | amDateFormat:'m[m]ss[s]' }}</span>

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6523,6 +6523,9 @@ svg-icon > img[disabled] {
 .page-main .button-brick {
   min-width: 170px; }
 
+.page-main .button-abort-write {
+  margin-right: -35px; }
+
 .page-main .step-border-left, .page-main .step-border-right {
   height: 2px;
   background-color: #fff;

--- a/lib/gui/modules/child-writer.js
+++ b/lib/gui/modules/child-writer.js
@@ -111,6 +111,8 @@ ipc.connectTo(IPC_SERVER_ID, () => {
     terminate(EXIT_CODES.SUCCESS)
   })
 
+  let writer = null
+
   ipc.of[IPC_SERVER_ID].on('write', (options) => {
     const destinations = [].concat(options.destinations)
 
@@ -147,6 +149,17 @@ ipc.connectTo(IPC_SERVER_ID, () => {
     }
 
     /**
+     * @summary Abort handler
+     * @example
+     * writer.on('abort', onAbort)
+     */
+    const onAbort = () => {
+      log('Abort')
+      ipc.of[IPC_SERVER_ID].emit('abort')
+      terminate(exitCode)
+    }
+
+    /**
      * @summary Error handler
      * @param {Error} error - error
      * @example
@@ -171,7 +184,7 @@ ipc.connectTo(IPC_SERVER_ID, () => {
       })
     }
 
-    const writer = new ImageWriter({
+    writer = new ImageWriter({
       verify: options.validateWriteOnSuccess,
       unmountOnSuccess: options.unmountOnSuccess,
       checksumAlgorithms: options.checksumAlgorithms || []
@@ -181,8 +194,15 @@ ipc.connectTo(IPC_SERVER_ID, () => {
     writer.on('fail', onFail)
     writer.on('progress', onProgress)
     writer.on('finish', onFinish)
+    writer.on('abort', onAbort)
 
     writer.write(options.imagePath, destinations)
+  })
+
+  ipc.of[IPC_SERVER_ID].on('cancel', () => {
+    if (writer) {
+      writer.abort()
+    }
   })
 
   ipc.of[IPC_SERVER_ID].on('connect', () => {

--- a/lib/sdk/writer/.eslintrc.yml
+++ b/lib/sdk/writer/.eslintrc.yml
@@ -4,3 +4,4 @@ rules:
   no-param-reassign: off
   no-underscore-dangle: off
   lodash/prefer-lodash-method: off
+  lodash/prefer-get: off

--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -568,8 +568,8 @@ class ImageWriter extends EventEmitter {
    * imageWriter.abort()
    */
   abort () {
-    if (this.source) {
-      this.source.destroy()
+    if (this.source && this.source.stream) {
+      this.source.stream.destroy()
     }
     this.emit('abort')
   }


### PR DESCRIPTION
We add a cancel button next to the flash progress bar that gracefully
aborts the flash process.

Closes: https://github.com/resin-io/etcher/issues/1791
Closes: https://github.com/resin-io/etcher/issues/2234
Closes: https://github.com/resin-io/etcher/issues/2245
Change-Type: patch
Changelog-Entry: Add a button to cancel the flash process.