### PR TITLE
fix(tests): Change port so not to overlap with other builds

### DIFF
--- a/tests/spectron/runner.spec.js
+++ b/tests/spectron/runner.spec.js
@@ -36,6 +36,7 @@ describe('Spectron', function () {
   before('app:start', function () {
     app = new spectron.Application({
       path: entrypoint,
+      port: 9999,
       args: [ '.' ]
     })
 


### PR DESCRIPTION
This temporarily fixes an issue regarding Spectron's ChromeDriver exiting on the `EADDRINUSE` error when the default port is already taken by another process.

Reference: https://github.com/electron/chromedriver/pull/29

Change-type: patch
Signed-off-by: Lorenzo Alberto Maria Ambrosi <lorenzoa@resin.io>