### PR TITLE
fix(writer): Set EVALIDATION on blockmap checksum errors

### DIFF
--- a/lib/sdk/writer/index.js
+++ b/lib/sdk/writer/index.js
@@ -515,6 +515,12 @@ class ImageWriter extends EventEmitter {
       const pipeline = this._createVerifyPipeline(destination)
 
       pipeline.on('error', (error) => {
+        // NOTE: As the `blockmap` module doesn't set our custom error codes,
+        // we need to patch `EVALIDATION` into a range checksum error here
+        if (error.message && error.message.startsWith('Invalid checksum for range')) {
+          error.code = 'EVALIDATION'
+          this.emit('fail', { device: destination.device.device, error })
+        }
         this.emit('error', error)
       })
 


### PR DESCRIPTION
This patches validation errors coming form the `blockmap` module to have
the `EVALIDATION` error code, in order to trigger the appropriate code
paths and analytics.

Change-type: patch
Signed-off-by: Jonas Hermsmeier <jhermsmeier@gmail.com>