### PR TITLE
fix(diskpart): Fix diskpart argv when tmpdir contains spaces

### DIFF
--- a/lib/cli/diskpart.js
+++ b/lib/cli/diskpart.js
@@ -69,7 +69,7 @@ const runDiskpart = (commands, callback) => {
   }, (writeError) => {
     debug('write %s:', filename, writeError || 'OK')
 
-    childProcess.exec(`diskpart /s ${filename}`, (execError, stdout, stderr) => {
+    childProcess.execFile('diskpart', [ '/s', filename ], (execError, stdout, stderr) => {
       debug('stdout:', stdout)
       debug('stderr:', stderr)
 


### PR DESCRIPTION
This escapes the diskpart script filename when shelling out,
to avoid failure when the username and thus the `os.tmpdir()` path
contains spaces.

Change-Type: patch
Connects To: https://github.com/resin-io/etcher/issues/1991