### PR TITLE
fix(cli): Don't use electron to get USER_DATA_DIR in CLI

### DIFF
--- a/lib/gui/app/models/local-settings.js
+++ b/lib/gui/app/models/local-settings.js
@@ -16,10 +16,10 @@
 
 'use strict'
 
-const electron = require('electron')
 const Bluebird = require('bluebird')
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
 
 /**
  * @summary Number of spaces to indent JSON output with
@@ -36,14 +36,31 @@ const JSON_INDENT = 2
  * - `$XDG_CONFIG_HOME/etcher` or `~/.config/etcher` on Linux
  * - `~/Library/Application Support/etcher` on macOS
  * See https://electronjs.org/docs/api/app#appgetpathname
- * NOTE: The ternary is due to this module being loaded both,
- * in Electron's main and renderer processes
  * @constant
  * @type {String}
  */
-const USER_DATA_DIR = electron.app
-  ? electron.app.getPath('userData')
-  : electron.remote.app.getPath('userData')
+const USER_DATA_DIR = (() => {
+  // Electron
+  if (process.versions.electron) {
+    // NOTE: The ternary is due to this module being loaded both,
+    // Electron's main process and renderer process
+    const electron = require('electron')
+    return electron.app
+      ? electron.app.getPath('userData')
+      : electron.remote.app.getPath('userData')
+  }
+
+  // CLI
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA, 'etcher')
+  }
+
+  if (process.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'etcher')
+  }
+
+  return path.join(process.env.XDG_CONFIG_HOME || os.homedir(), '.config', 'etcher')
+})()
 
 /**
  * @summary Configuration file path


### PR DESCRIPTION
A previous change erroneously relied solely on `electron` to determine
the user's data directory, which of course, isn't available when running
in the CLI. So this adds a fallback to the same mechanic for CLI should
this code not be loaded in Electron.

Change-type: patch
Signed-off-by: Jonas Hermsmeier <jhermsmeier@gmail.com>