### PR TITLE
resinci: Set private: true in package.json to avoid running npm builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "etcher",
+  "private": true,
   "displayName": "Etcher",
   "version": "1.4.4",
   "packageType": "local",


### PR DESCRIPTION
This should cause ResinCI to ignore this repo for npm builds, and just run the basic checks + electron + node-cli pipelines.

Change-type: patch
Signed-off-by: Jack Brown <jack@resin.io>