### PR TITLE
refactor(gui): Add separating borders to file selector

### DIFF
--- a/lib/gui/app/components/file-selector/file-selector/file-selector.jsx
+++ b/lib/gui/app/components/file-selector/file-selector/file-selector.jsx
@@ -57,7 +57,8 @@ const Flex = styled.div`
 `
 
 const Header = Flex.extend`
-  margin: 10px 15px 0;
+  padding: 10px 15px 0;
+  border-bottom: 1px solid ${ colors.primary.faded };
 
   > * {
     margin: 5px;
@@ -67,8 +68,9 @@ const Header = Flex.extend`
 const Main = Flex.extend``
 
 const Footer = Flex.extend`
-  margin: 10px 20px;
+  padding: 10px;
   flex: 0 0 auto;
+  border-top: 1px solid ${ colors.primary.faded };
 
   > * {
     margin: 0 10px;


### PR DESCRIPTION
This adds thin gray borders to the control surfaces in
the file selector for better visual distinction

![screen shot 2018-06-20 at 18 49 40](https://user-images.githubusercontent.com/244907/41673306-dc3214ee-74bc-11e8-9694-06473f8696f6.png)

Change-Type: patch