### PR TITLE
feat(GUI): blacklist drives with an env var

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -47,6 +47,8 @@ const driveScanner = require('./modules/drive-scanner')
 const osDialog = require('./os/dialog')
 const exceptionReporter = require('./modules/exception-reporter')
 
+/* eslint-disable lodash/prefer-lodash-method */
+
 // Enable debug information from all modules that use `debug`
 // See https://github.com/visionmedia/debug#browser-support
 //
@@ -54,6 +56,16 @@ const exceptionReporter = require('./modules/exception-reporter')
 // See https://github.com/resin-io-modules/drivelist
 process.env.DRIVELIST_DEBUG = /drivelist|^\*$/i.test(process.env.DEBUG) ? '1' : ''
 window.localStorage.debug = process.env.DEBUG
+
+/**
+ * @summary Environment variable blacklisted drives by path
+ * @type {Array<String>}
+ * @constant
+ * @private
+ */
+const BLACKLISTED_DRIVES = process.env.ETCHER_BLACKLISTED_DRIVES
+  ? process.env.ETCHER_BLACKLISTED_DRIVES.split(',')
+  : []
 
 const app = angular.module('Etcher', [
   require('angular-ui-router'),
@@ -209,7 +221,14 @@ app.run(($timeout) => {
     // available drives list has changed, and incorrectly
     // keeps asking the user to "Connect a drive".
     $timeout(() => {
-      availableDrives.setDrives(drives)
+      if (BLACKLISTED_DRIVES.length) {
+        const allowedDrives = drives.filter((drive) => {
+          return !BLACKLISTED_DRIVES.includes(drive.device)
+        })
+        availableDrives.setDrives(allowedDrives)
+      } else {
+        availableDrives.setDrives(drives)
+      }
     })
   })
 


### PR DESCRIPTION
We add an environment variable `ETCHER_BLACKLISTED_DRIVES` that allows
us to filter certain drives from ever showing up in Etcher with comma
separated device paths, e.g. `/dev/sda,/dev/sdb,/dev/mmcblk0`.

Closes: https://github.com/resin-io/etcher/issues/2264
Change-Type: patch
Changelog-Entry: Allow blacklisting of drives through and environment
variable ETCHER_BLACKLISTED_DRIVES.