### PR TITLE
doc(README): Use ubuntu keyserver for apt-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ installers for all supported operating systems.
 2. Trust Bintray.com's GPG key:
 
     ```sh
-    sudo apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 379CE192D401AB61
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
     ```
 
 3. Update and install:


### PR DESCRIPTION
As [pgp.mit.edu](//pgp.mit.edu) has become extremely unreliable, this switches to
[keyserver.ubuntu.com](//keyserver.ubuntu.com) for retrieval of package keys

Change-Type: patch
Connects To: #1786, #1634, #2009, #2144, #2303, #2317 