### PR TITLE
fix(sudo-prompt): Use a fork of sudo-prompt

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8223,8 +8223,8 @@
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz"
     },
     "sudo-prompt": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.0.0.tgz"
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.3.tgz"
     },
     "sumchecker": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "speedometer": "1.0.0",
     "styled-components": "3.2.3",
     "styled-system": "1.1.7",
-    "sudo-prompt": "8.0.0",
+    "sudo-prompt": "8.2.3",
     "udif": "0.13.0",
     "unbzip2-stream": "github:resin-io-modules/unbzip2-stream#core-streams",
     "usb": "github:tessel/node-usb#1.3.0",


### PR DESCRIPTION
This is to avoid running the child-writer twice when the hostname isn't
set in /etc/hosts. See https://github.com/jorangreef/sudo-prompt/pull/76

Change-type: patch
Signed-off-by: Alexis Svinartchouk <alexis@resin.io>