### PR TITLE
feat(gui): Enable device specific constraints for file selection

### DIFF
--- a/lib/gui/app/components/file-selector/controllers/file-selector.js
+++ b/lib/gui/app/components/file-selector/controllers/file-selector.js
@@ -48,11 +48,10 @@ module.exports = function (
    * @example
    * FileSelectorController.getFolderConstraint()
    */
-  this.getFolderConstraints = utils.memoize(() => {
-    // TODO(Shou): get this dynamically from the mountpoint of a specific port in Etcher Pro
+  this.getFolderConstraint = utils.memoize(() => {
     return settings.has('fileBrowserConstraintPath')
-      ? settings.get('fileBrowserConstraintPath').split(',')
-      : []
+      ? settings.get('fileBrowserConstraintPath')
+      : ''
   }, angular.equals)
 
   /**
@@ -66,7 +65,6 @@ module.exports = function (
    * <file-selector path="FileSelectorController.getPath()"></file-selector>
    */
   this.getPath = () => {
-    const [ constraint ] = this.getFolderConstraints()
-    return constraint || os.homedir()
+    return this.getFolderConstraint() ? '/' : os.homedir()
   }
 }

--- a/lib/gui/app/components/file-selector/templates/file-selector-modal.tpl.html
+++ b/lib/gui/app/components/file-selector/templates/file-selector-modal.tpl.html
@@ -1,4 +1,4 @@
 <file-selector
-  constraints="selector.getFolderConstraints()"
+  constraintpath="selector.getFolderConstraint()"
   path="selector.getPath()"
   close="selector.close"></file-selector>

--- a/lib/gui/app/models/files.js
+++ b/lib/gui/app/models/files.js
@@ -18,6 +18,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const drivelist = require('drivelist')
 
 /* eslint-disable lodash/prefer-lodash-method */
 /* eslint-disable no-undefined */
@@ -70,7 +71,6 @@ class FileEntry {
     this.isFile = stats.isFile()
     this.isDirectory = stats.isDirectory()
     this.size = stats.size
-    this.stats = stats
   }
 }
 
@@ -138,3 +138,30 @@ exports.splitPath = (fullpath, subpaths = []) => {
 
   return exports.splitPath(dir, [ base ].concat(subpaths))
 }
+
+/**
+ * @summary Get constraint path device
+ * @param {String} pathname - device path
+ * @param {Function} callback - callback(error, constraintDevice)
+ * @example
+ * files.getConstraintDevice('/dev/disk2', (error, device) => {
+ *   // ...
+ * })
+ */
+exports.getConstraintDevice = (pathname, callback) => {
+  drivelist.list((error, devices) => {
+    if (error) {
+      callback()
+      return
+    }
+
+    const constraintDevice = devices.find((device) => {
+      return device.device === pathname ||
+        device.devicePath === pathname
+    })
+
+    callback(null, constraintDevice)
+  })
+}
+
+exports.FileEntry = FileEntry


### PR DESCRIPTION
This adds the ability to restrict the file selection to a given device,
only making its mountpoints accessible.

![screen shot 2018-06-22 at 11 21 57](https://user-images.githubusercontent.com/244907/41769235-e24b26a6-760e-11e8-9ec4-3ef5534987b7.png)

![screen shot 2018-06-22 at 11 22 01](https://user-images.githubusercontent.com/244907/41769234-e2257fd2-760e-11e8-9d7b-01b556c0754d.png)

Change-Type: patch
Connects To: https://github.com/resin-io/etcher/issues/2377