### PR TITLE
fix(webpack): Exclude all node externals / node_modules

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9437,6 +9437,11 @@
         }
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "simple-progress-webpack-plugin": "1.1.2",
     "spectron": "3.7.3",
     "versionist": "2.8.1",
-    "webpack": "github:jviotti/webpack#symlink-fix"
+    "webpack": "github:jviotti/webpack#symlink-fix",
+    "webpack-node-externals": "1.7.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@
 
 const path = require('path')
 const SimpleProgressWebpackPlugin = require('simple-progress-webpack-plugin')
+const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
   target: 'electron-main',
@@ -33,6 +34,7 @@ module.exports = {
     filename: '[name].js'
   },
   externals: [
+    nodeExternals(),
     (context, request, callback) => {
       // eslint-disable-next-line lodash/prefer-lodash-method
       const absoluteContext = path.resolve(context)


### PR DESCRIPTION
This adds `webpack-node-externals` to exclude node_modules,
immensely reducing bundle size and avoiding complex exclusion rules
for the etcher-sdk

Change-Type: patch