### PR TITLE
upgrade(package): Update winusb-driver-generator

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6747,10 +6747,12 @@
     "prebuild-install": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
+      "dev": true,
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "dev": true
         }
       }
     },
@@ -9505,8 +9507,34 @@
       "dev": true
     },
     "winusb-driver-generator": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/winusb-driver-generator/-/winusb-driver-generator-1.1.7.tgz"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/winusb-driver-generator/-/winusb-driver-generator-1.2.1.tgz",
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
+        },
+        "node-abi": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz"
+        },
+        "prebuild-install": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz"
+        },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz"
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz"
+        }
+      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "unbzip2-stream": "github:resin-io-modules/unbzip2-stream#core-streams",
     "usb": "github:tessel/node-usb#1.3.0",
     "uuid": "3.0.1",
-    "winusb-driver-generator": "1.1.7",
+    "winusb-driver-generator": "1.2.1",
     "xml2js": "0.4.17",
     "xxhash": "0.2.4",
     "yargs": "11.0.0",


### PR DESCRIPTION
This updates `winusb-driver-generator` to the latest version,
which supports building under VS 2015 and running under Electron 2.0+

Change-Type: patch