### PR TITLE
feat(GUI): use gtk3 dark theme mode

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -47,6 +47,7 @@ electron.app.on('ready', () => {
     autoHideMenuBar: true,
     titleBarStyle: 'hidden-inset',
     icon: path.join(__dirname, '..', '..', 'assets', 'icon.png'),
+    darkTheme: true,
     webPreferences: {
       backgroundThrottling: false
     }


### PR DESCRIPTION
We enable the `darkTheme` mode for GTK-3 applications (mainly Linux)
that suits Etcher's dark theme better, making the window title bar dark.

Change-Type: patch
Changelog-Entry: Use GTK-3 darkTheme mode.