### PR TITLE
feat(gui): Add ability to set analytics tokens via env

### DIFF
--- a/lib/gui/app/modules/analytics.js
+++ b/lib/gui/app/modules/analytics.js
@@ -23,8 +23,10 @@ const settings = require('../models/settings')
 
 resinCorvus.install({
   services: {
-    sentry: _.get(packageJSON, [ 'analytics', 'sentry', 'token' ]),
-    mixpanel: _.get(packageJSON, [ 'analytics', 'mixpanel', 'token' ])
+    sentry: process.env.ANALYTICS_SENTRY_TOKEN ||
+      _.get(packageJSON, [ 'analytics', 'sentry', 'token' ]),
+    mixpanel: process.env.ANALYTICS_MIXPANEL_TOKEN ||
+      _.get(packageJSON, [ 'analytics', 'mixpanel', 'token' ])
   },
   options: {
     release: packageJSON.version,


### PR DESCRIPTION
This adds the ability to set the Sentry & Mixpanel API tokens
via environment variables.

Change-Type: patch
Connects To: #2329 