### PR TITLE
upgrade(package): Update lodash to 4.17.10

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5010,8 +5010,8 @@
       }
     },
     "lodash": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
     },
     "lodash-deep": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "gpt": "1.0.0",
     "immutable": "3.8.1",
     "inactivity-timer": "1.0.0",
-    "lodash": "4.13.1",
+    "lodash": "4.17.10",
     "lzma-native": "1.5.2",
     "mbr": "1.1.2",
     "mime-types": "2.1.15",


### PR DESCRIPTION
This updates `lodash` to mitigate a prototype pollution vulnerability.
See https://nodesecurity.io/advisories/577

Change-Type: patch