### PR TITLE
fix(GUI): file-picker performance and design improvements

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -330,6 +330,13 @@ app.config(($provide) => {
   })
 })
 
+app.config(($locationProvider) => {
+  // NOTE(Shou): this seems to invoke a minor perf decrease when set to true
+  $locationProvider.html5Mode({
+    rewriteLinks: false
+  })
+})
+
 app.controller('HeaderController', function (OSOpenExternalService) {
   /**
    * @summary Open help page

--- a/lib/gui/app/components/file-selector/controllers/file-selector.js
+++ b/lib/gui/app/components/file-selector/controllers/file-selector.js
@@ -16,7 +16,10 @@
 
 'use strict'
 
+const os = require('os')
 const settings = require('../../../models/settings')
+
+/* eslint-disable lodash/prefer-lodash-method */
 
 module.exports = function (
   $uibModalInstance
@@ -43,9 +46,25 @@ module.exports = function (
    * @example
    * FileSelectorController.getFolderConstraint()
    */
-  this.getFolderConstraint = () => {
+  this.getFolderConstraints = () => {
     // TODO(Shou): get this dynamically from the mountpoint of a specific port in Etcher Pro
-    // TODO: Make this handle multiple constraints
-    return settings.get('fileBrowserConstraintPath')
+    return settings.has('fileBrowserConstraintPath')
+      ? settings.get('fileBrowserConstraintPath').split(',')
+      : []
+  }
+
+  /**
+   * @summary Get initial path
+   * @function
+   * @public
+   *
+   * @returns {String} - path
+   *
+   * @example
+   * <file-selector path="FileSelectorController.getPath()"></file-selector>
+   */
+  this.getPath = () => {
+    const [ constraint ] = this.getFolderConstraints()
+    return constraint || os.homedir()
   }
 }

--- a/lib/gui/app/components/file-selector/styles/_file-selector.scss
+++ b/lib/gui/app/components/file-selector/styles/_file-selector.scss
@@ -18,6 +18,6 @@
   width: calc(100vw - 10px);
 
   > .modal-content {
-    height: calc(100vh - 10px);
+    height: calc(100vh - 20px);
   }
 }

--- a/lib/gui/app/components/file-selector/templates/file-selector-modal.tpl.html
+++ b/lib/gui/app/components/file-selector/templates/file-selector-modal.tpl.html
@@ -1,1 +1,4 @@
-<file-selector close="selector.close" constraint="selector.getFolderConstraint()" ></file-selector>
+<file-selector
+  constraints="selector.getFolderConstraints()"
+  path="selector.getPath()"
+  close="selector.close"></file-selector>

--- a/lib/gui/app/models/files.js
+++ b/lib/gui/app/models/files.js
@@ -24,6 +24,31 @@ const fs = Bluebird.promisifyAll(require('fs'))
 /* eslint-disable lodash/prefer-lodash-method */
 
 /**
+ * @summary Async exists function
+ * @function
+ * @public
+ *
+ * @description
+ * This is a promise for convenience, as it never fails with an exception/catch.
+ *
+ * @param {String} fullpath - full path
+ * @returns {Boolean}
+ *
+ * @example
+ * files.existsAsync('/home/user/file').then(console.log)
+ * > true
+ */
+exports.existsAsync = (fullpath) => {
+  return new Bluebird((resolve, reject) => {
+    return fs.accessAsync(fullpath, fs.constants.F_OK).then(() => {
+      resolve(true)
+    }).catch(() => {
+      resolve(false)
+    })
+  })
+}
+
+/**
  * @summary Get file metadata
  * @function
  * @private
@@ -53,7 +78,7 @@ exports.getFileMetadataSync = (dirname, basename = '') => {
     basename: pathObj.base,
     dirname: pathObj.dir,
     fullpath,
-    extension: pathObj.ext.replace('.', ''),
+    extension: pathObj.ext,
     name: pathObj.name,
     isDirectory: stats.isDirectory(),
     isHidden,
@@ -85,7 +110,7 @@ exports.getFileMetadataAsync = (fullpath) => {
       basename: pathObj.base,
       dirname: pathObj.dir,
       fullpath,
-      extension: pathObj.ext.replace('.', ''),
+      extension: pathObj.ext,
       name: pathObj.name,
       isDirectory: stats.isDirectory(),
       isHidden,
@@ -109,15 +134,14 @@ exports.getFileMetadataAsync = (fullpath) => {
  * files.getAllFilesMetadataAsync(os.homedir(), [ 'file1.txt', 'file2.txt' ])
  */
 exports.getAllFilesMetadataAsync = (dirname, basenames) => {
-  return Bluebird.all(basenames.map((basename) => {
-    const metadata = exports.getFileMetadataAsync(path.join(dirname, basename))
-    return metadata.reflect()
-  })).reduce((fileMetas, inspection) => {
-    if (inspection.isFulfilled()) {
-      return fileMetas.concat(inspection.value())
-    }
-
-    return fileMetas
+  return Bluebird.reduce(basenames, (fileMetas, basename) => {
+    return new Bluebird((resolve, reject) => {
+      exports.getFileMetadataAsync(path.join(dirname, basename)).then((metadata) => {
+        resolve(fileMetas.concat(metadata))
+      }).catch(() => {
+        resolve(fileMetas)
+      })
+    })
   }, [])
 }
 

--- a/lib/gui/css/main.css
+++ b/lib/gui/css/main.css
@@ -6505,7 +6505,7 @@ svg-icon {
 .modal-file-selector-modal {
   width: calc(100vw - 10px); }
   .modal-file-selector-modal > .modal-content {
-    height: calc(100vh - 10px); }
+    height: calc(100vh - 20px); }
 
 /*
  * Copyright 2016 resin.io

--- a/tests/gui/models/files.spec.js
+++ b/tests/gui/models/files.spec.js
@@ -18,7 +18,7 @@
 
 const m = require('mochainon')
 const path = require('path')
-const files = require('../../lib/shared/files')
+const files = require('../../../lib/gui/app/models/files')
 
 describe('Shared: Files', function () {
   describe('.splitPath()', function () {


### PR DESCRIPTION
- Replace onClick arrow functions in all components that use them for
  efficiency reasons: 300-500% speed-up
- Sort by folders and ignore case for better UX
- Remove use of `rendition.Button` in files, leading to a 10-20%
  performance increase when browsing files
- Proper sidebar width and spacing
- Recents and favorites are now filtered by existence async for a tiny
  performance improvement
- Make Breadcrumbs and Icon pure components to stop frequent re-rendering
- Initial support for array constraints
- Use first constraint as initial path instead of homedir if a
  constraint is set
- Use correct design height on modal, `calc(100vh - 20px)`
- Reset scroll position when browsing a new folder
- Fuse Bluebird `.map()` and `.reduce()` in
`files.getAllFilesMetadataAsync`.
- Use `localeCompare`'s own case-insensitive option instead of calling
`.toLowerCase()` twice on `n-2` files compared.
- Use 16px font sizes in sidebar and files to match design.
- Disable `$locationProvider.html5Mode.rewriteLinks`, which seemed to
  take 50ms of the directory changing time.
- Leave file extension as-is in `files.getFileMetadataSync` and the
  async counterpart for a very minor performance improvement.

Change-Type: patch