### PR TITLE
feat: blacklist devices by device path

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -224,7 +224,7 @@ app.run(($timeout) => {
     $timeout(() => {
       if (BLACKLISTED_DRIVES.length) {
         const allowedDrives = drives.filter((drive) => {
-          return !BLACKLISTED_DRIVES.includes(drive.device)
+          return !BLACKLISTED_DRIVES.includes(drive.devicePath)
         })
         availableDrives.setDrives(allowedDrives)
       } else {


### PR DESCRIPTION
We use `devicePath` instead of `device` to blacklist drives using the
`ETCHER_BLACKLISTED_DRIVES` environment variable.

Closes: https://github.com/resin-io/etcher/issues/2264
Change-Type: patch