### PR TITLE
gui: Also blacklist match against device & raw path

### DIFF
--- a/lib/gui/app/app.js
+++ b/lib/gui/app/app.js
@@ -242,7 +242,9 @@ app.run(($timeout) => {
     $timeout(() => {
       if (BLACKLISTED_DRIVES.length) {
         const allowedDrives = drives.filter((drive) => {
-          return !BLACKLISTED_DRIVES.includes(drive.devicePath)
+          return !(BLACKLISTED_DRIVES.includes(drive.devicePath) ||
+            BLACKLISTED_DRIVES.includes(drive.device) ||
+            BLACKLISTED_DRIVES.includes(drive.raw))
         })
         availableDrives.setDrives(allowedDrives)
       } else {


### PR DESCRIPTION
This fixes device blacklist handling to also match against
`drive.device` and `drive.raw`, in order to be able to specify devices
lacking a `devicePath`.

Change-type: patch
Signed-off-by: Jonas Hermsmeier <jhermsmeier@gmail.com>
Connects to: #2468 