### PR TITLE
fix: ensure file-picker is slicing arrays

### DIFF
--- a/lib/gui/app/components/file-selector/file-selector/file-selector.jsx
+++ b/lib/gui/app/components/file-selector/file-selector/file-selector.jsx
@@ -216,8 +216,8 @@ class RecentFilesUnstyled extends React.PureComponent {
     super(props)
 
     this.state = {
-      recents: recentStorage.get('recents'),
-      favorites: recentStorage.get('favorites')
+      recents: recentStorage.get('recents', []),
+      favorites: recentStorage.get('favorites', [])
     }
   }
 


### PR DESCRIPTION
We ensure the file-picker is slicing arrays when the localStorage values
aren't available.

Change-Type: patch