### PR TITLE
upgrade(package): Bump drivelist 6.1.7 -> 6.2.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2417,8 +2417,8 @@
       "dev": true
     },
     "drivelist": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-6.1.7.tgz",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/drivelist/-/drivelist-6.2.2.tgz",
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
@@ -2433,12 +2433,12 @@
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
         },
         "node-abi": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz"
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.1.tgz"
         },
         "prebuild-install": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz"
         },
         "pump": {
           "version": "2.0.1",
@@ -2449,8 +2449,8 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
         },
         "simple-get": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz"
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "chalk": "1.1.3",
     "command-join": "2.0.0",
     "debug": "3.1.0",
-    "drivelist": "6.1.7",
+    "drivelist": "6.2.2",
     "electron-is-running-in-asar": "1.0.0",
     "file-type": "4.1.0",
     "flexboxgrid": "6.3.0",


### PR DESCRIPTION
This will enable use of unique device paths on Linux

Change-Type: patch
Connects To: #2235 