### PR TITLE
Makefile: Don't use tilde in rpm versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ endif
 
 APPLICATION_NAME_LOWERCASE = $(shell echo $(APPLICATION_NAME) | tr A-Z a-z)
 APPLICATION_VERSION_DEBIAN = $(shell echo $(APPLICATION_VERSION) | tr "-" "~")
-APPLICATION_VERSION_REDHAT = $(shell echo $(APPLICATION_VERSION) | tr "-" "~")
+APPLICATION_VERSION_REDHAT = $(APPLICATION_VERSION)
 
 # ---------------------------------------------------------------------
 # Release type

--- a/tests/spectron/runner.spec.js
+++ b/tests/spectron/runner.spec.js
@@ -36,6 +36,7 @@ describe('Spectron', function () {
   before('app:start', function () {
     app = new spectron.Application({
       path: entrypoint,
+      port: 9999,
       args: [ '.' ]
     })
 


### PR DESCRIPTION
The tilde is not a valid version character in RPM packages, according to
the RPM source code.

Change-type: patch