### PR TITLE
feat(GUI): hide unsafe mode option with env var

### DIFF
--- a/lib/gui/app/modules/drive-scanner.js
+++ b/lib/gui/app/modules/drive-scanner.js
@@ -23,7 +23,7 @@ const permissions = require('../../../shared/permissions')
 const scanner = SDK.createScanner({
   blockdevice: {
     get includeSystemDrives () {
-      return settings.get('unsafeMode')
+      return settings.get('unsafeMode') && !process.env.ETCHER_HIDE_UNSAFE_MODE
     }
   },
   usbboot: {}

--- a/lib/gui/app/pages/main/controllers/drive-selection.js
+++ b/lib/gui/app/pages/main/controllers/drive-selection.js
@@ -109,7 +109,7 @@ module.exports = function (DriveSelectorService) {
 
       analytics.logEvent('Select drive', {
         device: drive.device,
-        unsafeMode: settings.get('unsafeMode')
+        unsafeMode: settings.get('unsafeMode') && !process.env.ETCHER_HIDE_UNSAFE_MODE
       })
     }).catch(exceptionReporter.report)
   }

--- a/lib/gui/app/pages/settings/controllers/settings.js
+++ b/lib/gui/app/pages/settings/controllers/settings.js
@@ -104,4 +104,18 @@ module.exports = function (WarningModalService) {
       }
     }).catch(exceptionReporter.report)
   }
+
+  /**
+   * @summary Show unsafe mode based on an env var
+   * @function
+   * @public
+   *
+   * @returns {Boolean}
+   *
+   * @example
+   * SettingsController.shouldShowUnsafeMode()
+   */
+  this.shouldShowUnsafeMode = () => {
+    return !process.env.ETCHER_HIDE_UNSAFE_MODE
+  }
 }

--- a/lib/gui/app/pages/settings/templates/settings.tpl.html
+++ b/lib/gui/app/pages/settings/templates/settings.tpl.html
@@ -54,7 +54,7 @@
     </label>
   </div>
 
-  <div class="checkbox">
+  <div class="checkbox" ng-if="settings.shouldShowUnsafeMode()">
     <label>
       <input type="checkbox"
         tabindex="10"


### PR DESCRIPTION
We hide the unsafe mode option toggle with an env var
`ETCHER_HIDE_UNSAFE_MODE` that also enables unsafe mode.

Closes: https://github.com/resin-io/etcher/issues/2243
Change-Type: patch
Changelog-Entry: Hide unsafe mode option toggle with an env var.