### PR TITLE
fix(gui): Fix error with empty drive blacklist

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -58,14 +58,6 @@ const updateLock = require('./modules/update-lock')
 process.env.DRIVELIST_DEBUG = /drivelist|^\*$/i.test(process.env.DEBUG) ? '1' : ''
 window.localStorage.debug = process.env.DEBUG
 
-/**
- * @summary Environment variable blacklisted drives by path
- * @type {Array<String>}
- * @constant
- * @private
- */
-const BLACKLISTED_DRIVES = settings.get('driveBlacklist')
-
 const app = angular.module('Etcher', [
   require('angular-ui-router'),
   require('angular-ui-bootstrap'),
@@ -216,6 +208,10 @@ app.run(() => {
 
 app.run(($timeout) => {
   driveScanner.on('devices', (drives) => {
+    const BLACKLISTED_DRIVES = settings.has('driveBlacklist')
+      ? settings.get('driveBlacklist').split(',')
+      : []
+
     // Safely trigger a digest cycle.
     // In some cases, AngularJS doesn't acknowledge that the
     // available drives list has changed, and incorrectly


### PR DESCRIPTION
This fixes an error occuring if the drive blacklist
is empty, and not split correctly

Change-Type: patch