### PR TITLE
fix(app): Fix settings being unavailable when packaged

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,7 +6,6 @@ nodeGypRebuild: false
 publish: null
 files:
   - lib
-  - "!lib/gui/app"
   - lib/gui/app/index.html
   - generated
   - build/**/*.node


### PR DESCRIPTION
This fixes an issue where the settings model would be missing
from Etcher when packaged, as it's used in two different contexts;
namely the webpack bundle and the main process.

Change-Type: patch
Connects To: #2385 