### PR TITLE
fix: Provide a Buffer to xxhash.Stream

### DIFF
--- a/lib/sdk/writer/checksum-stream.js
+++ b/lib/sdk/writer/checksum-stream.js
@@ -73,7 +73,7 @@ class ChecksumStream extends stream.Transform {
       // Seed value 0x45544348 = ASCII "ETCH"
       const seed = 0x45544348
       const is64Bit = process.arch === 'x64' || process.arch === 'aarch64'
-      hash = new xxhash.Stream(seed, is64Bit ? 64 : 32)
+      hash = new xxhash.Stream(seed, is64Bit ? 64 : 32, Buffer.allocUnsafe(is64Bit ? 8 : 4))
     } else {
       hash = _.attempt(crypto.createHash, algorithm)
     }


### PR DESCRIPTION
This fixes the digest being a number instead of a buffer.

Signed-off-by: Alexis Svinartchouk <alexis@resin.io>