### PR TITLE
feat(gui): Add ability to read settings from a config file

### DIFF
--- a/lib/gui/app/models/local-settings.js
+++ b/lib/gui/app/models/local-settings.js
@@ -17,6 +17,10 @@
 'use strict'
 
 const Bluebird = require('bluebird')
+const _ = require('lodash')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
 
 /**
  * @summary Local storage settings key
@@ -24,6 +28,43 @@ const Bluebird = require('bluebird')
  * @type {String}
  */
 const LOCAL_STORAGE_SETTINGS_KEY = 'etcher-settings'
+
+/**
+ * @summary Local settings filename
+ * @constant
+ * @type {String}
+ */
+const RCFILE = '.etcher.json'
+
+/**
+ * @summary Read a local .etcherrc file
+ * @function
+ * @public
+ *
+ * @param {String} filename - file path
+ * @fulfil {Object} - settings
+ * @returns {Promise}
+ *
+ * @example
+ * readConfigFile('.etcherrc').then((settings) => {
+ *   console.log(settings)
+ * })
+ */
+const readConfigFile = (filename) => {
+  return new Bluebird((resolve, reject) => {
+    fs.readFile(filename, (error, buffer) => {
+      if (error) {
+        if (error.code === 'ENOENT') {
+          resolve({})
+        } else {
+          reject(error)
+        }
+      } else {
+        resolve(JSON.parse(buffer.toString()))
+      }
+    })
+  })
+}
 
 /**
  * @summary Read all local settings
@@ -39,9 +80,22 @@ const LOCAL_STORAGE_SETTINGS_KEY = 'etcher-settings'
  * });
  */
 exports.readAll = () => {
+  const homeConfigPath = process.platform === 'win32'
+    ? path.join(os.userInfo().homedir, RCFILE)
+    : path.join(os.userInfo().homedir, '.config', 'etcher', 'config.json')
+  const workdirConfigPath = path.join(process.cwd(), RCFILE)
+  const settings = {}
   return Bluebird.try(() => {
-    return JSON.parse(window.localStorage.getItem(LOCAL_STORAGE_SETTINGS_KEY)) || {}
-  })
+    _.merge(settings, JSON.parse(window.localStorage.getItem(LOCAL_STORAGE_SETTINGS_KEY)))
+  }).return(readConfigFile(homeConfigPath))
+    .then((homeConfig) => {
+      _.merge(settings, homeConfig)
+    })
+    .return(readConfigFile(workdirConfigPath))
+    .then((workdirConfig) => {
+      _.merge(settings, workdirConfig)
+    })
+    .return(settings)
 }
 
 /**


### PR DESCRIPTION
This adds the capability to configure settings via a `.etcherrc` file,
either in the user's home directory, or the current working directory.
The defined settings are merged with localStorage settings, and preceding
configuration files.
If both are present, the current working directory takes precedence.

Change-Type: minor
Changelog-Entry: Add support for configuration files
Connects To: #1356