### PR TITLE
minifix: add "make webpack" to travis-ci build script

### DIFF
--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -48,9 +48,9 @@ if [ "$ARGV_OPERATING_SYSTEM" == "linux" ]; then
   ./scripts/build/docker/run-command.sh \
     -r "$ARGV_ARCHITECTURE" \
     -s "$(pwd)" \
-    -c 'xvfb-run --server-args=$XVFB_ARGS make lint test sanity-checks'
+    -c 'xvfb-run --server-args=$XVFB_ARGS make webpack lint test sanity-checks'
 else
   ./scripts/build/check-dependency.sh make
   export TARGET_ARCH="$ARGV_ARCHITECTURE"
-  make lint test sanity-checks
+  make webpack lint test sanity-checks
 fi


### PR DESCRIPTION
Currently, the Travis CI build is failing due to the fact that
the folder 'generated/etcher' is empty.

The folder is missing because the "make webpack" step is missing
from the travis CI build.

This commit amends that by adding the "make webpack" build step
after linting.

Change-Type: patch