### PR TITLE
fix(GUI): restrict webkit drag to header

### DIFF
--- a/lib/gui/css/desktop.css
+++ b/lib/gui/css/desktop.css
@@ -21,8 +21,12 @@ body {
 
 
 /* Allow window to be dragged from anywhere */
-* {
+body > header {
   -webkit-app-region: drag;
+}
+
+.modal-body {
+  -webkit-app-region: no-drag;
 }
 
 button,


### PR DESCRIPTION
We ensure that the `-webkit-app-region` attribute is only set to `drag`
on the header element and we explicitly disable it on modals, as this
has unintended behaviour on a non-draggable window with touch-screens.

Change-Type: patch