### PR TITLE
chore(webpack): Reduce build log verbosity

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = {
   },
   plugins: [
     new SimpleProgressWebpackPlugin({
-      format: process.env.WEBPACK_PROGRESS || 'verbose'
+      format: process.env.WEBPACK_PROGRESS || 'compact'
     })
   ]
 }


### PR DESCRIPTION
Travis CI is complaining about 10k+ lines of log output again.
This was initially set to `verbose` to facilitate debugging on concourse, which has since concluded.
But as it's generating 2000+ lines of output, it's masking CI build results

Change-Type: patch