### PR TITLE
minifix(gui): Don't check for updates when in resin

### DIFF
--- a/lib/gui/app/components/update-notifier.js
+++ b/lib/gui/app/components/update-notifier.js
@@ -62,6 +62,10 @@ const currentWindow = electron.remote.getCurrentWindow()
  * }
  */
 exports.shouldCheckForUpdates = (options) => {
+  if (process.env.ELECTRON_RESIN_UPDATE_LOCK) {
+    return false
+  }
+
   _.defaults(options, {
     lastSleptUpdateNotifierVersion: options.currentVersion
   })


### PR DESCRIPTION
This disables Etcher checking for updates & showing update notifications
if running under resinOS with update locks enabled

Change-Type: patch
Connects To: #2258 