### PR TITLE
minifix(GUI): resolve react missing key field warning

### DIFF
--- a/lib/gui/app/components/file-selector/file-selector/file-selector.jsx
+++ b/lib/gui/app/components/file-selector/file-selector/file-selector.jsx
@@ -317,6 +317,7 @@ const Breadcrumbs = styled((props) => {
         _.map(dirs.slice(-MAX_DIR_CRUMBS), (dir, index) => {
           return (
             <rendition.Button
+              key={ dir.fullpath }
               onClick={ () => props.selectFile(dir) }
               plaintext={ true }>
               <rendition.Txt bold={ index === dirs.length - 1 }>
@@ -427,6 +428,7 @@ class FileSelector extends React.PureComponent {
                   items.map((item, index) => {
                     return (
                       <FileLink { ...item }
+                        key={ item.fullpath }
                         highlight={ _.get(this.state.highlighted, 'fullpath') === _.get(item, 'fullpath') }
                         onClick={ () => this.setState({ highlighted: item }) }
                         onDoubleClick={ _.partial(this.selectFile, item) }


### PR DESCRIPTION
We attach key fields where necessary to make the warnings go away.

Change-Type: patch