### PR TITLE
minifix(gui): Only enable Kiosk Mode when FULLSCREEN is set

### DIFF
--- a/lib/gui/etcher.js
+++ b/lib/gui/etcher.js
@@ -44,7 +44,7 @@ electron.app.on('ready', () => {
     maximizable: false,
     fullscreen: Boolean(process.env.ETCHER_FULLSCREEN),
     fullscreenable: Boolean(process.env.ETCHER_FULLSCREEN),
-    kiosk: true,
+    kiosk: Boolean(process.env.ETCHER_FULLSCREEN),
     autoHideMenuBar: true,
     titleBarStyle: 'hidden-inset',
     icon: path.join(__dirname, '..', '..', 'assets', 'icon.png'),


### PR DESCRIPTION
This fixes the `kiosk` setting always being true, and causing
the operating system's desktop to disappear.

Change-Type: patch