### PR TITLE
Fix devtools key binding for Windows in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,7 +20,7 @@ support:
 - The operating system you're running Etcher in.
 
 - Relevant logging output, if any, from DevTools, which you can open by
-  pressing `Ctrl+Alt+I` or `Cmd+Alt+I` depending on your platform.
+  pressing `Ctrl+Shift+I` or `Cmd+Alt+I` depending on your platform.
 
 GitHub
 ------


### PR DESCRIPTION
The key binding for devtools is Ctrl + **Shift** + I and not Ctrl + Alt + I.